### PR TITLE
feat: add floating overlay window (#15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,4 @@ This project follows TDD practices. Always:
 - Optional LLM text post-processing (preheat + conservative modes)
 - System tray with recording status indicator
 - CLI config management and offline WAV transcription
+- Floating overlay window with click-to-toggle recording (macOS)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 tray-icon = "0.21"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26"
+objc = "0.2"
+core-graphics = "0.24"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/changelog
+++ b/changelog
@@ -6,3 +6,4 @@
 2026-03-15: Add long-audio streaming plan covering in-recording chunking, offline WAV split fallback, retry, and result merge
 2026-03-15: Add end-to-end stream recognition plan covering unified Hold/Toggle session orchestration, chunk state machine, convergence, and error propagation
 2026-03-18: Add LLM post-processing plan covering punctuation cleanup, filler removal, and graceful fallback after STT
+2026-04-01: Add floating overlay window: always-on-top clickable mic icon, system theme matching, click-to-toggle recording, draggable (macOS)

--- a/docs/plan/09-floating-window.md
+++ b/docs/plan/09-floating-window.md
@@ -1,0 +1,52 @@
+# 09 - Floating Window Overlay
+
+## Goal
+
+Add a floating overlay window that shows recording status and allows click-to-toggle recording. Addresses issue #15.
+
+## Requirements
+
+1. **Appearance**: 48×48 rounded rectangle with microphone icon
+2. **Background**: Matches system theme (dark/light mode)
+3. **Icon states**: White/dark mic when idle, red mic when recording
+4. **Interaction**: Click to toggle recording on/off
+5. **Window behavior**: Always on top, borderless, draggable, doesn't steal focus, visible on all spaces
+
+## Implementation
+
+### Module: `src/input/overlay/`
+
+Platform-specific implementations behind `#[cfg]`:
+- `macos.rs` — Cocoa NSWindow + custom NSView with CoreGraphics drawing
+- `windows_impl.rs` — Stub (to be implemented)
+- `stub.rs` — No-op fallback for other platforms
+
+### Public API
+
+```rust
+pub struct OverlayManager { ... }
+
+impl OverlayManager {
+    pub fn new() -> Result<Self, Box<dyn Error>>;
+    pub fn set_recording(&mut self, recording: bool);
+    pub fn check_click(&self) -> bool;
+    pub fn update(&self);
+}
+```
+
+### macOS Details
+
+- Borderless `NSWindow` at `NSStatusWindowLevel` (25)
+- Custom `VWOverlayView` subclass with `drawRect:` override
+- System theme detection via `NSApp.effectiveAppearance`
+- `acceptsFirstMouse:` returns YES for click-without-activate
+- `setMovableByWindowBackground:` for dragging
+- `NSWindowCollectionBehaviorCanJoinAllSpaces` for all desktops
+- Recording state via static `AtomicBool` (thread-safe, polled by main loop)
+
+### Integration
+
+Overlay plugs into the main event loop alongside tray and hotkeys:
+- `overlay.check_click()` triggers toggle recording (same as F9)
+- `overlay.set_recording(bool)` syncs with all tray/hotkey state changes
+- `overlay.update()` pumps Cocoa events each loop iteration

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,3 +1,4 @@
 pub mod hotkey;
+pub mod overlay;
 pub mod tray;
 pub mod typer;

--- a/src/input/overlay/macos.rs
+++ b/src/input/overlay/macos.rs
@@ -1,0 +1,261 @@
+use cocoa::appkit::{
+    NSApp, NSBackingStoreBuffered, NSColor, NSWindow, NSWindowCollectionBehavior, NSWindowStyleMask,
+};
+use cocoa::base::{NO, YES, id, nil};
+use cocoa::foundation::{NSAutoreleasePool, NSPoint, NSRect, NSSize, NSString};
+use objc::declare::ClassDecl;
+use objc::runtime::{BOOL, Class, Object, Sel};
+use objc::{class, msg_send, sel, sel_impl};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const OVERLAY_SIZE: f64 = 48.0;
+const CORNER_RADIUS: f64 = 12.0;
+const SCREEN_MARGIN: f64 = 20.0;
+
+static CLICKED: AtomicBool = AtomicBool::new(false);
+static IS_RECORDING: AtomicBool = AtomicBool::new(false);
+
+pub struct OverlayManager {
+    _window: id,
+    content_view: id,
+}
+
+unsafe impl Send for OverlayManager {}
+
+impl OverlayManager {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        unsafe {
+            let _pool = NSAutoreleasePool::new(nil);
+
+            let app = NSApp();
+            let _: () = msg_send![app, setActivationPolicy: 1i64];
+
+            let screen: id = msg_send![class!(NSScreen), mainScreen];
+            let screen_frame: NSRect = msg_send![screen, frame];
+
+            let x = screen_frame.origin.x + screen_frame.size.width - OVERLAY_SIZE - SCREEN_MARGIN;
+            let y = screen_frame.origin.y + SCREEN_MARGIN;
+
+            let window_rect =
+                NSRect::new(NSPoint::new(x, y), NSSize::new(OVERLAY_SIZE, OVERLAY_SIZE));
+
+            let window = NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
+                window_rect,
+                NSWindowStyleMask::NSBorderlessWindowMask,
+                NSBackingStoreBuffered,
+                NO,
+            );
+
+            window.setLevel_(25);
+            let _: () = msg_send![window, setOpaque: NO];
+            window.setBackgroundColor_(NSColor::clearColor(nil));
+            let _: () = msg_send![window, setHasShadow: YES];
+            let _: () = msg_send![window, setMovableByWindowBackground: YES];
+            let _: () = msg_send![window, setIgnoresMouseEvents: NO];
+            let _: () = msg_send![window, setAlphaValue: 0.95f64];
+
+            window.setCollectionBehavior_(
+                NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
+                    | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary,
+            );
+
+            let content_view = create_overlay_view(window_rect.size);
+            window.setContentView_(content_view);
+
+            window.makeKeyAndOrderFront_(nil);
+            let _: () = msg_send![window, resignKeyWindow];
+
+            Ok(OverlayManager {
+                _window: window,
+                content_view,
+            })
+        }
+    }
+
+    pub fn set_recording(&mut self, recording: bool) {
+        IS_RECORDING.store(recording, Ordering::Relaxed);
+        unsafe {
+            let _: () = msg_send![self.content_view, setNeedsDisplay: YES];
+        }
+    }
+
+    pub fn check_click(&self) -> bool {
+        CLICKED.swap(false, Ordering::Relaxed)
+    }
+
+    pub fn update(&self) {
+        unsafe {
+            let app = NSApp();
+            loop {
+                let event: id = msg_send![app,
+                    nextEventMatchingMask: u64::MAX
+                    untilDate: nil
+                    inMode: NSString::alloc(nil).init_str("kCFRunLoopDefaultMode")
+                    dequeue: YES
+                ];
+                if event == nil {
+                    break;
+                }
+                let _: () = msg_send![app, sendEvent: event];
+            }
+        }
+    }
+}
+
+fn create_overlay_view(size: NSSize) -> id {
+    unsafe {
+        let superclass = Class::get("NSView").unwrap();
+
+        if let Some(cls) = Class::get("VWOverlayView") {
+            let view: id = msg_send![cls, alloc];
+            let frame = NSRect::new(NSPoint::new(0.0, 0.0), size);
+            let view: id = msg_send![view, initWithFrame: frame];
+            return view;
+        }
+
+        let mut decl = ClassDecl::new("VWOverlayView", superclass).unwrap();
+
+        extern "C" fn draw_rect(this: &Object, _sel: Sel, _dirty_rect: NSRect) {
+            unsafe {
+                let bounds: NSRect = msg_send![this, bounds];
+                let recording = IS_RECORDING.load(Ordering::Relaxed);
+
+                let bg_color = if is_dark_mode() {
+                    NSColor::colorWithRed_green_blue_alpha_(nil, 0.2, 0.2, 0.2, 0.9)
+                } else {
+                    NSColor::colorWithRed_green_blue_alpha_(nil, 0.95, 0.95, 0.95, 0.9)
+                };
+
+                let path: id = msg_send![class!(NSBezierPath),
+                    bezierPathWithRoundedRect: bounds
+                    xRadius: CORNER_RADIUS
+                    yRadius: CORNER_RADIUS
+                ];
+
+                let _: () = msg_send![bg_color, setFill];
+                let _: () = msg_send![path, fill];
+
+                draw_mic_icon(bounds, recording);
+            }
+        }
+
+        extern "C" fn mouse_down(_this: &Object, _sel: Sel, _event: id) {
+            CLICKED.store(true, Ordering::Relaxed);
+        }
+
+        extern "C" fn accepts_first_mouse(_this: &Object, _sel: Sel, _event: id) -> BOOL {
+            YES
+        }
+
+        decl.add_method(
+            sel!(drawRect:),
+            draw_rect as extern "C" fn(&Object, Sel, NSRect),
+        );
+        decl.add_method(
+            sel!(mouseDown:),
+            mouse_down as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
+            sel!(acceptsFirstMouse:),
+            accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
+        );
+
+        let cls = decl.register();
+
+        let view: id = msg_send![cls, alloc];
+        let frame = NSRect::new(NSPoint::new(0.0, 0.0), size);
+        let view: id = msg_send![view, initWithFrame: frame];
+        view
+    }
+}
+
+fn is_dark_mode() -> bool {
+    unsafe {
+        let app = NSApp();
+        let appearance: id = msg_send![app, effectiveAppearance];
+        if appearance == nil {
+            return false;
+        }
+        let name: id = msg_send![appearance, name];
+        if name == nil {
+            return false;
+        }
+        let dark_name = NSString::alloc(nil).init_str("NSAppearanceNameDarkAqua");
+        let contains: BOOL = msg_send![name, containsString: dark_name];
+        contains == YES
+    }
+}
+
+fn draw_mic_icon(bounds: NSRect, recording: bool) {
+    unsafe {
+        let icon_color = if recording {
+            NSColor::colorWithRed_green_blue_alpha_(nil, 0.9, 0.2, 0.2, 1.0)
+        } else if is_dark_mode() {
+            NSColor::colorWithRed_green_blue_alpha_(nil, 0.9, 0.9, 0.9, 1.0)
+        } else {
+            NSColor::colorWithRed_green_blue_alpha_(nil, 0.3, 0.3, 0.3, 1.0)
+        };
+        let _: () = msg_send![icon_color, setFill];
+        let _: () = msg_send![icon_color, setStroke];
+
+        let cx = bounds.origin.x + bounds.size.width / 2.0;
+        let cy = bounds.origin.y + bounds.size.height / 2.0;
+        let scale = bounds.size.width / 48.0;
+
+        // Microphone body (rounded rectangle)
+        let mic_width = 10.0 * scale;
+        let mic_height = 16.0 * scale;
+        let mic_rect = NSRect::new(
+            NSPoint::new(cx - mic_width / 2.0, cy - 1.0 * scale),
+            NSSize::new(mic_width, mic_height),
+        );
+        let mic_path: id = msg_send![class!(NSBezierPath),
+            bezierPathWithRoundedRect: mic_rect
+            xRadius: mic_width / 2.0
+            yRadius: mic_width / 2.0
+        ];
+        let _: () = msg_send![mic_path, fill];
+
+        // Microphone arc (holder curve)
+        let arc_path: id = msg_send![class!(NSBezierPath), bezierPath];
+        let _: () = msg_send![arc_path, setLineWidth: 2.0 * scale];
+        let _: () = msg_send![arc_path,
+            appendBezierPathWithArcWithCenter: NSPoint::new(cx, cy + 6.0 * scale)
+            radius: 9.0 * scale
+            startAngle: 210.0f64
+            endAngle: 330.0f64
+        ];
+        let _: () = msg_send![arc_path, stroke];
+
+        // Stand (vertical line)
+        let stand_path: id = msg_send![class!(NSBezierPath), bezierPath];
+        let _: () = msg_send![stand_path, setLineWidth: 2.0 * scale];
+        let _: () = msg_send![stand_path, moveToPoint: NSPoint::new(cx, cy - 3.0 * scale)];
+        let _: () = msg_send![stand_path, lineToPoint: NSPoint::new(cx, cy - 8.0 * scale)];
+        let _: () = msg_send![stand_path, stroke];
+
+        // Base
+        let base_path: id = msg_send![class!(NSBezierPath), bezierPath];
+        let _: () = msg_send![base_path, setLineWidth: 2.0 * scale];
+        let _: () = msg_send![
+            base_path,
+            moveToPoint: NSPoint::new(cx - 5.0 * scale, cy - 8.0 * scale)
+        ];
+        let _: () = msg_send![
+            base_path,
+            lineToPoint: NSPoint::new(cx + 5.0 * scale, cy - 8.0 * scale)
+        ];
+        let _: () = msg_send![base_path, stroke];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_static_flags_default() {
+        assert!(!CLICKED.load(Ordering::Relaxed));
+        assert!(!IS_RECORDING.load(Ordering::Relaxed));
+    }
+}

--- a/src/input/overlay/mod.rs
+++ b/src/input/overlay/mod.rs
@@ -1,0 +1,17 @@
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "macos")]
+pub use macos::OverlayManager;
+
+#[cfg(target_os = "windows")]
+mod windows_impl;
+
+#[cfg(target_os = "windows")]
+pub use windows_impl::OverlayManager;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod stub;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub use stub::OverlayManager;

