### PR TITLE
Add toggle recording mode

### DIFF
--- a/viberwhisper/docs/toggle_recording_plan.md
+++ b/viberwhisper/docs/toggle_recording_plan.md
@@ -1,0 +1,93 @@
+# 按键切换录音（Toggle Recording）实现计划
+
+## 当前行为分析
+
+### 热键系统 (`src/hotkey.rs`)
+- 使用 `rdev` 库监听全局键盘事件
+- 两个静态 `AtomicBool`：`F8_PRESSED` 和 `F8_RELEASED`
+- `check_event()` 返回 `HotkeyEvent::Pressed` 或 `HotkeyEvent::Released`
+
+### 主循环 (`src/main.rs` → `run_listener()`)
+- `Pressed` → `start_recording()`
+- `Released` → `stop_recording()` → `transcribe()` → `type_text()`
+- 这是**长按模式**（hold-to-record）
+
+### 配置 (`src/config.rs`)
+- `hotkey: String` — 热键名称（默认 "F8"）
+- 没有录音模式的配置项
+
+## 需求
+
+支持**切换模式**（toggle）：按一下开始录音，再按一下结束录音并开始识别。
+
+## 实现方案
+
+### 1. 配置新增 `recording_mode` 字段
+
+**文件**: `src/config.rs`
+
+```rust
+// 新增枚举
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RecordingMode {
+    Hold,    // 长按录音（当前行为）
+    Toggle,  // 按一下开始，再按一下结束
+}
+
+// AppConfig 新增字段
+pub recording_mode: RecordingMode,
+
+// Default 中设为 Toggle（用户要求的新行为）
+recording_mode: RecordingMode::Toggle,
+```
+
+- `get_field` / `set_field` / `apply_json` 都需要支持 `recording_mode`
+
+### 2. 修改主循环以支持两种模式
+
+**文件**: `src/main.rs` → `run_listener()`
+
+```rust
+// Toggle 模式下的状态机：
+// Idle → (按下F8) → Recording → (按下F8) → Stopping/Transcribing → Idle
+//
+// Hold 模式（现有行为）：
+// Idle → (按下F8) → Recording → (释放F8) → Stopping/Transcribing → Idle
+
+match config.recording_mode {
+    RecordingMode::Hold => {
+        // 现有逻辑不变
+        match event {
+            Pressed => start_recording(),
+            Released => stop_and_transcribe(),
+        }
+    }
+    RecordingMode::Toggle => {
+        // 只响应 Pressed 事件，忽略 Released
+        if let Pressed = event {
+            if recorder.is_recording() {
+                stop_and_transcribe();
+            } else {
+                start_recording();
+            }
+        }
+    }
+}
+```
+
+### 3. 边界情况处理
+
+1. **快速双击**：Toggle 模式下快速按两次 → 录音时间极短 → `stop_recording()` 可能返回空 buffer → 已有 "No audio data recorded" 错误处理，OK
+2. **录音中切换模式**：不支持运行时切换，需要重启程序
+3. **按键重复**（长按产生连续 KeyPress）：`audio.rs` 的 `start_recording()` 已经有重复检测（"Already recording, ignoring duplicate start request"），所以 Toggle 模式下长按不会出问题
+4. **提示文字**：根据模式显示不同的操作提示
+
+### 4. 涉及文件变更清单
+
+| 文件 | 变更内容 |
+|------|---------|
+| `src/config.rs` | 新增 `RecordingMode` 枚举，`AppConfig` 加 `recording_mode` 字段，更新 get/set/apply |
+| `src/main.rs` | `run_listener()` 根据模式分发不同的热键处理逻辑 |
+
+注意：`hotkey.rs` 和 `audio.rs` **不需要改动**，Toggle 逻辑完全在 `main.rs` 中处理。

--- a/viberwhisper/src/config.rs
+++ b/viberwhisper/src/config.rs
@@ -3,6 +3,22 @@ use std::fs;
 
 const CONFIG_FILE: &str = "config.json";
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RecordingMode {
+    Hold,
+    Toggle,
+}
+
+impl std::fmt::Display for RecordingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecordingMode::Hold => write!(f, "hold"),
+            RecordingMode::Toggle => write!(f, "toggle"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15,6 +31,7 @@ pub struct AppConfig {
     pub temperature: f32,
     pub hotkey: String,
     pub mic_gain: f32,
+    pub recording_mode: RecordingMode,
 }
 
 impl Default for AppConfig {
@@ -27,6 +44,7 @@ impl Default for AppConfig {
             temperature: 0.0,
             hotkey: "F8".to_string(),
             mic_gain: 1.0,
+            recording_mode: RecordingMode::Toggle,
         }
     }
 }
