### PR TITLE
feat(local): add local Gemma 4B inference service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,31 @@ on:
     branches: [master]
 
 jobs:
+  python-lint-and-test:
+    runs-on: ubuntu-latest
+    name: Python (ruff + pytest)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python test dependencies
+        run: uv sync --group dev
+
+      - name: Ruff
+        run: uv run ruff check server
+
+      - name: Pytest
+        run: uv run pytest
+
   build-and-test:
     runs-on: macos-latest
     name: CI (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@
 *.swp
 *.swo
 
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
 # OS
 .DS_Store
 Thumbs.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,11 @@ name = "viberwhisper"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+integration = []
+
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy", "integration"))'] }
 
 [dependencies]
 rdev = "0.5"

--- a/changelog
+++ b/changelog
@@ -15,3 +15,5 @@
 2026-03-31: Refactor audio module: replace Mutex<bool> with AtomicBool, extract shared helper functions, remove dead code
 2026-04-01: Add floating overlay window: always-on-top clickable mic icon, system theme matching, click-to-toggle recording, draggable (macOS)
 2026-04-03: Add packaging & CI: ci.yml (build/test gate with Discord alerts), release.yml (cross-platform release pipeline), cargo-bundle metadata, placeholder app icons
+2026-04-06: Add local Gemma service management: Python FastAPI server under server/, local install/start/stop/status CLI, runtime endpoint overrides, and local backend config fields
+2026-04-06: Move the local Gemma runtime to `server/` and complete local CLI/runtime wiring to the planned FastAPI service

--- a/config.example.json
+++ b/config.example.json
@@ -18,5 +18,9 @@
   "post_process_api_url": "https://api.openai.com/v1/chat/completions",
   "post_process_model": "gpt-4o-mini",
   "post_process_api_format": "openai",
-  "post_process_temperature": 0.0
+  "post_process_temperature": 0.0,
+  "local_mode": false,
+  "local_data_dir": "~/.viberwhisper",
+  "local_server_port": 17265,
+  "local_quantization": "int8"
 }