--- a/src/input/overlay/stub.rs
+++ b/src/input/overlay/stub.rs
@@ -1,0 +1,16 @@
+/// No-op overlay for unsupported platforms.
+pub struct OverlayManager;
+
+impl OverlayManager {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(OverlayManager)
+    }
+
+    pub fn set_recording(&mut self, _recording: bool) {}
+
+    pub fn check_click(&self) -> bool {
+        false
+    }
+
+    pub fn update(&self) {}
+}

--- a/src/input/overlay/windows_impl.rs
+++ b/src/input/overlay/windows_impl.rs
@@ -1,0 +1,16 @@
+/// Stub overlay for Windows (to be implemented later).
+pub struct OverlayManager;
+
+impl OverlayManager {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(OverlayManager)
+    }
+
+    pub fn set_recording(&mut self, _recording: bool) {}
+
+    pub fn check_click(&self) -> bool {
+        false
+    }
+
+    pub fn update(&self) {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,12 +41,13 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     use core::config::AppConfig;
     use core::orchestrator::{SessionError, SessionMode, SessionOrchestrator};
     use input::hotkey::{HotkeyEvent, HotkeyManager, HotkeySource};
+    use input::overlay::OverlayManager;
     use input::tray::TrayManager;
     use input::typer::TextTyper;
+    use postprocess::create_post_processor;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
-    use postprocess::create_post_processor;
-    use transcriber::{create_transcriber, Transcriber};
+    use transcriber::{Transcriber, create_transcriber};
 
     println!("ViberWhisper - Voice-to-Text Input");
     println!("===================================");
@@ -96,7 +97,13 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     let mut tray = TrayManager::new()?;
     info!("System tray icon started");
 
-    println!("Hold {} to record, release to transcribe.", config.hold_hotkey);
+    let mut overlay = OverlayManager::new()?;
+    info!("Floating overlay window started");
+
+    println!(
+        "Hold {} to record, release to transcribe.",
+        config.hold_hotkey
+    );
     println!(
         "Press {} to start recording, press again to stop.",
         config.toggle_hotkey
@@ -188,6 +195,7 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
                             orchestrator.start_session(SessionMode::Hold);
                             info!("Recording started (hold mode)");
                             tray.set_recording(true);
+                            overlay.set_recording(true);
                         }
                         Err(e) => error!(error = %e, "Failed to start recording"),
                     }