@@ -78,6 +96,7 @@ impl AppConfig {
                 .groq_api_key
                 .as_ref()
                 .map(|_| "***（已设置）".to_string()),
+            "recording_mode" => Some(self.recording_mode.to_string()),
             _ => None,
         }
     }
@@ -117,8 +136,24 @@ impl AppConfig {
                 self.groq_api_key = Some(value.to_string());
                 Ok(())
             }
+            "recording_mode" => {
+                match value.to_lowercase().as_str() {
+                    "hold" => {
+                        self.recording_mode = RecordingMode::Hold;
+                        Ok(())
+                    }
+                    "toggle" => {
+                        self.recording_mode = RecordingMode::Toggle;
+                        Ok(())
+                    }
+                    _ => Err(format!(
+                        "recording_mode 必须是 hold 或 toggle，收到: {}",
+                        value
+                    )),
+                }
+            }
             _ => Err(format!(
-                "未知配置项: {}。可用项: model, hotkey, language, prompt, temperature, mic_gain, groq_api_key",
+                "未知配置项: {}。可用项: model, hotkey, language, prompt, temperature, mic_gain, recording_mode, groq_api_key",
                 key
             )),
         }
@@ -146,6 +181,13 @@ impl AppConfig {
         if let Some(prompt) = json["prompt"].as_str() {
             self.prompt = Some(prompt.to_string());
         }
+        if let Some(mode) = json["recording_mode"].as_str() {
+            match mode {
+                "hold" => self.recording_mode = RecordingMode::Hold,
+                "toggle" => self.recording_mode = RecordingMode::Toggle,
+                _ => eprintln!("[Config] 未知 recording_mode: {}，忽略", mode),
+            }
+        }
     }
 }
 
@@ -161,6 +203,7 @@ mod tests {
         assert_eq!(config.temperature, 0.0);
         assert!(config.groq_api_key.is_none());
         assert_eq!(config.language.as_deref(), Some("zh"));
+        assert_eq!(config.recording_mode, RecordingMode::Toggle);
     }
 
     #[test]
@@ -223,5 +266,33 @@ mod tests {
         let mut config = AppConfig::default();
         let result = config.set_field("nonexistent", "value");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_recording_mode_default_is_toggle() {
+        let config = AppConfig::default();
+        assert_eq!(config.recording_mode, RecordingMode::Toggle);
+    }
+
+    #[test]
+    fn test_set_recording_mode() {
+        let mut config = AppConfig::default();
+        config.set_field("recording_mode", "hold").unwrap();
+        assert_eq!(config.recording_mode, RecordingMode::Hold);
+        config.set_field("recording_mode", "toggle").unwrap();
+        assert_eq!(config.recording_mode, RecordingMode::Toggle);
+    }
+
+    #[test]
+    fn test_set_recording_mode_invalid() {
+        let mut config = AppConfig::default();
+        let result = config.set_field("recording_mode", "invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_recording_mode() {
+        let config = AppConfig::default();
+        assert_eq!(config.get_field("recording_mode"), Some("toggle".to_string()));
     }
 }

--- a/viberwhisper/src/main.rs
+++ b/viberwhisper/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// 原有的语音监听主循环
 fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     use audio::AudioRecorder;
-    use config::AppConfig;
+    use config::{AppConfig, RecordingMode};
     use hotkey::{HotkeyEvent, HotkeyManager};
     use std::sync::{Arc, Mutex};
     use transcriber::{GroqTranscriber, MockTranscriber, Transcriber};
@@ -41,10 +41,11 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = AppConfig::load();
     println!(
-        "[Config] 热键: {}  模型: {}  语言: {}",
+        "[Config] 热键: {}  模型: {}  语言: {}  录音模式: {}",
         config.hotkey,
         config.model,
         config.language.as_deref().unwrap_or("auto"),
+        config.recording_mode,
     );
     println!();
 
@@ -62,38 +63,69 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     };
     let typer = WindowsTyper;
 
-    println!("Hold {} to record, release to transcribe and type.", config.hotkey);
+    match config.recording_mode {
+        RecordingMode::Hold => {
+            println!("Hold {} to record, release to transcribe and type.", config.hotkey);
+        }
+        RecordingMode::Toggle => {
+            println!("Press {} to start recording, press again to stop and transcribe.", config.hotkey);
+        }
+    }
     println!("Press Ctrl+C to exit.");
     println!();