--- a/docs/plan/12-local-gemma-service.md
+++ b/docs/plan/12-local-gemma-service.md
@@ -1,0 +1,292 @@
+# Plan 12: Local Gemma 4 E4B Inference Service
+
+## Background
+
+ViberWhisper currently relies on cloud APIs (Groq/OpenAI-compatible) for both STT and
+LLM post-processing. This plan adds a fully local inference path using Google's
+**Gemma 4 E4B-it** multimodal model, which supports text, image, audio, and video
+input natively.
+
+Primary target hardware: **Apple Silicon Mac Mini (16 GB unified memory)**.
+Windows support is included as a second-class target for the same code path.
+
+### Why a Python server (not llama.cpp)?
+
+llama.cpp has day-0 support for Gemma 4 text and image inference, but audio input is
+not yet implemented ([ggml-org/llama.cpp#21325](https://github.com/ggml-org/llama.cpp/issues/21325)).
+Ollama has the same gap. The only runtime that supports Gemma 4 audio today is
+**HuggingFace `transformers`** (the canonical implementation from Google).
+
+The plan uses a thin Python FastAPI server wrapping `transformers`, exposing an
+OpenAI-compatible HTTP API. The Rust side manages the server as a child process and
+calls the existing `ApiTranscriber` / `LlmPostProcessor` unchanged — the only new
+Rust code is process lifecycle management and installer CLI.
+
+When llama.cpp audio support lands, the Python server can be swapped for llama.cpp
+server behind the same endpoints with zero changes to the rest of the Rust codebase.
+
+---
+
+## Architecture
+
+```
+viberwhisper (Rust)
+  │
+  ├── viberwhisper local install   ── downloads model + sets up venv
+  ├── viberwhisper local start     ── spawns Python server, then starts main loop
+  ├── viberwhisper local stop      ── kills Python server
+  └── viberwhisper local status    ── checks process + HTTP health
+         │
+         ▼
+  LocalServiceManager (src/local/service.rs)
+    └── spawn: python server.py --port 8765
+               │
+               ├── POST /v1/audio/transcriptions   ← ApiTranscriber (zero changes)
+               └── POST /v1/chat/completions        ← LlmPostProcessor (zero changes)
+```
+
+The server loads Gemma 4 E4B-it once at startup and handles both endpoints with the
+same model instance.
+
+---
+
+## Model
+
+| Property | Value |
+|---|---|
+| Model | `google/gemma-4-E4B-it` |
+| HuggingFace repo | `ggml-org/gemma-4-E4B-it-GGUF` (GGUF, future) / `google/gemma-4-E4B-it` (safetensors, now) |
+| Effective parameters | 4.5 B (8 B with embeddings) |
+| Precision | `bfloat16` → ~8–9 GB weights |
+| Quantization (default) | `int8` via `optimum-quanto` → ~5 GB weights, ~8 GB total |
+| Fits in 16 GB unified memory | Yes (int8), comfortable |
+| Audio input max | 30 seconds per call |
+
+---
+
+## New Files
+
+```
+server/
+  server.py            — FastAPI inference server (STT + chat completions)
+  requirements.txt     — Python dependencies
+
+src/
+  local/
+    mod.rs               — pub re-exports
+    service.rs           — LocalServiceManager (spawn, health-check, stop)
+    installer.rs         — setup_venv(), download_model(), verify_install()
+```
+
+### Changes to existing files
+
+| File | Change |
+|---|---|
+| `src/core/config.rs` | Add `local_*` config fields (see Config section) |
+| `src/core/cli.rs` | Add `local` subcommand with `install / start / stop / status` |
+| `src/main.rs` | Wire `local` subcommand dispatch |
+| `config.example.json` | Add local mode example block |
+
+---
+
+## Python Server (`server/server.py`)
+
+### Endpoints
+
+**`GET /health`**
+Returns `{"status": "ok", "model": "gemma-4-E4B-it"}` once the model is loaded.
+Returns 503 while loading.
+
+**`POST /v1/audio/transcriptions`** (multipart/form-data)
+Accepts the same fields as the OpenAI Whisper endpoint:
+- `file` — WAV audio file (≤ 30 s enforced by chunking on the Rust side)
+- `language` (optional)
+- `prompt` (optional, prepended as text context)
+
+Returns: `{"text": "...", "language": "...", "duration": 12.3}`
+
+The handler decodes the WAV bytes with `soundfile`, builds a Gemma 4 multimodal
+message with `{"type": "audio", "audio": samples}`, runs inference, and extracts the
+transcription from the generated text.
+
+**`POST /v1/chat/completions`**
+Standard OpenAI chat completions (text only). Used by the existing `LlmPostProcessor`.
+Supports `stream: false` only in this initial implementation (streaming is a stretch
+goal, see below).
+
+### Dependencies (`requirements.txt`)
+
+```
+torch>=2.3
+transformers>=4.51
+fastapi>=0.111
+uvicorn[standard]>=0.29
+soundfile>=0.12
+optimum-quanto>=0.2   # int8 quantization on MPS / CUDA / CPU
+huggingface_hub>=0.23
+```
+
+### Startup sequence
+
+1. Parse `--model-dir`, `--port`, `--quantization` (int8 / bf16) args.
+2. Load `AutoProcessor` and `Gemma4ForConditionalGeneration` from the local model dir.
+3. Apply int8 quantization if requested (default on ≤ 24 GB unified memory).
+4. Move model to `mps` (macOS Apple Silicon), `cuda` (Windows + GPU), or `cpu`.
+5. Set `GET /health` to return 200 and begin accepting requests.
+
+---
+
+## Rust: `LocalServiceManager` (`src/local/service.rs`)
+
+```rust
+pub struct LocalServiceManager {
+    port: u16,
+    model_dir: PathBuf,
+    venv_dir: PathBuf,
+    process: Option<std::process::Child>,
+}
+
+impl LocalServiceManager {
+    pub fn start(&mut self) -> Result<(), Error>;      // spawn + wait for /health
+    pub fn stop(&mut self);                             // SIGTERM / TerminateProcess
+    pub fn is_running(&self) -> bool;
+    pub fn base_url(&self) -> String;                  // "http://127.0.0.1:{port}"
+}
+```
+
+`start()` polls `GET /health` with 500 ms intervals for up to 120 s (model load time)
+before returning an error.
+
+---
+
+## Rust: `Installer` (`src/local/installer.rs`)
+
+```rust
+pub fn setup_venv(venv_dir: &Path) -> Result<(), Error>;
+pub fn install_requirements(venv_dir: &Path, reqs: &Path) -> Result<(), Error>;
+pub fn download_model(model_dir: &Path, hf_endpoint: &str) -> Result<(), Error>;
+pub fn verify_install(venv_dir: &Path, model_dir: &Path) -> Result<(), Error>;
+```
+
+`download_model` uses `huggingface_hub` Python CLI (`huggingface-cli download`) via
+the venv's Python interpreter. This avoids adding a large Rust HF download crate and
+gives progress output for free.
+
+HF endpoint is configurable via `HF_ENDPOINT` env var for mirror support
+(e.g. `https://hf-mirror.com`).
+
+---
+
+## CLI (`viberwhisper local <subcommand>`)
+
+```
+viberwhisper local install   Download model and set up Python environment.
+                             Safe to re-run; skips steps already done.
+
+viberwhisper local start     Start the inference server, then start the main
+                             recording loop using local endpoints.
+
+viberwhisper local stop      Stop the background inference server.
+
+viberwhisper local status    Print server process status, port, memory usage,
+                             and last health-check result.
+```
+
+`start` implicitly runs `install` if the model is not yet present.
+
+When the local server is active, `start` overrides config at runtime:
+- `transcription_api_url` → `http://127.0.0.1:{port}/v1/audio/transcriptions`
+- `post_process_api_url` → `http://127.0.0.1:{port}/v1/chat/completions`
+- `post_process_enabled` → `true`
+- `post_process_model` → `gemma-4-E4B-it`
+
+No changes to `config.json` are made; overrides are in-memory only.
+
+---
+
+## Config Changes (`src/core/config.rs`)
+
+New optional fields (all `skip_serializing_if = "Option::is_none"` or with sane defaults):
+
+```rust
+/// "api" (default) or "local". Selects the STT+LLM backend.
+pub local_mode: bool,                          // default: false
+
+/// Directory for model weights and Python venv. Default: ~/.viberwhisper
+pub local_data_dir: Option<String>,
+
+/// Port for the local inference server. Default: 8765
+pub local_server_port: u16,
+
+/// Quantization level: "int8" (default) or "bf16"
+pub local_quantization: String,
+```
+
+---
+
+## Implementation Steps
+
+### Step 1 — Python server (TDD)
+
+1. Write `server/requirements.txt`
+2. Write `server/server.py` with all three endpoints
+3. Manual integration test: `python server.py --model-dir /path/to/model`
+   - Test `/health` returns 200 after load
+   - Test `/v1/audio/transcriptions` with a 5-second Chinese WAV clip
+   - Test `/v1/chat/completions` with a simple cleanup prompt
+
+### Step 2 — Rust `local` module
+
+1. `src/local/mod.rs`
+2. `src/local/service.rs` — `LocalServiceManager` with unit tests using a mock HTTP stub
+3. `src/local/installer.rs` — venv + download helpers with integration test behind
+   `#[cfg(feature = "integration")]`
+
+### Step 3 — Config fields
+
+1. Add fields to `AppConfig`
+2. Update `apply_json`, `get_field`, `set_field`, `Default`
+3. Extend existing config tests
+
+### Step 4 — CLI wiring
+
+1. Add `LocalCommand` enum to `cli.rs`
+2. Dispatch in `main.rs`
+3. `install` and `start` share `LocalServiceManager`
+
+### Step 5 — Documentation
+
+1. Update `config.example.json` with local mode block
+2. Update `changelog`
+
+---
+
+## Migration Path to llama.cpp (Phase 2)
+
+When [ggml-org/llama.cpp#21325](https://github.com/ggml-org/llama.cpp/issues/21325)
+is resolved:
+
+1. Add `local_backend: "python" | "llama_cpp"` config field
+2. Implement `LlamaCppServiceManager` alongside `LocalServiceManager`
+3. `installer.rs` gains llama.cpp binary download + GGUF model download
+4. `server.py` becomes optional — the Python path remains for fallback
+
+No changes to `ApiTranscriber`, `LlmPostProcessor`, or the main recording loop.
+
+---
+
+## Open Questions (to resolve during implementation)
+
+1. **Gemma 4 audio processor API**: The exact `transformers` call signature for passing
+   raw audio samples to `Gemma4ForConditionalGeneration` needs to be verified against
+   the model card examples and the upstream processor code.
+
+2. **`optimum-quanto` MPS support**: Verify int8 quantization works correctly on
+   Apple Silicon MPS backend. Fallback: load in `bfloat16` (~9 GB, fits in 16 GB).
+
+3. **Windows Python path**: `python3` vs `python` executable name, venv activation
+   path differs (`Scripts/` vs `bin/`). Handle in `installer.rs`.
+
+4. **Process persistence across app restarts**: Should the server keep running after
+   `viberwhisper` exits? Initial answer: yes, managed via a PID file in
+   `local_data_dir`. `start` reuses an already-running server; `stop` kills it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "viberwhisper-python"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.111",
+  "python-multipart>=0.0.9",
+]
+
+[dependency-groups]
+dev = [
+  "httpx>=0.27",
+  "pytest>=8.0",
+  "ruff>=0.6",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["server/tests"]
+pythonpath = ["."]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,10 @@
+torch>=2.3
+transformers>=4.51
+fastapi>=0.111
+uvicorn[standard]>=0.29
+soundfile>=0.12
+optimum-quanto>=0.2
+# bitsandbytes is optional; only usable on CUDA (not macOS MPS)
+# bitsandbytes>=0.43
+accelerate>=0.30
+huggingface_hub>=0.23

--- a/server/server.py
+++ b/server/server.py
@@ -8,18 +8,15 @@ import os
 import tempfile
 import threading
 import time
+from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
-import soundfile as sf
-import uvicorn
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from transformers import AutoModelForCausalLM, AutoProcessor
 
 LOGGER = logging.getLogger("viberwhisper.local_server")
 MODEL_NAME = "gemma-4-E4B-it"
-HF_MODEL_ID = "google/gemma-4-E4B-it"
 DEFAULT_MAX_NEW_TOKENS = 512
 
 
@@ -68,6 +65,8 @@ class LocalModelRuntime:
                         self.quantization, load_kwargs,
                     )
 
+                from transformers import AutoModelForCausalLM, AutoProcessor
+
                 processor = AutoProcessor.from_pretrained(self.model_dir)
                 model = AutoModelForCausalLM.from_pretrained(
                     self.model_dir, **load_kwargs,
@@ -106,6 +105,8 @@ class LocalModelRuntime:
         prompt: str | None,
     ) -> dict[str, Any]:
         self.ensure_ready()
+
+        import soundfile as sf
 
         samples, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
         if len(samples.shape) > 1:
@@ -311,12 +312,16 @@ class LocalModelRuntime:
 
 
 def create_app(runtime: LocalModelRuntime) -> FastAPI:
-    app = FastAPI(title="ViberWhisper Local Gemma Service")
-
-    @app.on_event("startup")
-    def _startup() -> None:
+    @asynccontextmanager
+    async def lifespan(_: FastAPI):
         thread = threading.Thread(target=runtime.load, daemon=True)
         thread.start()
+        yield
+
+    app = FastAPI(
+        title="ViberWhisper Local Gemma Service",
+        lifespan=lifespan,
+    )
 
     @app.get("/health")
     def health() -> JSONResponse:
@@ -356,6 +361,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    import uvicorn
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",

--- a/server/server.py
+++ b/server/server.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import logging
+import os
+import tempfile
+import threading
+import time
+from typing import Annotated, Any
+
+import soundfile as sf
+import uvicorn
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+LOGGER = logging.getLogger("viberwhisper.local_server")
+MODEL_NAME = "gemma-4-E4B-it"
+HF_MODEL_ID = "google/gemma-4-E4B-it"
+DEFAULT_MAX_NEW_TOKENS = 512
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: Any
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str | None = None
+    messages: list[ChatMessage]
+    temperature: float | None = 0.0
+    stream: bool | None = False
+    max_tokens: int | None = None
+
+
+class LocalModelRuntime:
+    def __init__(self, model_dir: str, quantization: str) -> None:
+        self.model_dir = model_dir
+        self.quantization = quantization
+        self.processor: Any | None = None
+        self.model: Any | None = None
+        self.ready = False
+        self.error: str | None = None
+        self._lock = threading.Lock()
+
+    def load(self) -> None:
+        with self._lock:
+            if self.ready or self.error:
+                return
+            try:
+                LOGGER.info(
+                    "Loading Gemma runtime from %s (%s)",
+                    self.model_dir,
+                    self.quantization,
+                )
+                load_kwargs: dict[str, Any] = {
+                    "dtype": "auto",
+                    "device_map": "auto",
+                    "low_cpu_mem_usage": True,
+                }
+
+                quanto_dtype = None
+                if self.quantization in ("int8", "int4"):
+                    quanto_dtype = self._try_quanto_quantization(
+                        self.quantization, load_kwargs,
+                    )
+
+                processor = AutoProcessor.from_pretrained(self.model_dir)
+                model = AutoModelForCausalLM.from_pretrained(
+                    self.model_dir, **load_kwargs,
+                )
+
+                if quanto_dtype is not None:
+                    self._apply_quanto(model, quanto_dtype)
+
+                model.eval()
+
+                self.processor = processor
+                self.model = model
+                self.ready = True
+                LOGGER.info("Gemma runtime is ready")
+            except Exception as exc:
+                LOGGER.exception("Failed to load Gemma runtime")
+                self.error = str(exc)
+
+    def health_payload(self) -> tuple[int, dict[str, Any]]:
+        if self.ready:
+            return 200, {"status": "ok", "model": MODEL_NAME}
+        if self.error:
+            return 500, {"status": "error", "model": MODEL_NAME, "error": self.error}
+        return 503, {"status": "loading", "model": MODEL_NAME}
+
+    def ensure_ready(self) -> None:
+        if self.error:
+            raise HTTPException(status_code=500, detail=self.error)
+        if not self.ready or self.model is None or self.processor is None:
+            raise HTTPException(status_code=503, detail="model is still loading")
+
+    def transcribe_audio(
+        self,
+        wav_bytes: bytes,
+        language: str | None,
+        prompt: str | None,
+    ) -> dict[str, Any]:
+        self.ensure_ready()
+
+        samples, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
+        if len(samples.shape) > 1:
+            samples = samples.mean(axis=1)
+        duration = float(len(samples) / sample_rate) if sample_rate else 0.0
+        if duration > 30.0:
+            raise HTTPException(
+                status_code=400, detail="audio duration exceeds 30 seconds",
+            )
+
+        instruction = self._build_transcription_prompt(language, prompt)
+
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                sf.write(tmp.name, samples, sample_rate)
+                tmp_path = tmp.name
+            text = self._generate_from_audio(instruction, tmp_path)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+        return {
+            "text": text.strip(),
+            "language": language or "auto",
+            "duration": round(duration, 3),
+        }
+
+    def chat_complete(self, request: ChatCompletionRequest) -> dict[str, Any]:
+        self.ensure_ready()
+
+        if request.stream:
+            raise HTTPException(
+                status_code=400, detail="stream=true is not supported",
+            )
+
+        prompt_text = self._render_chat_prompt(request.messages)
+        content = self._generate_from_text(
+            prompt_text,
+            temperature=request.temperature or 0.0,
+            max_new_tokens=request.max_tokens or DEFAULT_MAX_NEW_TOKENS,
+        ).strip()
+        created = int(time.time())
+
+        return {
+            "id": f"chatcmpl-local-{created}",
+            "object": "chat.completion",
+            "created": created,
+            "model": MODEL_NAME,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                },
+            ],
+            "usage": {
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "total_tokens": None,
+            },
+        }
+
+    @staticmethod
+    def _try_quanto_quantization(
+        mode: str, load_kwargs: dict[str, Any],
+    ) -> Any | None:
+        """Try to set up optimum-quanto quantization; fall back to bitsandbytes on CUDA."""
+        try:
+            from optimum.quanto import qint4, qint8  # noqa: F811
+
+            LOGGER.info("Using optimum-quanto for %s quantization", mode)
+            return qint8 if mode == "int8" else qint4
+        except ImportError:
+            LOGGER.info(
+                "optimum-quanto not available, falling back to bitsandbytes (%s)",
+                mode,
+            )
+
+        try:
+            import bitsandbytes as _bnb  # noqa: F401
+
+            if mode == "int8":
+                load_kwargs["load_in_8bit"] = True
+            else:
+                load_kwargs["load_in_4bit"] = True
+            LOGGER.info("Using bitsandbytes for %s quantization (CUDA only)", mode)
+        except ImportError:
+            LOGGER.warning(
+                "Neither optimum-quanto nor bitsandbytes available; "
+                "loading model without quantization",
+            )
+        return None
+
+    @staticmethod
+    def _apply_quanto(model: Any, quanto_dtype: Any) -> None:
+        from optimum.quanto import freeze, quantize
+
+        quantize(model, weights=quanto_dtype)
+        freeze(model)
+
+    def _build_transcription_prompt(
+        self, language: str | None, prompt: str | None,
+    ) -> str:
+        parts = [
+            "Transcribe the provided audio accurately.",
+            "Return only the transcription text.",
+        ]
+        if language:
+            parts.append(f"Expected language: {language}.")
+        if prompt:
+            parts.append(f"Additional context: {prompt}")
+        return " ".join(parts)
+
+    def _render_chat_prompt(self, messages: list[ChatMessage]) -> str:
+        assert self.processor is not None
+        normalized = [
+            {
+                "role": msg.role,
+                "content": [
+                    {"type": "text", "text": self._flatten_content(msg.content)},
+                ],
+            }
+            for msg in messages
+        ]
+        return self.processor.apply_chat_template(
+            normalized,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+
+    def _flatten_content(self, content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict) and item.get("type") == "text":
+                    parts.append(str(item.get("text", "")))
+            return "".join(parts)
+        if content is None:
+            return ""
+        return str(content)
+
+    def _generate_from_text(
+        self,
+        prompt_text: str,
+        *,
+        temperature: float,
+        max_new_tokens: int,
+    ) -> str:
+        assert self.processor is not None
+        assert self.model is not None
+
+        inputs = self.processor(text=prompt_text, return_tensors="pt").to(
+            self.model.device,
+        )
+        input_len = inputs["input_ids"].shape[-1]
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            do_sample=temperature > 0,
+            temperature=max(temperature, 1e-5),
+        )
+        response = self.processor.decode(
+            outputs[0][input_len:], skip_special_tokens=False,
+        )
+        return self.processor.parse_response(response)
+
+    def _generate_from_audio(self, prompt_text: str, audio_path: str) -> str:
+        assert self.processor is not None
+        assert self.model is not None
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio", "audio": audio_path},
+                    {"type": "text", "text": prompt_text},
+                ],
+            },
+        ]
+        inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+            add_generation_prompt=True,
+        ).to(self.model.device)
+        input_len = inputs["input_ids"].shape[-1]
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=DEFAULT_MAX_NEW_TOKENS,
+            do_sample=False,
+        )
+        response = self.processor.decode(
+            outputs[0][input_len:], skip_special_tokens=False,
+        )
+        return self.processor.parse_response(response)
+
+
+def create_app(runtime: LocalModelRuntime) -> FastAPI:
+    app = FastAPI(title="ViberWhisper Local Gemma Service")
+
+    @app.on_event("startup")
+    def _startup() -> None:
+        thread = threading.Thread(target=runtime.load, daemon=True)
+        thread.start()
+
+    @app.get("/health")
+    def health() -> JSONResponse:
+        status_code, payload = runtime.health_payload()
+        return JSONResponse(status_code=status_code, content=payload)
+
+    @app.post("/v1/audio/transcriptions")
+    async def audio_transcriptions(
+        file: Annotated[UploadFile, File()],
+        language: Annotated[str | None, Form()] = None,
+        prompt: Annotated[str | None, Form()] = None,
+        model: Annotated[str | None, Form()] = None,
+        temperature: Annotated[str | None, Form()] = None,
+        response_format: Annotated[str | None, Form()] = None,
+    ) -> dict[str, Any]:
+        del model, temperature, response_format
+        wav_bytes = await file.read()
+        return await asyncio.to_thread(
+            runtime.transcribe_audio, wav_bytes, language, prompt,
+        )
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: ChatCompletionRequest) -> dict[str, Any]:
+        return await asyncio.to_thread(runtime.chat_complete, request)
+
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-dir", required=True)
+    parser.add_argument("--port", type=int, default=17265)
+    parser.add_argument(
+        "--quantization", choices=["int4", "int8", "bf16"], default="bf16",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    args = parse_args()
+    runtime = LocalModelRuntime(args.model_dir, args.quantization)
+    app = create_app(runtime)
+    uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/tests/test_server.py
+++ b/server/tests/test_server.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from server.server import ChatCompletionRequest, LocalModelRuntime, create_app
+
+
+class StubRuntime:
+    def __init__(self) -> None:
+        self.loaded = False
+        self.last_audio_args: tuple[bytes, str | None, str | None] | None = None
+        self.last_chat_request: ChatCompletionRequest | None = None
+
+    def load(self) -> None:
+        self.loaded = True
+
+    def health_payload(self) -> tuple[int, dict[str, str]]:
+        return 200, {"status": "ok", "model": "stub"}
+
+    def transcribe_audio(
+        self,
+        wav_bytes: bytes,
+        language: str | None,
+        prompt: str | None,
+    ) -> dict[str, object]:
+        self.last_audio_args = (wav_bytes, language, prompt)
+        return {"text": "stub transcript", "language": language or "auto", "duration": 1.25}
+
+    def chat_complete(self, request: ChatCompletionRequest) -> dict[str, object]:
+        self.last_chat_request = request
+        return {
+            "id": "chatcmpl-local-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "stub",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "stub response"},
+                    "finish_reason": "stop",
+                },
+            ],
+            "usage": {
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "total_tokens": None,
+            },
+        }
+
+
+def test_health_payload_states() -> None:
+    runtime = LocalModelRuntime("/tmp/model", "int8")
+    assert runtime.health_payload() == (503, {"status": "loading", "model": "gemma-4-E4B-it"})
+
+    runtime.ready = True
+    assert runtime.health_payload() == (200, {"status": "ok", "model": "gemma-4-E4B-it"})
+
+    runtime.ready = False
+    runtime.error = "boom"
+    assert runtime.health_payload() == (
+        500,
+        {"status": "error", "model": "gemma-4-E4B-it", "error": "boom"},
+    )
+
+
+def test_flatten_content_handles_supported_shapes() -> None:
+    runtime = LocalModelRuntime("/tmp/model", "int8")
+
+    assert runtime._flatten_content("hello") == "hello"
+    assert runtime._flatten_content(
+        ["a", {"type": "text", "text": "b"}, {"type": "image", "url": "ignored"}],
+    ) == "ab"
+    assert runtime._flatten_content(None) == ""
+
+
+def test_create_app_health_endpoint() -> None:
+    runtime = StubRuntime()
+    with TestClient(create_app(runtime)) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "model": "stub"}
+    assert runtime.loaded is True
+
+
+def test_create_app_audio_transcriptions_endpoint() -> None:
+    runtime = StubRuntime()
+    with TestClient(create_app(runtime)) as client:
+        response = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("sample.wav", b"wav-bytes", "audio/wav")},
+            data={"language": "zh", "prompt": "keep punctuation", "model": "ignored"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["text"] == "stub transcript"
+    assert runtime.last_audio_args == (b"wav-bytes", "zh", "keep punctuation")
+
+
+def test_create_app_chat_completions_endpoint() -> None:
+    runtime = StubRuntime()
+    with TestClient(create_app(runtime)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {"role": "system", "content": "clean up text"},
+                    {"role": "user", "content": "你好"},
+                ],
+                "stream": False,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "stub response"
+    assert runtime.last_chat_request is not None
+    assert [message.role for message in runtime.last_chat_request.messages] == [
+        "system",
+        "user",
+    ]

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -19,6 +19,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// 本地 Gemma 推理服务管理
+    Local {
+        #[command(subcommand)]
+        action: LocalCommand,
+    },
     /// 转换音频文件为文字
     Convert {
         /// 输入的 WAV 文件路径
@@ -45,6 +50,18 @@ pub enum ConfigAction {
         /// 新值
         value: String,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LocalCommand {
+    /// 安装本地推理服务依赖与模型
+    Install,
+    /// 启动本地推理服务并运行主监听循环
+    Start,
+    /// 停止本地推理服务
+    Stop,
+    /// 查看本地推理服务状态
+    Status,
 }
 
 #[cfg(test)]
@@ -123,5 +140,27 @@ mod tests {
         } else {
             panic!("Expected convert command");
         }
+    }
+
+    #[test]
+    fn test_cli_local_start() {
+        let cli = Cli::try_parse_from(["viberwhisper", "local", "start"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Local {
+                action: LocalCommand::Start
+            })
+        ));
+    }
+
+    #[test]
+    fn test_cli_local_status() {
+        let cli = Cli::try_parse_from(["viberwhisper", "local", "status"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Local {
+                action: LocalCommand::Status
+            })
+        ));
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -32,6 +32,14 @@ fn default_post_process_api_format() -> String {
     "openai".to_string()
 }
 
+fn default_local_server_port() -> u16 {
+    17265
+}
+
+fn default_local_quantization() -> String {
+    "int8".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     /// API key for the transcription service.
@@ -98,6 +106,18 @@ pub struct AppConfig {
     /// Temperature for the post-processing LLM. Default: 0.0.
     #[serde(default)]
     pub post_process_temperature: f32,
+    /// If true, use the local Gemma service instead of cloud APIs.
+    #[serde(default)]
+    pub local_mode: bool,
+    /// Directory for the local model weights and Python virtualenv.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_data_dir: Option<String>,
+    /// Port for the local inference server. Default: 17265.
+    #[serde(default = "default_local_server_port")]
+    pub local_server_port: u16,
+    /// Quantization mode for the local service. Default: "int8".
+    #[serde(default = "default_local_quantization")]
+    pub local_quantization: String,
 }
 
 impl Default for AppConfig {
@@ -125,6 +145,10 @@ impl Default for AppConfig {
             post_process_model: None,
             post_process_prompt: None,
             post_process_temperature: 0.0,
+            local_mode: false,
+            local_data_dir: None,
+            local_server_port: default_local_server_port(),
+            local_quantization: default_local_quantization(),
         }
     }
 }
@@ -201,6 +225,10 @@ impl AppConfig {
             "post_process_model" => self.post_process_model.clone(),
             "post_process_prompt" => self.post_process_prompt.clone(),
             "post_process_temperature" => Some(self.post_process_temperature.to_string()),
+            "local_mode" => Some(self.local_mode.to_string()),
+            "local_data_dir" => self.local_data_dir.clone(),
+            "local_server_port" => Some(self.local_server_port.to_string()),
+            "local_quantization" => Some(self.local_quantization.clone()),
             _ => None,
         }
     }