@@ -198,11 +206,13 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
                     match rec.stop_recording() {
                         Ok(stop_result) => {
                             tray.set_recording(false);
+                            overlay.set_recording(false);
                             finalize(stop_result);
                         }
                         Err(e) => {
                             error!(error = %e, "Failed to stop recording");
                             tray.set_recording(false);
+                            overlay.set_recording(false);
                         }
                     }
                 }
@@ -213,11 +223,13 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
                         match rec.stop_recording() {
                             Ok(stop_result) => {
                                 tray.set_recording(false);
+                                overlay.set_recording(false);
                                 finalize(stop_result);
                             }
                             Err(e) => {
                                 error!(error = %e, "Failed to stop recording");
                                 tray.set_recording(false);
+                                overlay.set_recording(false);
                             }
                         }
                     } else {
@@ -227,12 +239,44 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
                                 orchestrator.start_session(SessionMode::Toggle);
                                 info!("Recording started (toggle mode)");
                                 tray.set_recording(true);
+                                overlay.set_recording(true);
                             }
                             Err(e) => error!(error = %e, "Failed to start recording"),
                         }
                     }
                 }
                 HotkeyEvent::Released(HotkeySource::Toggle) => {}
+            }
+        }
+
+        // Check overlay click (acts like toggle hotkey)
+        if overlay.check_click() {
+            let mut rec = recorder.lock().unwrap();
+            if rec.is_recording() {
+                info!("Overlay clicked, stopping recording");
+                match rec.stop_recording() {
+                    Ok(stop_result) => {
+                        tray.set_recording(false);
+                        overlay.set_recording(false);
+                        finalize(stop_result);
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Failed to stop recording");
+                        tray.set_recording(false);
+                        overlay.set_recording(false);
+                    }
+                }
+            } else {
+                info!("Overlay clicked, starting recording");
+                match rec.start_recording() {
+                    Ok(()) => {
+                        orchestrator.start_session(SessionMode::Toggle);
+                        info!("Recording started (overlay toggle)");
+                        tray.set_recording(true);
+                        overlay.set_recording(true);
+                    }
+                    Err(e) => error!(error = %e, "Failed to start recording"),
+                }
             }
         }
 
