### PR TITLE
refactor: remove dead code and suppress intentional unused-field warnings

### DIFF
--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -28,7 +28,7 @@ pub struct AudioRecorder {
 }
 
 impl AudioRecorder {
-    #[instrument(skip_all, fields(gain))]
+    #[cfg(test)]
     pub fn new(gain: f32) -> Result<Self, Box<dyn std::error::Error>> {
         Self::with_config(gain, 30, 23 * 1024 * 1024)
     }
@@ -139,7 +139,8 @@ impl AudioRecorder {
                         let mono: Vec<i16> = data
                             .chunks(channels)
                             .map(|ch| {
-                                let avg = ch.iter().map(|&s| s as f32).sum::<f32>() / channels as f32;
+                                let avg =
+                                    ch.iter().map(|&s| s as f32).sum::<f32>() / channels as f32;
                                 (avg * gain).clamp(i16::MIN as f32, i16::MAX as f32) as i16
                             })
                             .collect();
@@ -147,7 +148,11 @@ impl AudioRecorder {
                         buffer.lock().unwrap().extend_from_slice(&mono);
                         let total = sample_count.fetch_add(len, Ordering::Relaxed) + len;
                         if total % (sample_rate as usize / 2) < len {
-                            debug!(frames = total, seconds = total / sample_rate as usize, "Recording progress");
+                            debug!(
+                                frames = total,
+                                seconds = total / sample_rate as usize,
+                                "Recording progress"
+                            );
                         }
                         // Signal flush when chunk threshold is crossed.
                         if chunk_max_samples > 0
@@ -177,7 +182,11 @@ impl AudioRecorder {
                         buffer.lock().unwrap().extend_from_slice(&mono);
                         let total = sample_count.fetch_add(len, Ordering::Relaxed) + len;
                         if total % (sample_rate as usize / 2) < len {
-                            debug!(frames = total, seconds = total / sample_rate as usize, "Recording progress");
+                            debug!(
+                                frames = total,
+                                seconds = total / sample_rate as usize,
+                                "Recording progress"
+                            );
                         }
                         if chunk_max_samples > 0
                             && !flush_needed.load(Ordering::Relaxed)
@@ -332,10 +341,7 @@ impl AudioRecorder {
     }
 
     /// Write the entire buffer as a single WAV file (legacy path, no chunking).
-    fn write_full_recording(
-        &self,
-        buffer: &[i16],
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    fn write_full_recording(&self, buffer: &[i16]) -> Result<String, Box<dyn std::error::Error>> {
         let mut path = PathBuf::from("./tmp");
         std::fs::create_dir_all(&path)?;
 

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -95,8 +95,10 @@ impl fmt::Display for SessionError {
 enum ChunkState {
     /// Written to disk; not yet picked up by the worker.
     Flushed,
-    /// Worker is transcribing this chunk (attempt number tracked internally).
-    Uploading { attempt: u32 },
+    /// Worker is transcribing this chunk.
+    /// `attempt` is reserved for future retry logic (see `max_retries` in AppConfig);
+    /// retry is not yet implemented — on failure the chunk transitions directly to `Failed`.
+    Uploading { #[allow(dead_code)] attempt: u32 },
     /// Successfully transcribed.
     Transcribed(String),
     /// Transcription failed (all retries exhausted, or timeout).
@@ -120,6 +122,7 @@ enum WorkerMsg {
 }
 
 struct ActiveSessionInner {
+    #[allow(dead_code)]
     mode: SessionMode,
     chunks: Arc<Mutex<Vec<ChunkEntry>>>,
     chunk_tx: mpsc::SyncSender<WorkerMsg>,

--- a/src/input/typer.rs
+++ b/src/input/typer.rs
@@ -4,6 +4,7 @@ pub trait TextTyper {
     fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>>;
 }
 
+#[allow(dead_code)]
 pub struct MockTyper;
 
 impl TextTyper for MockTyper {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,69 +35,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Manages background transcription tasks spawned during a streaming (toggle) recording.
-///
-/// Each time a live chunk is ready, `dispatch` spawns a thread to transcribe it.
-/// `collect` waits for all spawned threads and returns their results in order.
-struct StreamingSession {
-    handles: Vec<(usize, std::thread::JoinHandle<Result<String, String>>)>,
-    next_index: usize,
-}
-
-impl StreamingSession {
-    fn new() -> Self {
-        Self {
-            handles: Vec::new(),
-            next_index: 0,
-        }
-    }
-
-    /// Spawn a background thread to transcribe `chunk_path`.
-    fn dispatch(
-        &mut self,
-        chunk_path: String,
-        transcriber: std::sync::Arc<Box<dyn transcriber::Transcriber>>,
-    ) {
-        let index = self.next_index;
-        self.next_index += 1;
-        info!(index = index, path = %chunk_path, "Dispatching background chunk transcription");
-        let handle = std::thread::spawn(move || {
-            transcriber
-                .transcribe(&chunk_path)
-                .map_err(|e| e.to_string())
-                // Clean up the chunk file after transcription.
-                .inspect(|_| {
-                    if let Err(e) = std::fs::remove_file(&chunk_path) {
-                        // Non-fatal: file might already be gone.
-                        let _ = e;
-                    }
-                })
-                .inspect_err(|_| {
-                    let _ = std::fs::remove_file(&chunk_path);
-                })
-        });
-        self.handles.push((index, handle));
-    }
-
-    fn has_pending(&self) -> bool {
-        !self.handles.is_empty()
-    }
-
-    /// Wait for all background threads and return results sorted by chunk index.
-    fn collect(self) -> Vec<Result<String, String>> {
-        let mut indexed: Vec<(usize, Result<String, String>)> = self
-            .handles
-            .into_iter()
-            .map(|(idx, h)| {
-                let result = h.join().unwrap_or_else(|_| Err("thread panicked".to_string()));
-                (idx, result)
-            })
-            .collect();
-        indexed.sort_by_key(|(idx, _)| *idx);
-        indexed.into_iter().map(|(_, r)| r).collect()
-    }
-}
-
 fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     use audio::{AudioRecorder, StopResult};
     use core::config::AppConfig;

--- a/src/transcriber/mod.rs
+++ b/src/transcriber/mod.rs
@@ -1,4 +1,6 @@
 pub mod api;
 pub mod factory;
-pub use api::{MockTranscriber, Transcriber};
+#[cfg(test)]
+pub use api::MockTranscriber;
+pub use api::Transcriber;
 pub use factory::create_transcriber;


### PR DESCRIPTION
## Summary

- Remove `StreamingSession` struct — superseded by `SessionOrchestrator`, was dead code
- Gate `AudioRecorder::new` under `#[cfg(test)]` — only used in tests
- Gate `MockTranscriber` re-export under `#[cfg(test)]` — only consumed by test code
- Add `#[allow(dead_code)]` to `MockTyper`, `ChunkState::attempt`, and `ActiveSessionInner::mode`
- Document `attempt` field as reserved for future retry logic (`max_retries` in AppConfig)

## Test plan

- [ ] `cargo build` produces zero warnings
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)