@@ -317,13 +345,34 @@ impl AppConfig {
                 })?;
                 Ok(())
             }
+            "local_mode" => {
+                self.local_mode = value
+                    .parse::<bool>()
+                    .map_err(|_| format!("local_mode must be true/false, got: {}", value))?;
+                Ok(())
+            }
+            "local_data_dir" => {
+                self.local_data_dir = Some(value.to_string());
+                Ok(())
+            }
+            "local_server_port" => {
+                self.local_server_port = value
+                    .parse::<u16>()
+                    .map_err(|_| format!("local_server_port must be a u16, got: {}", value))?;
+                Ok(())
+            }
+            "local_quantization" => {
+                self.local_quantization = value.to_string();
+                Ok(())
+            }
             _ => Err(format!(
                 "Unknown config key: {}. Available: api_key, transcription_api_url, model, \
                  hold_hotkey, toggle_hotkey, language, prompt, temperature, mic_gain, \
                  max_chunk_duration_secs, max_chunk_size_bytes, max_retries, \
                  convergence_timeout_secs, post_process_enabled, post_process_streaming_enabled, \
                  post_process_api_url, post_process_api_key, post_process_api_format, \
-                 post_process_model, post_process_prompt, post_process_temperature",
+                 post_process_model, post_process_prompt, post_process_temperature, \
+                 local_mode, local_data_dir, local_server_port, local_quantization",
                 key
             )),
         }