@@ -265,6 +309,7 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
 
+        overlay.update();
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 }
@@ -335,7 +380,7 @@ fn handle_config(action: ConfigAction) {
 fn handle_convert(input: &str, output: Option<&str>) {
     use core::config::AppConfig;
     use postprocess::create_post_processor;
-    use transcriber::{create_transcriber, Transcriber};
+    use transcriber::{Transcriber, create_transcriber};
 
     println!("Transcribing: {}", input);
 


### PR DESCRIPTION
## Summary
- Add a 48×48 floating overlay window with microphone icon that allows click-to-toggle recording
- macOS implementation using Cocoa NSWindow + CoreGraphics (always-on-top, borderless, draggable, system theme matching)
- Overlay syncs recording state with hotkeys and system tray
- White/dark mic icon when idle, red when recording
- Windows/other platforms have stub implementations for now

Closes #15

## Changes
- **New**: `src/input/overlay/` module (macos.rs, windows_impl.rs, stub.rs)
- **Modified**: `src/main.rs` — overlay integration into main event loop
- **Modified**: `Cargo.toml` — added cocoa, objc, core-graphics deps for macOS
- **Docs**: Plan doc and changelog updated

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 110 tests pass
- [x] `cargo clippy` — no new warnings (only cocoa deprecation notices)
- [ ] Manual test: run app, verify overlay appears bottom-right
- [ ] Manual test: click overlay to toggle recording
- [ ] Manual test: verify overlay reflects hotkey-triggered recording state
- [ ] Manual test: verify draggable positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)