+
+    // 停止录音并转录的辅助闭包
+    let stop_and_transcribe = |rec: &mut AudioRecorder| {
+        match rec.stop_recording() {
+            Ok(wav_path) => {
+                println!("Recording saved: {}", wav_path);
+                match transcriber.transcribe(&wav_path) {
+                    Ok(text) => {
+                        if let Err(e) = typer.type_text(&text) {
+                            eprintln!("Failed to type text: {}", e);
+                        }
+                    }
+                    Err(e) => eprintln!("Transcription failed: {}", e),
+                }
+            }
+            Err(e) => eprintln!("Failed to stop recording: {}", e),
+        }
+    };
 
     let mut counter = 0;
     loop {
         if let Some(event) = hotkey_manager.check_event() {
-            match event {
-                HotkeyEvent::Pressed => {
-                    println!("{} pressed, starting recording...", config.hotkey);
-                    let mut rec = recorder.lock().unwrap();
-                    match rec.start_recording() {
-                        Ok(()) => println!("Recording started."),
-                        Err(e) => eprintln!("Failed to start recording: {}", e),
-                    }
-                }
-                HotkeyEvent::Released => {
-                    println!("{} released, stopping recording...", config.hotkey);
-                    let mut rec = recorder.lock().unwrap();
-                    match rec.stop_recording() {
-                        Ok(wav_path) => {
-                            println!("Recording saved: {}", wav_path);
-                            match transcriber.transcribe(&wav_path) {
-                                Ok(text) => {
-                                    if let Err(e) = typer.type_text(&text) {
-                                        eprintln!("Failed to type text: {}", e);
-                                    }
-                                }
-                                Err(e) => eprintln!("Transcription failed: {}", e),
+            match config.recording_mode {
+                RecordingMode::Hold => {
+                    match event {
+                        HotkeyEvent::Pressed => {
+                            println!("{} pressed, starting recording...", config.hotkey);
+                            let mut rec = recorder.lock().unwrap();
+                            match rec.start_recording() {
+                                Ok(()) => println!("Recording started."),
+                                Err(e) => eprintln!("Failed to start recording: {}", e),
                             }
                         }
-                        Err(e) => eprintln!("Failed to stop recording: {}", e),
+                        HotkeyEvent::Released => {
+                            println!("{} released, stopping recording...", config.hotkey);
+                            let mut rec = recorder.lock().unwrap();
+                            stop_and_transcribe(&mut rec);
+                        }
+                    }
+                }
+                RecordingMode::Toggle => {
+                    if let HotkeyEvent::Pressed = event {
+                        let mut rec = recorder.lock().unwrap();
+                        if rec.is_recording() {
+                            println!("{} pressed, stopping recording...", config.hotkey);
+                            stop_and_transcribe(&mut rec);
+                        } else {
+                            println!("{} pressed, starting recording...", config.hotkey);
+                            match rec.start_recording() {
+                                Ok(()) => println!("Recording started."),
+                                Err(e) => eprintln!("Failed to start recording: {}", e),
+                            }
+                        }
                     }
                 }
             }
@@ -101,7 +133,12 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
 
         counter += 1;
         if counter % 300 == 0 {
-            println!("[Heartbeat] Running... Hold {} to record", config.hotkey);
+            let status = if recorder.lock().unwrap().is_recording() {
+                "Recording..."
+            } else {
+                "Idle"
+            };
+            println!("[Heartbeat] {} | {} mode | {}", status, config.recording_mode, config.hotkey);
         }
 
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -125,6 +162,7 @@ fn handle_config(action: ConfigAction) {
                 "prompt",
                 "temperature",
                 "mic_gain",
+                "recording_mode",
                 "groq_api_key",
             ] {
                 let value = config


### PR DESCRIPTION
## Summary
- 新增 `RecordingMode` 枚举（`Hold` / `Toggle`），支持两种录音触发方式
- **Toggle 模式**（默认）：按一下热键开始录音，再按一下结束录音并开始识别
- **Hold 模式**：保持现有行为，长按录音，释放转录
- 配置系统支持 `recording_mode` 字段的 get/set/list
- Heartbeat 显示当前录音状态和模式

## 变更文件
- `src/config.rs` — 新增 `RecordingMode` 枚举及相关配置方法
- `src/main.rs` — `run_listener()` 支持双模式热键处理
- `docs/toggle_recording_plan.md` — 实现计划文档

## 使用方式
```bash
# 切换到 toggle 模式（默认）
viberwhisper config set recording_mode toggle

# 切换回 hold 模式
viberwhisper config set recording_mode hold
```

## Test plan
- [ ] 验证 Toggle 模式：按 F8 开始录音，再按 F8 停止并转录
- [ ] 验证 Hold 模式：长按 F8 录音，释放后转录
- [ ] 验证 config set/get recording_mode 功能
- [ ] 验证快速双击边界情况

🤖 Generated with [Claude Code](https://claude.com/claude-code)