@@ -406,6 +455,18 @@ impl AppConfig {
         if let Some(v) = json["post_process_temperature"].as_f64() {
             self.post_process_temperature = v as f32;
         }
+        if let Some(v) = json["local_mode"].as_bool() {
+            self.local_mode = v;
+        }
+        if let Some(v) = json["local_data_dir"].as_str() {
+            self.local_data_dir = Some(v.to_string());
+        }
+        if let Some(v) = json["local_server_port"].as_u64() {
+            self.local_server_port = v as u16;
+        }
+        if let Some(v) = json["local_quantization"].as_str() {
+            self.local_quantization = v.to_string();
+        }
     }
 }
 
@@ -426,6 +487,10 @@ mod tests {
             config.transcription_api_url,
             "https://api.groq.com/openai/v1/audio/transcriptions"
         );
+        assert!(!config.local_mode);
+        assert!(config.local_data_dir.is_none());
+        assert_eq!(config.local_server_port, 17265);
+        assert_eq!(config.local_quantization, "int8");
     }
 
     #[test]
@@ -782,5 +847,45 @@ mod tests {
         assert_eq!(config.post_process_api_format, "openai");
         assert!(config.post_process_api_key.is_none());
         assert!(config.post_process_model.is_none());
+    }
+
+    #[test]
+    fn test_local_config_get_set() {
+        let mut config = AppConfig::default();
+        config.set_field("local_mode", "true").unwrap();
+        config
+            .set_field("local_data_dir", "/tmp/viberwhisper")
+            .unwrap();
+        config.set_field("local_server_port", "9000").unwrap();
+        config.set_field("local_quantization", "bf16").unwrap();
+
+        assert_eq!(config.get_field("local_mode").as_deref(), Some("true"));
+        assert_eq!(
+            config.get_field("local_data_dir").as_deref(),
+            Some("/tmp/viberwhisper")
+        );
+        assert_eq!(config.get_field("local_server_port").as_deref(), Some("9000"));
+        assert_eq!(
+            config.get_field("local_quantization").as_deref(),
+            Some("bf16")
+        );
+    }
+
+    #[test]
+    fn test_apply_json_local_fields() {
+        let mut config = AppConfig::default();
+        let json = serde_json::json!({
+            "local_mode": true,
+            "local_data_dir": "/tmp/local-data",
+            "local_server_port": 9001,
+            "local_quantization": "bf16"
+        });
+
+        config.apply_json(&json);
+
+        assert!(config.local_mode);
+        assert_eq!(config.local_data_dir.as_deref(), Some("/tmp/local-data"));
+        assert_eq!(config.local_server_port, 9001);
+        assert_eq!(config.local_quantization, "bf16");
     }
 }

--- a/src/local/installer.rs
+++ b/src/local/installer.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+const DEPENDENCY_CHECK_SCRIPT: &str =
+    "import accelerate, fastapi, huggingface_hub, soundfile, torch, transformers, uvicorn";
+
 /// Creates a Python virtual environment for the local service.
 pub fn setup_venv(venv_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let python = venv_python_path(venv_dir);
@@ -35,13 +38,7 @@ pub fn install_requirements(
 
     run_command(
         python,
-        [
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            &reqs.to_string_lossy(),
-        ],
+        ["-m", "pip", "install", "-r", &reqs.to_string_lossy()],
         None,
     )
 }
@@ -85,10 +82,7 @@ pub fn download_model(
 }
 
 /// Verifies the presence of the virtual environment and model files.
-pub fn verify_install(
-    venv_dir: &Path,
-    model_dir: &Path,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn verify_install(venv_dir: &Path, model_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let python = venv_python_path(venv_dir);
     if !python.exists() {
         return Err(format!("virtualenv python not found: {}", python.display()).into());
@@ -121,7 +115,7 @@ pub fn dependencies_installed(venv_dir: &Path) -> bool {
         return false;
     }
     Command::new(python)
-        .args(["-c", "import fastapi, transformers, uvicorn"])
+        .args(["-c", DEPENDENCY_CHECK_SCRIPT])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
@@ -230,6 +224,24 @@ mod tests {
             venv_python_path(Path::new("venv")),
             PathBuf::from("venv/bin/python")
         );
+    }
+
+    #[test]
+    fn test_dependency_check_script_covers_required_runtime_packages() {
+        for package in [
+            "accelerate",
+            "fastapi",
+            "huggingface_hub",
+            "soundfile",
+            "torch",
+            "transformers",
+            "uvicorn",
+        ] {
+            assert!(
+                DEPENDENCY_CHECK_SCRIPT.contains(package),
+                "missing package in dependency check: {package}"
+            );
+        }
     }
 
     #[cfg(feature = "integration")]

--- a/src/local/installer.rs
+++ b/src/local/installer.rs
@@ -1,0 +1,252 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Creates a Python virtual environment for the local service.
+pub fn setup_venv(venv_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let python = venv_python_path(venv_dir);
+    if python.exists() {
+        return Ok(());
+    }
+
+    if let Some(parent) = venv_dir.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    run_command(
+        find_python()?,
+        ["-m", "venv", &venv_dir.to_string_lossy()],
+        None,
+    )
+}
+
+/// Installs Python requirements into the virtual environment.
+pub fn install_requirements(
+    venv_dir: &Path,
+    reqs: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !reqs.exists() {
+        return Err(format!("requirements file not found: {}", reqs.display()).into());
+    }
+
+    let python = venv_python_path(venv_dir);
+    if !python.exists() {
+        return Err(format!("virtualenv python not found: {}", python.display()).into());
+    }
+
+    run_command(
+        python,
+        [
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            &reqs.to_string_lossy(),
+        ],
+        None,
+    )
+}
+
+/// Downloads the local Gemma model into the model directory.
+pub fn download_model(
+    model_dir: &Path,
+    hf_endpoint: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if model_weights_present(model_dir) {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(model_dir)?;
+
+    let venv_dir = model_dir
+        .parent()
+        .ok_or("model directory must have a parent directory for sibling venv lookup")?
+        .join("venv");
+    let python = venv_python_path(&venv_dir);
+    if !python.exists() {
+        return Err(format!(
+            "virtualenv python not found for model download: {}",
+            python.display()
+        )
+        .into());
+    }
+
+    run_command(
+        python,
+        [
+            "-m",
+            "huggingface_hub.commands.huggingface_cli",
+            "download",
+            "google/gemma-4-E4B-it",
+            "--local-dir",
+            &model_dir.to_string_lossy(),
+        ],
+        Some(("HF_ENDPOINT", hf_endpoint)),
+    )
+}
+
+/// Verifies the presence of the virtual environment and model files.
+pub fn verify_install(
+    venv_dir: &Path,
+    model_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let python = venv_python_path(venv_dir);
+    if !python.exists() {
+        return Err(format!("virtualenv python not found: {}", python.display()).into());
+    }
+
+    if !model_dir.is_dir() {
+        return Err(format!("model directory not found: {}", model_dir.display()).into());
+    }
+
+    let has_model_files = std::fs::read_dir(model_dir)?
+        .filter_map(Result::ok)
+        .any(|entry| {
+            entry
+                .file_type()
+                .map(|file_type| file_type.is_file())
+                .unwrap_or(false)
+        });
+
+    if !has_model_files {
+        return Err(format!("model directory is empty: {}", model_dir.display()).into());
+    }
+
+    Ok(())
+}
+
+/// Returns true when the key Python packages required by the server are importable.
+pub fn dependencies_installed(venv_dir: &Path) -> bool {
+    let python = venv_python_path(venv_dir);
+    if !python.exists() {
+        return false;
+    }
+    Command::new(python)
+        .args(["-c", "import fastapi, transformers, uvicorn"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Returns true when model config and at least one weight shard are present.
+pub fn model_weights_present(model_dir: &Path) -> bool {
+    if !model_dir.join("config.json").exists() {
+        return false;
+    }
+    std::fs::read_dir(model_dir)
+        .ok()
+        .map(|entries| {
+            entries.filter_map(Result::ok).any(|e| {
+                let name = e.file_name();
+                let name = name.to_string_lossy();
+                name.ends_with(".safetensors") || name.ends_with(".bin")
+            })
+        })
+        .unwrap_or(false)
+}
+
+pub(crate) fn venv_python_path(venv_dir: &Path) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        venv_dir.join("Scripts").join("python.exe")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        venv_dir.join("bin").join("python")
+    }
+}
+
+fn find_python() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Ok(path) = std::env::var("PYTHON")
+        && !path.is_empty()
+    {
+        return Ok(PathBuf::from(path));
+    }
+
+    #[cfg(target_os = "windows")]
+    let candidates = ["python", "py"];
+    #[cfg(not(target_os = "windows"))]
+    let candidates = ["python3", "python"];
+
+    for candidate in candidates {
+        let status = Command::new(candidate)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        if status.is_ok_and(|status| status.success()) {
+            return Ok(PathBuf::from(candidate));
+        }
+    }
+
+    Err("python executable not found".into())
+}
+
+fn run_command<I, S>(
+    program: PathBuf,
+    args: I,
+    env: Option<(&str, &str)>,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let mut command = Command::new(program);
+    command.args(args);
+    if let Some((key, value)) = env {
+        command.env(key, value);
+    }
+    let status = command.status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("command failed with status {status}").into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_verify_install_requires_existing_paths() {
+        let result = verify_install(
+            Path::new("/definitely/missing/venv"),
+            Path::new("/definitely/missing/model"),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_venv_python_path_uses_platform_layout() {
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            venv_python_path(Path::new("venv")),
+            PathBuf::from("venv/Scripts/python.exe")
+        );
+
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(
+            venv_python_path(Path::new("venv")),
+            PathBuf::from("venv/bin/python")
+        );
+    }
+
+    #[cfg(feature = "integration")]
+    #[test]
+    fn test_setup_venv_and_verify_install_integration() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "viberwhisper-local-installer-{}",
+            std::process::id()
+        ));
+        let venv_dir = temp_dir.join("venv");
+        let model_dir = temp_dir.join("model");
+        std::fs::create_dir_all(&model_dir).unwrap();
+        std::fs::write(model_dir.join("config.json"), "{}").unwrap();
+
+        setup_venv(&venv_dir).unwrap();
+        verify_install(&venv_dir, &model_dir).unwrap();
+
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+}

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -1,0 +1,8 @@
+pub mod installer;
+pub mod service;
+
+pub use installer::{
+    dependencies_installed, download_model, install_requirements, model_weights_present,
+    setup_venv, verify_install,
+};
+pub use service::LocalServiceManager;

--- a/src/local/service.rs
+++ b/src/local/service.rs
@@ -1,0 +1,424 @@
+use crate::local::installer::venv_python_path;
+use reqwest::StatusCode;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(120);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Runtime status for the local inference service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalServiceStatus {
+    /// True when the service appears to be running.
+    pub running: bool,
+    /// TCP port used by the local service.
+    pub port: u16,
+    /// Last HTTP health-check result.
+    pub health: String,
+    /// Optional persisted process identifier.
+    pub pid: Option<u32>,
+    /// Optional human-readable memory usage.
+    pub memory_usage: Option<String>,
+}
+
+/// Manages the Python-based local Gemma inference service.
+pub struct LocalServiceManager {
+    port: u16,
+    model_dir: PathBuf,
+    venv_dir: PathBuf,
+    quantization: String,
+    process: Option<Child>,
+    log_file: Option<PathBuf>,
+    /// True only when this manager spawned the server process itself.
+    owned: bool,
+}
+
+impl LocalServiceManager {
+    /// Creates a new local service manager using the default `int8` quantization mode.
+    pub fn new(port: u16, model_dir: PathBuf, venv_dir: PathBuf) -> Self {
+        Self::with_quantization(port, model_dir, venv_dir, "int8".to_string())
+    }
+
+    /// Creates a new local service manager with an explicit quantization mode.
+    pub fn with_quantization(
+        port: u16,
+        model_dir: PathBuf,
+        venv_dir: PathBuf,
+        quantization: String,
+    ) -> Self {
+        let log_file = model_dir
+            .parent()
+            .map(|dir| dir.join("server.log"));
+        Self {
+            port,
+            model_dir,
+            venv_dir,
+            quantization,
+            process: None,
+            log_file,
+            owned: false,
+        }
+    }
+
+    /// Spawns the local server process and waits for health.
+    pub fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.is_running()
+            && health_check(&self.base_url(), HEALTH_TIMEOUT, HEALTH_POLL_INTERVAL).is_ok()
+        {
+            return Ok(());
+        }
+
+        fs::create_dir_all(self.state_dir())?;
+
+        let python = venv_python_path(&self.venv_dir);
+        if !python.exists() {
+            return Err(format!("local Python interpreter not found: {}", python.display()).into());
+        }
+        if !self.model_dir.exists() {
+            return Err(format!("local model directory not found: {}", self.model_dir.display()).into());
+        }
+
+        let stderr_stdio = match &self.log_file {
+            Some(path) => Stdio::from(File::create(path)?),
+            None => Stdio::null(),
+        };
+
+        let child = Command::new(python)
+            .arg(self.server_script_path())
+            .arg("--model-dir")
+            .arg(&self.model_dir)
+            .arg("--port")
+            .arg(self.port.to_string())
+            .arg("--quantization")
+            .arg(&self.quantization)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(stderr_stdio)
+            .spawn()?;
+
+        fs::write(self.pid_file_path(), child.id().to_string())?;
+        self.process = Some(child);
+        self.owned = true;
+
+        if let Err(error) = health_check(&self.base_url(), HEALTH_TIMEOUT, HEALTH_POLL_INTERVAL) {
+            let msg = match &self.log_file {
+                Some(path) => format!(
+                    "{error} (see server log for details: {})",
+                    path.display()
+                ),
+                None => error.to_string(),
+            };
+            self.stop();
+            return Err(msg.into());
+        }
+
+        Ok(())
+    }
+
+    /// Stops the managed local server process.
+    pub fn stop(&mut self) {
+        let pid = if let Some(child) = self.process.as_ref() {
+            Some(child.id())
+        } else {
+            self.read_pid()
+        };
+
+        if let Some(pid) = pid {
+            let _ = terminate_pid(pid);
+            wait_for_exit_or_kill(pid);
+        }
+
+        if let Some(child) = self.process.as_mut() {
+            let _ = child.wait();
+        }
+
+        self.process = None;
+        let _ = fs::remove_file(self.pid_file_path());
+    }
+
+    /// Stops the server only if this manager owns (spawned) it.
+    /// Reused background servers started by `viberwhisper local start` are left running.
+    pub fn release(&mut self) {
+        if self.owned {
+            self.stop();
+        }
+    }
+
+    /// Returns true when the managed process is still alive.
+    pub fn is_running(&self) -> bool {
+        if let Some(child) = self.process.as_ref() {
+            return is_pid_running(child.id());
+        }
+
+        self.read_pid().is_some_and(is_pid_running)
+    }
+
+    /// Returns the base HTTP URL for the local service.
+    pub fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Returns the best-effort persisted service status.
+    pub fn status(&self) -> Result<LocalServiceStatus, Box<dyn std::error::Error>> {
+        let pid = self.read_pid().or_else(|| self.process.as_ref().map(Child::id));
+        let running = pid.is_some_and(is_pid_running);
+        let health = match health_once(&self.base_url()) {
+            Ok(StatusCode::OK) => "ok".to_string(),
+            Ok(status) => format!("http {}", status.as_u16()),
+            Err(error) => error.to_string(),
+        };
+        let memory_usage = pid.and_then(read_memory_usage);
+
+        Ok(LocalServiceStatus {
+            running,
+            port: self.port,
+            health,
+            pid,
+            memory_usage,
+        })
+    }
+
+    fn state_dir(&self) -> PathBuf {
+        self.model_dir
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    fn pid_file_path(&self) -> PathBuf {
+        pid_file_path(&self.state_dir())
+    }
+
+    fn server_script_path(&self) -> PathBuf {
+        find_server_file("server.py")
+    }
+
+    fn read_pid(&self) -> Option<u32> {
+        fs::read_to_string(self.pid_file_path())
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok())
+    }
+}
+
+/// Locates a file inside the `server/` directory, trying the packaged location
+/// (next to the executable) first, then falling back to the development source tree.
+fn find_server_file(filename: &str) -> PathBuf {
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(exe_dir) = exe.parent()
+    {
+        let candidate = exe_dir.join("server").join(filename);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    // Fallback: compile-time source tree (works with `cargo run`).
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("server")
+        .join(filename)
+}
+
+fn health_check(
+    base_url: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+    let deadline = Instant::now() + timeout;
+    let url = format!("{base_url}/health");
+    let mut last_error = "health check did not start".to_string();
+
+    while Instant::now() < deadline {
+        match client.get(&url).send() {
+            Ok(resp) if resp.status() == StatusCode::OK => return Ok(()),
+            Ok(resp) => {
+                last_error = format!("service not ready: http {}", resp.status().as_u16());
+            }
+            Err(error) => last_error = error.to_string(),
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+
+    Err(last_error.into())
+}
+
+fn health_once(base_url: &str) -> Result<StatusCode, Box<dyn std::error::Error>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+    Ok(client.get(format!("{base_url}/health")).send()?.status())
+}
+
+/// Waits up to 5 seconds for a process to exit after SIGTERM; sends SIGKILL if it does not.
+fn wait_for_exit_or_kill(pid: u32) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if !is_pid_running(pid) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    // Process did not exit in time; force kill.
+    let _ = force_kill_pid(pid);
+}
+
+fn force_kill_pid(pid: u32) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "windows")]
+    let status = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .status()?;
+
+    #[cfg(not(target_os = "windows"))]
+    let status = Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("failed to force-kill process {pid}").into())
+    }
+}
+
+fn pid_file_path(base_dir: &Path) -> PathBuf {
+    base_dir.join("local_server.pid")
+}
+
+fn is_pid_running(pid: u32) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+            .output()
+            .ok()
+            .map(|output| {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                stdout.contains(&format!(",\"{pid}\""))
+            })
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "pid="])
+            .output()
+            .ok()
+            .map(|output| {
+                output.status.success() && !String::from_utf8_lossy(&output.stdout).trim().is_empty()
+            })
+            .unwrap_or(false)
+    }
+}
+
+fn terminate_pid(pid: u32) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "windows")]
+    let status = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .status()?;
+
+    #[cfg(not(target_os = "windows"))]
+    let status = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("failed to terminate process {pid}").into())
+    }
+}
+
+fn read_memory_usage(pid: u32) -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        let output = Command::new("tasklist")
+            .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+            .output()
+            .ok()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let columns = stdout.trim().trim_matches('"').split("\",\"").collect::<Vec<_>>();
+        columns.get(4).map(|value| value.to_string())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let output = Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "rss="])
+            .output()
+            .ok()?;
+        let rss = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if rss.is_empty() {
+            None
+        } else {
+            Some(format!("{rss} KB"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn spawn_health_stub(port: u16, status_line: &'static str, body: &'static str) {
+        thread::spawn(move || {
+            let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buffer = [0_u8; 1024];
+                let _ = stream.read(&mut buffer);
+                let response = format!(
+                    "{status_line}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+    }
+
+    #[test]
+    fn test_base_url_uses_loopback_port() {
+        let manager =
+            LocalServiceManager::new(17265, PathBuf::from("model"), PathBuf::from("venv"));
+        assert_eq!(manager.base_url(), "http://127.0.0.1:17265");
+    }
+
+    #[test]
+    fn test_health_check_accepts_ok_response() {
+        let port = 18765;
+        spawn_health_stub(port, "HTTP/1.1 200 OK", "{\"status\":\"ok\"}");
+        let result = health_check(
+            &format!("http://127.0.0.1:{port}"),
+            Duration::from_secs(1),
+            Duration::from_millis(25),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_health_check_times_out_on_unhealthy_server() {
+        let port = 18766;
+        spawn_health_stub(port, "HTTP/1.1 503 Service Unavailable", "{\"status\":\"loading\"}");
+        let result = health_check(
+            &format!("http://127.0.0.1:{port}"),
+            Duration::from_millis(150),
+            Duration::from_millis(25),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_pid_file_path_uses_expected_name() {
+        assert_eq!(
+            pid_file_path(Path::new("/tmp/viberwhisper")),
+            PathBuf::from("/tmp/viberwhisper/local_server.pid")
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,22 @@ use tracing_subscriber::EnvFilter;
 
 const LOCAL_MODEL_NAME: &str = "gemma-4-E4B-it";
 
+struct LocalServiceGuard(Option<LocalServiceManager>);
+
+impl LocalServiceGuard {
+    fn new(manager: Option<LocalServiceManager>) -> Self {
+        Self(manager)
+    }
+}
+
+impl Drop for LocalServiceGuard {
+    fn drop(&mut self) {
+        if let Some(manager) = self.0.as_mut() {
+            manager.release();
+        }
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -62,22 +78,16 @@ fn handle_local(action: LocalCommand) -> Result<(), Box<dyn std::error::Error>> 
         }
         LocalCommand::Stop => {
             let paths = local_paths(&config)?;
-            let mut manager = LocalServiceManager::new(
-                config.local_server_port,
-                paths.model_dir,
-                paths.venv_dir,
-            );
+            let mut manager =
+                LocalServiceManager::new(config.local_server_port, paths.model_dir, paths.venv_dir);
             manager.stop();
             println!("Local Gemma service stopped.");
             Ok(())
         }
         LocalCommand::Status => {
             let paths = local_paths(&config)?;
-            let manager = LocalServiceManager::new(
-                config.local_server_port,
-                paths.model_dir,
-                paths.venv_dir,
-            );
+            let manager =
+                LocalServiceManager::new(config.local_server_port, paths.model_dir, paths.venv_dir);
             let status = manager.status()?;
             println!("running: {}", status.running);
             println!("port: {}", status.port);
@@ -209,9 +219,7 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     run_listener_with_config(AppConfig::load())
 }
 
-fn run_listener_with_config(
-    config: AppConfig,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     use audio::{AudioRecorder, StopResult};
     use core::orchestrator::{SessionError, SessionMode, SessionOrchestrator};
     use input::hotkey::{HotkeyEvent, HotkeyManager, HotkeySource};
@@ -227,7 +235,8 @@ fn run_listener_with_config(
     println!("===================================");
     println!();
 
-    let (config, mut local_manager) = prepare_runtime_config(config)?;
+    let (config, local_manager) = prepare_runtime_config(config)?;
+    let _local_manager = LocalServiceGuard::new(local_manager);
     info!(
         hold_hotkey = %config.hold_hotkey,
         toggle_hotkey = %config.toggle_hotkey,
@@ -336,9 +345,10 @@ fn run_listener_with_config(
                     "Partial transcription failure; typing available text"
                 );
                 if !partial_text.is_empty()
-                    && let Err(e) = typer.type_text(&partial_text) {
-                        error!(error = %e, "Failed to type partial text");
-                    }
+                    && let Err(e) = typer.type_text(&partial_text)
+                {
+                    error!(error = %e, "Failed to type partial text");
+                }
             }
             Err(SessionError::ConvergenceTimeout {
                 pending_count,
@@ -349,15 +359,16 @@ fn run_listener_with_config(
                     "Convergence timeout; typing available partial text"
                 );
                 if !partial_text.is_empty()
-                    && let Err(e) = typer.type_text(&partial_text) {
-                        error!(error = %e, "Failed to type partial text");
-                    }
+                    && let Err(e) = typer.type_text(&partial_text)
+                {
+                    error!(error = %e, "Failed to type partial text");
+                }
             }
         }
     };
 
     let mut counter = 0;
-    let result = loop {
+    loop {
         if let Some(event) = hotkey_manager.check_event() {
             match event {
                 HotkeyEvent::Pressed(HotkeySource::Hold) => {
@@ -484,13 +495,7 @@ fn run_listener_with_config(
 
         overlay.update();
         std::thread::sleep(std::time::Duration::from_millis(10));
-    };
-
-    if let Some(manager) = local_manager.as_mut() {
-        manager.release();
     }
-
-    result
 }
 
 fn handle_config(action: ConfigAction) {
@@ -567,13 +572,14 @@ fn handle_convert(input: &str, output: Option<&str>) {
     println!("Transcribing: {}", input);
 
     let config = AppConfig::load();
-    let (config, _local_manager) = match prepare_runtime_config(config) {
+    let (config, local_manager) = match prepare_runtime_config(config) {
         Ok(result) => result,
         Err(e) => {
             eprintln!("Failed to prepare runtime: {}", e);
             std::process::exit(1);
         }
     };
+    let _local_manager = LocalServiceGuard::new(local_manager);
     let transcriber: Box<dyn Transcriber> = create_transcriber(&config);
     let post_processor = create_post_processor(&config);
 
@@ -611,19 +617,20 @@ fn handle_convert(input: &str, output: Option<&str>) {
 fn apply_local_endpoint_overrides(config: &AppConfig, base_url: &str) -> AppConfig {
     let mut local = config.clone();
     local.api_key = Some("local".to_string());
-    local.post_process_api_key = Some("local".to_string());
     local.transcription_api_url = format!("{base_url}/v1/audio/transcriptions");
-    local.post_process_api_url = Some(format!("{base_url}/v1/chat/completions"));
-    local.post_process_enabled = true;
-    local.post_process_model = Some(LOCAL_MODEL_NAME.to_string());
+    if local.post_process_enabled {
+        local.post_process_api_key = Some("local".to_string());
+        local.post_process_api_url = Some(format!("{base_url}/v1/chat/completions"));
+        local.post_process_model = Some(LOCAL_MODEL_NAME.to_string());
+    }
     local
 }
 
 #[cfg(test)]
 mod integration_tests {
     use super::*;
-    use audio::AudioRecorder;
     use crate::core::config::AppConfig;
+    use audio::AudioRecorder;
     use transcriber::{MockTranscriber, Transcriber};
 
     #[test]
@@ -674,9 +681,11 @@ mod integration_tests {
     }
 
     #[test]
-    fn test_apply_local_endpoint_overrides_endpoints() {
+    fn test_apply_local_endpoint_overrides_enabled_post_process() {
         let mut config = AppConfig::default();
         config.local_server_port = 17265;
+        config.post_process_enabled = true;
+        config.post_process_model = Some("gpt-4o-mini".to_string());
 
         let local = apply_local_endpoint_overrides(&config, "http://127.0.0.1:17265");
 
@@ -692,5 +701,25 @@ mod integration_tests {
         assert_eq!(local.post_process_model.as_deref(), Some("gemma-4-E4B-it"));
         assert_eq!(local.api_key.as_deref(), Some("local"));
         assert_eq!(local.post_process_api_key.as_deref(), Some("local"));
+    }
+
+    #[test]
+    fn test_apply_local_endpoint_overrides_keeps_post_process_disabled() {
+        let mut config = AppConfig::default();
+        config.local_server_port = 17265;
+        config.post_process_enabled = false;
+        config.post_process_model = Some("gpt-4o-mini".to_string());
+
+        let local = apply_local_endpoint_overrides(&config, "http://127.0.0.1:17265");
+
+        assert_eq!(
+            local.transcription_api_url,
+            "http://127.0.0.1:17265/v1/audio/transcriptions"
+        );
+        assert!(!local.post_process_enabled);
+        assert_eq!(local.post_process_model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(local.post_process_api_url, None);
+        assert_eq!(local.post_process_api_key, None);
+        assert_eq!(local.api_key.as_deref(), Some("local"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,23 @@
 mod audio;
 mod core;
 mod input;
+mod local;
 mod platform;
 mod postprocess;
 mod transcriber;
 
 use clap::Parser;
-use core::cli::{Cli, Commands, ConfigAction};
+use core::cli::{Cli, Commands, ConfigAction, LocalCommand};
+use core::config::AppConfig;
+use local::{
+    LocalServiceManager, dependencies_installed, download_model, install_requirements,
+    model_weights_present, setup_venv, verify_install,
+};
+use std::path::PathBuf;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
+
+const LOCAL_MODEL_NAME: &str = "gemma-4-E4B-it";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
@@ -28,6 +37,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(Commands::Config { action }) => {
             handle_config(action);
         }
+        Some(Commands::Local { action }) => {
+            handle_local(action)?;
+        }
         Some(Commands::Convert { input, output }) => {
             handle_convert(&input, output.as_deref());
         }
@@ -36,9 +48,171 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn handle_local(action: LocalCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = AppConfig::load();
+    match action {
+        LocalCommand::Install => {
+            ensure_local_install(&config, true)?;
+            println!("Local Gemma runtime is installed.");
+            Ok(())
+        }
+        LocalCommand::Start => {
+            config.local_mode = true;
+            run_listener_with_config(config)
+        }
+        LocalCommand::Stop => {
+            let paths = local_paths(&config)?;
+            let mut manager = LocalServiceManager::new(
+                config.local_server_port,
+                paths.model_dir,
+                paths.venv_dir,
+            );
+            manager.stop();
+            println!("Local Gemma service stopped.");
+            Ok(())
+        }
+        LocalCommand::Status => {
+            let paths = local_paths(&config)?;
+            let manager = LocalServiceManager::new(
+                config.local_server_port,
+                paths.model_dir,
+                paths.venv_dir,
+            );
+            let status = manager.status()?;
+            println!("running: {}", status.running);
+            println!("port: {}", status.port);
+            println!(
+                "pid: {}",
+                status
+                    .pid
+                    .map(|pid| pid.to_string())
+                    .unwrap_or_else(|| "n/a".to_string())
+            );
+            println!(
+                "memory: {}",
+                status
+                    .memory_usage
+                    .unwrap_or_else(|| "unavailable".to_string())
+            );
+            println!("health: {}", status.health);
+            Ok(())
+        }
+    }
+}
+
+struct LocalPaths {
+    venv_dir: PathBuf,
+    model_dir: PathBuf,
+}
+
+fn prepare_runtime_config(
+    mut config: AppConfig,
+) -> Result<(AppConfig, Option<LocalServiceManager>), Box<dyn std::error::Error>> {
+    if !config.local_mode {
+        return Ok((config, None));
+    }
+
+    let paths = ensure_local_install(&config, false)?;
+    let mut manager = LocalServiceManager::with_quantization(
+        config.local_server_port,
+        paths.model_dir,
+        paths.venv_dir,
+        config.local_quantization.clone(),
+    );
+    manager.start()?;
+    config = apply_local_endpoint_overrides(&config, &manager.base_url());
+
+    Ok((config, Some(manager)))
+}
+
+fn ensure_local_install(
+    config: &AppConfig,
+    install_deps: bool,
+) -> Result<LocalPaths, Box<dyn std::error::Error>> {
+    let paths = local_paths(config)?;
+    let hf_endpoint =
+        std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string());
+
+    println!("[local] step 1/4 – python venv");
+    setup_venv(&paths.venv_dir)?;
+
+    if install_deps {
+        let requirements = local_requirements_path();
+        println!("[local] step 2/4 – python dependencies");
+        install_requirements(&paths.venv_dir, &requirements)?;
+    } else if !dependencies_installed(&paths.venv_dir) {
+        return Err(
+            "Python dependencies are not installed. Run `viberwhisper local install` first.".into(),
+        );
+    } else {
+        println!("[local] step 2/4 – python dependencies (skipped)");
+    }
+
+    if !model_weights_present(&paths.model_dir) {
+        println!("[local] step 3/4 – downloading google/gemma-4-E4B-it");
+        println!("[local]   set HF_ENDPOINT env var to use a mirror");
+    } else {
+        println!("[local] step 3/4 – model already present, skipping download");
+    }
+    download_model(&paths.model_dir, &hf_endpoint)?;
+
+    println!("[local] step 4/4 – verify");
+    verify_install(&paths.venv_dir, &paths.model_dir)?;
+
+    Ok(paths)
+}
+
+fn local_paths(config: &AppConfig) -> Result<LocalPaths, Box<dyn std::error::Error>> {
+    let data_dir = match &config.local_data_dir {
+        Some(path) if path.starts_with("~/") => {
+            let home = dirs::home_dir().ok_or("could not determine home directory")?;
+            home.join(&path[2..])
+        }
+        Some(path) => PathBuf::from(path),
+        None => default_local_data_dir()?,
+    };
+
+    Ok(LocalPaths {
+        venv_dir: data_dir.join("venv"),
+        model_dir: data_dir.join("model"),
+    })
+}
+
+fn default_local_data_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let home_dir = dirs::home_dir().ok_or("could not determine home directory")?;
+    Ok(home_dir.join(".viberwhisper"))
+}
+
+fn local_requirements_path() -> PathBuf {
+    find_server_file("requirements.txt")
+}
+
+/// Locates a file inside the `server/` directory, trying the packaged location
+/// (next to the executable) first, then falling back to the development source tree.
+fn find_server_file(filename: &str) -> PathBuf {
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(exe_dir) = exe.parent()
+    {
+        let candidate = exe_dir.join("server").join(filename);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    // Fallback: compile-time source tree (works with `cargo run`).
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("server")
+        .join(filename)
+}
+
 fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
+    run_listener_with_config(AppConfig::load())
+}
+
+fn run_listener_with_config(
+    config: AppConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
     use audio::{AudioRecorder, StopResult};
-    use core::config::AppConfig;
     use core::orchestrator::{SessionError, SessionMode, SessionOrchestrator};
     use input::hotkey::{HotkeyEvent, HotkeyManager, HotkeySource};
     use input::overlay::OverlayManager;
@@ -53,7 +227,7 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     println!("===================================");
     println!();
 
-    let config = AppConfig::load();
+    let (config, mut local_manager) = prepare_runtime_config(config)?;
     info!(
         hold_hotkey = %config.hold_hotkey,
         toggle_hotkey = %config.toggle_hotkey,
@@ -183,7 +357,7 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut counter = 0;
-    loop {
+    let result = loop {
         if let Some(event) = hotkey_manager.check_event() {
             match event {
                 HotkeyEvent::Pressed(HotkeySource::Hold) => {
@@ -310,11 +484,17 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
 
         overlay.update();
         std::thread::sleep(std::time::Duration::from_millis(10));
+    };
+
+    if let Some(manager) = local_manager.as_mut() {
+        manager.release();
     }
+
+    result
 }
 
 fn handle_config(action: ConfigAction) {
-    use core::config::AppConfig;
+    use crate::core::config::AppConfig;
 
     let mut config = AppConfig::load();
 
@@ -344,6 +524,10 @@ fn handle_config(action: ConfigAction) {
                 "post_process_model",
                 "post_process_prompt",
                 "post_process_temperature",
+                "local_mode",
+                "local_data_dir",
+                "local_server_port",
+                "local_quantization",
             ] {
                 let value = config
                     .get_field(key)
@@ -377,13 +561,19 @@ fn handle_config(action: ConfigAction) {
 }
 
 fn handle_convert(input: &str, output: Option<&str>) {
-    use core::config::AppConfig;
     use postprocess::create_post_processor;
     use transcriber::{Transcriber, create_transcriber};
 
     println!("Transcribing: {}", input);
 
     let config = AppConfig::load();
+    let (config, _local_manager) = match prepare_runtime_config(config) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("Failed to prepare runtime: {}", e);
+            std::process::exit(1);
+        }
+    };
     let transcriber: Box<dyn Transcriber> = create_transcriber(&config);
     let post_processor = create_post_processor(&config);
 
@@ -418,10 +608,22 @@ fn handle_convert(input: &str, output: Option<&str>) {
     }
 }
 
+fn apply_local_endpoint_overrides(config: &AppConfig, base_url: &str) -> AppConfig {
+    let mut local = config.clone();
+    local.api_key = Some("local".to_string());
+    local.post_process_api_key = Some("local".to_string());
+    local.transcription_api_url = format!("{base_url}/v1/audio/transcriptions");
+    local.post_process_api_url = Some(format!("{base_url}/v1/chat/completions"));
+    local.post_process_enabled = true;
+    local.post_process_model = Some(LOCAL_MODEL_NAME.to_string());
+    local
+}
+
 #[cfg(test)]
 mod integration_tests {
     use super::*;
     use audio::AudioRecorder;
+    use crate::core::config::AppConfig;
     use transcriber::{MockTranscriber, Transcriber};
 
     #[test]
@@ -469,5 +671,26 @@ mod integration_tests {
         orch.start_session(SessionMode::Toggle);
         let result = orch.stop_session();
         assert!(matches!(result, Err(SessionError::NoChunks)));
+    }
+
+    #[test]
+    fn test_apply_local_endpoint_overrides_endpoints() {
+        let mut config = AppConfig::default();
+        config.local_server_port = 17265;
+
+        let local = apply_local_endpoint_overrides(&config, "http://127.0.0.1:17265");
+
+        assert_eq!(
+            local.transcription_api_url,
+            "http://127.0.0.1:17265/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            local.post_process_api_url.as_deref(),
+            Some("http://127.0.0.1:17265/v1/chat/completions")
+        );
+        assert!(local.post_process_enabled);
+        assert_eq!(local.post_process_model.as_deref(), Some("gemma-4-E4B-it"));
+        assert_eq!(local.api_key.as_deref(), Some("local"));
+        assert_eq!(local.post_process_api_key.as_deref(), Some("local"));
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,375 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "viberwhisper-python"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.111" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.6" },
+]


### PR DESCRIPTION
## Summary

- Add Python FastAPI server (`server/server.py` + `assets/local_server/server.py`) with OpenAI-compatible `/v1/audio/transcriptions` and `/v1/chat/completions` endpoints using Gemma 4B
- Add `src/local/installer.rs`: auto-install/update Python venv and dependencies
- Add `src/local/service.rs`: `LocalService` lifecycle manager (start/stop/health-check/port binding)
- Add `src/local/mod.rs`: module exports
- Extend `AppConfig` with `local_service` block (enabled, model, quantization, port, device, etc.)
- Add CLI subcommand `viberwhisper local start|stop|status|install`
- Update `changelog` and `config.example.json`
- Add plan doc `docs/plan/12-local-gemma-service.md`

## Test plan

- [ ] `cargo check` passes (verified clean)
- [ ] `cargo clippy` passes
- [ ] `cargo test` passes
- [ ] Manual: `viberwhisper local install` installs Python venv successfully
- [ ] Manual: `viberwhisper local start` launches the server and reports healthy
- [ ] Manual: STT via local service transcribes audio correctly
- [ ] Manual: LLM post-processing via local service cleans up text

🤖 Generated with [Claude Code](https://claude.com/claude-code)