### PR TITLE
docs: sync README and architecture for local runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agents.md
+# AGENTS.md
 
 This repository uses [CLAUDE.md](./CLAUDE.md) as the primary agent instruction file.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 一个基于 Rust 实现的语音转文字输入工具，按住热键即可将语音实时转录并输入到任意文本框。
 
-灵感来源于 [Typeless](https://typeless.ai/)，默认使用 [Groq Whisper API](https://console.groq.com) 进行语音识别，也可通过配置切换到任何兼容 OpenAI multipart 格式的转写接口。
+灵感来源于 [Typeless](https://typeless.ai/)，默认使用 [Groq Whisper API](https://console.groq.com) 进行语音识别，也可通过配置切换到任何兼容 OpenAI multipart 格式的转写接口；也支持启动本地 Gemma 服务，在本机完成转写与文本整理。
 
 ## 功能特性
 
@@ -10,7 +10,9 @@
 - **AI 语音识别**：通过可配置的 HTTP 转写接口将语音转为文字（默认 Groq Whisper）
 - **长录音自动分片**：超过时长/大小限制的录音自动切分，后台并行转写，结果智能合并
 - **LLM 文本后处理**：可选的 LLM 后处理层，自动补标点、去语气词、清理中断与重复
+- **本地推理模式**：通过内置 `local` 子命令拉起 Python FastAPI 服务，使用 Gemma 4 本地模型提供 `/v1/audio/transcriptions` 与 `/v1/chat/completions`
 - **自动文本输入**：识别结果自动输入到当前光标位置（支持中文等 Unicode 字符）
+- **悬浮录音按钮**：启动后显示可拖拽悬浮窗，点击即可像 Toggle 热键一样开始/停止录音
 - **灵活配置**：支持自定义热键、模型、语言、API 地址、麦克风增益等
 - **自动清理**：自动保留最新 10 条录音，旧文件自动删除
 
@@ -20,6 +22,7 @@
   - macOS：文字输入通过 System Events（osascript）实现，需在「系统设置 → 隐私与安全性 → 辅助功能」中授权终端应用
   - Windows：使用 SendInput API，无需额外权限
 - **Rust**：1.70 及以上版本
+- **Python**：本地模式需要 Python 3.11+（用于 FastAPI + Transformers 服务）
 
 ## 快速开始
 
@@ -69,13 +72,23 @@ cargo build --release
 cargo run --release
 ```
 
+如果要使用本地 Gemma 模式，先执行：
+
+```bash
+cargo run -- local install
+cargo run -- local start
+```
+
+`local install` 会创建虚拟环境、安装 `server/requirements.txt` 中的依赖、下载 `google/gemma-4-E4B-it` 模型并校验安装结果。默认数据目录为 `~/.viberwhisper`，可通过 `local_data_dir` 覆盖；如需 Hugging Face 镜像，可在安装前设置 `HF_ENDPOINT`。
+
 ### 4. 使用
 
 1. 启动程序，系统托盘会出现灰色图标
-2. 将光标定位到任意文本输入框（浏览器、编辑器、聊天框等）
-3. **按住 F8** 开始录音（图标变红），松开后自动转录并输入文字（Hold 模式）
-4. 或按一下 **F9** 开始录音，再按一下停止（Toggle 模式）
-5. 退出：右键点击托盘图标选择「退出」，或按 **Ctrl+C**
+2. 屏幕上会出现一个可拖拽的悬浮录音按钮，点击行为等同于 Toggle 模式
+3. 将光标定位到任意文本输入框（浏览器、编辑器、聊天框等）
+4. **按住 F8** 开始录音（图标变红），松开后自动转录并输入文字（Hold 模式）
+5. 或按一下 **F9** 开始录音，再按一下停止（Toggle 模式）
+6. 退出：右键点击托盘图标选择「退出」，或按 **Ctrl+C**
 
 > macOS 首次运行时，系统会弹出辅助功能授权请求，需要允许才能完成文字输入。
 
@@ -84,6 +97,12 @@ cargo run --release
 ```bash
 # 启动录音监听（默认，无子命令）
 viberwhisper
+
+# 安装 / 启动 / 停止 / 查看本地 Gemma 服务
+viberwhisper local install
+viberwhisper local start
+viberwhisper local stop
+viberwhisper local status
 
 # 查看所有配置
 viberwhisper config list
@@ -145,6 +164,17 @@ viberwhisper convert input.wav --output output.txt
 
 > **注意**：`config.json` 已在 `.gitignore` 中排除，避免误提交真实密钥。`api_key` 和 `post_process_api_key` 不会被程序写回磁盘。
 
+### 本地模式
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `local_mode` | 布尔 | `false` | 是否启用本地 Gemma 服务 |
+| `local_data_dir` | 字符串 | `~/.viberwhisper` | 本地模型、虚拟环境、PID 和日志目录 |
+| `local_server_port` | 数字 | `17265` | 本地 FastAPI 服务端口 |
+| `local_quantization` | 字符串 | `int8` | 量化模式，可选 `int4` / `int8` / `bf16` |
+
+启用 `local_mode` 后，程序会在启动监听前自动确保本地运行时已安装、拉起本地服务，并把转写端点重写为本地服务地址；如果同时启用了 `post_process_enabled`，后处理端点也会改写到本地 `/v1/chat/completions`。当前本地服务固定使用 `gemma-4-E4B-it` 作为模型名。
+
 ### 切换转写服务
 
 只需修改 `transcription_api_url` 和 `api_key` 即可切换到任何兼容 OpenAI Whisper multipart 格式的接口：
@@ -179,6 +209,17 @@ export POST_PROCESS_API_KEY=your_key_here
 
 后处理失败时自动降级为输出原始转写文本，不会导致整次录音失败。
 
+## 本地 Gemma 服务
+
+本地服务位于 [`server/server.py`](server/server.py)，通过 FastAPI 暴露两个 OpenAI 兼容端点：
+
+- `POST /v1/audio/transcriptions`：接收 WAV 音频并调用 Gemma 音频理解能力返回转写结果
+- `POST /v1/chat/completions`：供后处理模块复用，返回整理后的文本
+
+Rust 侧的 `LocalServiceManager` 负责启动、健康检查、PID 记录、日志文件和关闭流程。`viberwhisper local start` 会先拉起服务，再进入正常监听循环；直接把 `local_mode` 设为 `true` 也会在启动主程序时自动做同样的准备。
+
+当前本地服务限制单次音频请求最长 30 秒，因此长录音仍由 Rust 端先分片，再逐片提交给本地端点。
+
 ## 依赖项
 
 - [rdev](https://crates.io/crates/rdev) - 全局热键监听
@@ -197,6 +238,7 @@ export POST_PROCESS_API_KEY=your_key_here
 cargo test     # 运行测试
 cargo clippy   # 代码检查
 cargo fmt      # 代码格式化
+uv run pytest  # 运行 Python server 测试
 ```
 
 ## 许可证

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Module-level design docs covering structs, methods, and dependencies.
 | [audio.md](architecture/audio.md) | Audio recording — `AudioRecorder`, cpal stream management, live chunking, WAV output |
 | [core.md](architecture/core.md) | Config persistence (`AppConfig`), CLI argument parsing (`Cli`, `Commands`), `SessionOrchestrator` |
 | [input.md](architecture/input.md) | Hotkey detection (`HotkeyManager`), text injection (`TextTyper`), system tray (`TrayManager`) |
+| [local.md](architecture/local.md) | Local Gemma runtime: installer, Python FastAPI service, process lifecycle, health/status management |
 | [transcriber.md](architecture/transcriber.md) | Transcription trait, `ApiTranscriber` (OpenAI-compatible API), chunking, retry, text merging |
 | [platform.md](architecture/platform.md) | Platform text injection — `MacTyper` (osascript) and `WindowsTyper` (SendInput) |
 | [postprocess.md](architecture/postprocess.md) | Post-processing — `TextPostProcessor` trait, LLM integration, preheat/conservative sessions |

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `core` module (`src/core/`) contains three sub-modules: configuration persistence (`config.rs`), CLI argument parsing (`cli.rs`), and session orchestration (`orchestrator.rs`).
+The `core` module (`src/core/`) contains three sub-modules: configuration persistence (`config.rs`), CLI argument parsing (`cli.rs`), and session orchestration (`orchestrator.rs`). It also serves as the boundary where local-mode runtime settings are carried into the main loop.
 
 ---
 
@@ -41,6 +41,12 @@ pub struct AppConfig {
     pub post_process_model: Option<String>,
     pub post_process_prompt: Option<String>,
     pub post_process_temperature: f32,        // default: 0.0
+
+    // --- Local runtime ---
+    pub local_mode: bool,                     // default: false
+    pub local_data_dir: Option<String>,       // default: ~/.viberwhisper
+    pub local_server_port: u16,               // default: 17265
+    pub local_quantization: String,           // default: "int8"
 }
 ```
 
@@ -65,6 +71,9 @@ Serialized to/from `config.json` via `serde_json`. `api_key` and `post_process_a
 | `post_process_streaming_enabled` | `true` |
 | `post_process_api_format` | `"openai"` |
 | `post_process_temperature` | `0.0` |
+| `local_mode` | `false` |
+| `local_server_port` | `17265` |
+| `local_quantization` | `"int8"` |
 
 ### Key Methods
 
@@ -83,17 +92,18 @@ Serializes to pretty-printed JSON. `api_key` and `post_process_api_key` are neve
 
 **`get_field(&self, key: &str) -> Option<String>`**
 
-Returns a string representation of the named field. Supported keys: `api_key`, `groq_api_key`, `transcription_api_url`, `provider`, `model`, `hold_hotkey`, `toggle_hotkey`, `temperature`, `mic_gain`, `language`, `prompt`, `max_chunk_duration_secs`, `max_chunk_size_bytes`, `max_retries`, `convergence_timeout_secs`, `post_process_enabled`, `post_process_streaming_enabled`, `post_process_api_url`, `post_process_api_key`, `post_process_api_format`, `post_process_model`, `post_process_prompt`, `post_process_temperature`. Returns `"*** (set)"` for API key fields if present; `None` for unknown keys.
+Returns a string representation of the named field. Supported keys: `api_key`, `groq_api_key`, `transcription_api_url`, `provider`, `model`, `hold_hotkey`, `toggle_hotkey`, `temperature`, `mic_gain`, `language`, `prompt`, `max_chunk_duration_secs`, `max_chunk_size_bytes`, `max_retries`, `convergence_timeout_secs`, `post_process_enabled`, `post_process_streaming_enabled`, `post_process_api_url`, `post_process_api_key`, `post_process_api_format`, `post_process_model`, `post_process_prompt`, `post_process_temperature`, `local_mode`, `local_data_dir`, `local_server_port`, `local_quantization`. Returns `"*** (set)"` for API key fields if present; `None` for unknown keys.
 
 **`set_field(&mut self, key: &str, value: &str) -> Result<(), String>`**
 
-Sets a field by name with auto type conversion (strings, floats, bools, integers). `groq_api_key` is accepted as an alias for `api_key`.
+Sets a field by name with auto type conversion (strings, floats, bools, integers). `groq_api_key` is accepted as an alias for `api_key`. Local runtime keys can also be mutated from CLI.
 
 **`apply_json(&mut self, json: &Value)`** *(private)*
 
 Applies partial JSON overrides. Backward compatibility:
 - Old `"hotkey"` key maps to `hold_hotkey`
 - Old `"groq_api_key"` key maps to `api_key` (if `api_key` not already set)
+- Local runtime keys (`local_mode`, `local_data_dir`, `local_server_port`, `local_quantization`) are also deserialized from `config.json`
 
 ---
 
@@ -114,6 +124,7 @@ Parsed with `clap::Parser`. No subcommand runs the main recording loop.
 | Variant | Description |
 |---|---|
 | `Config { action: ConfigAction }` | Configuration management subcommand |
+| `Local { action: LocalCommand }` | Local Gemma runtime lifecycle commands |
 | `Convert { input: String, output: Option<String> }` | Transcribe a WAV file to text |
 
 ### `ConfigAction` Enum
@@ -123,6 +134,15 @@ Parsed with `clap::Parser`. No subcommand runs the main recording loop.
 | `List` | Print all config fields and current values |
 | `Get { key: String }` | Print a single field value |
 | `Set { key: String, value: String }` | Update a field and save |
+
+### `LocalCommand` Enum
+
+| Variant | Description |
+|---|---|
+| `Install` | Create venv, install Python dependencies, download model, and verify install |
+| `Start` | Force `local_mode = true`, start local server, then enter the normal listener loop |
+| `Stop` | Stop the persisted local server process |
+| `Status` | Print runtime state, pid, port, memory usage, and `/health` result |
 
 ---
 
@@ -145,3 +165,11 @@ Parsed with `clap::Parser`. No subcommand runs the main recording loop.
 | `NoChunks` | Recording too short to produce any audio |
 | `PartialFailure { partial_text, failures }` | Some chunks succeeded, includes partial text |
 | `ConvergenceTimeout { partial_text, pending }` | Timeout hit, includes what was completed |
+
+## Main Integration Notes
+
+Although the main event loop lives in `src/main.rs`, `core` owns the configuration and CLI abstractions that feed it:
+
+- `run_listener_with_config(config)` is the common entry point for both default mode and `local start`
+- when `config.local_mode` is true, startup first calls into the `local` module to ensure the runtime exists, always rewrites the transcription endpoint, and conditionally rewrites the post-process endpoint when `post_process_enabled` is on
+- the same orchestrator pipeline is reused regardless of whether the backend is Groq/OpenAI-compatible cloud STT or the local Gemma service

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `input` module (`src/input/`) handles three concerns: global hotkey detection (`hotkey.rs`), text injection into the focused window (`typer.rs`), and system tray UI (`tray.rs`).
+The `input` module (`src/input/`) handles four concerns: global hotkey detection (`hotkey.rs`), text injection into the focused window (`typer.rs`), system tray UI (`tray.rs`), and the floating overlay window (`overlay/`).
 
 ---
 
@@ -110,3 +110,34 @@ Switches icon and tooltip based on recording state.
 **`check_exit(&self) -> bool`**
 
 Non-blocking check of the menu event channel; returns `true` if the exit item was clicked.
+
+---
+
+## Overlay (`src/input/overlay/`)
+
+### Purpose
+
+Provides an always-on-top, draggable recording affordance separate from the tray icon. A click on the overlay acts like the toggle hotkey: start recording when idle, stop when recording.
+
+### Platform Selection
+
+| Target | Implementation |
+|---|---|
+| macOS | `overlay/macos.rs` |
+| Windows | `overlay/windows_impl.rs` |
+| Other | `overlay/stub.rs` |
+
+### Public API
+
+`main.rs` interacts with the overlay through a platform-specific `OverlayManager` with a shared interface:
+
+- `OverlayManager::new() -> Result<Self>`: create window/resources
+- `set_recording(recording: bool)`: update visual state
+- `check_click() -> bool`: poll whether the overlay was clicked since last check
+- `update()`: pump any pending UI work from the main loop
+
+### Main-loop Behavior
+
+- overlay clicks are checked on every tick, after hotkey polling
+- when clicked, the overlay follows the same start/stop flow as toggle mode
+- overlay state is kept in sync with tray state during all record transitions

--- a/docs/architecture/local.md
+++ b/docs/architecture/local.md
@@ -1,0 +1,107 @@
+# Local Runtime Architecture
+
+## Purpose
+
+`local` 模块负责把 Python FastAPI 推理服务接入 Rust 主程序，使 ViberWhisper 可以在本机使用 Gemma 4 完成转写和文本后处理，而不依赖外部云端 API。
+
+## Module Layout
+
+```
+src/local/
+  installer.rs  — Python 虚拟环境、依赖安装、模型下载与校验
+  service.rs    — 本地服务进程管理、健康检查、PID/日志状态
+
+server/
+  server.py     — FastAPI 服务，提供 OpenAI 兼容接口
+  requirements.txt
+  tests/test_server.py
+```
+
+## Runtime Flow
+
+1. `main.rs` 解析到 `local` 子命令，或检测到 `config.local_mode = true`
+2. `ensure_local_install()` 准备 `venv`、Python 依赖、Gemma 权重并做安装校验
+3. `LocalServiceManager::start()` 启动 `server/server.py`
+4. 健康检查通过后，`apply_local_endpoint_overrides()` 将转写端点改写到 `http://127.0.0.1:<port>`；若启用了后处理，再同时改写 chat completions 端点
+5. 之后主流程继续复用现有 `Transcriber` 和 `TextPostProcessor`，无需额外分支
+
+## Installer (`src/local/installer.rs`)
+
+### Responsibilities
+
+- `setup_venv(venv_dir)`: 创建 Python 虚拟环境；优先使用 `PYTHON` 环境变量指定的解释器，否则按平台寻找 `python3` / `python`
+- `install_requirements(venv_dir, reqs)`: 安装 [`server/requirements.txt`](../../server/requirements.txt) 中的运行时依赖
+- `download_model(model_dir, hf_endpoint)`: 通过 `huggingface_hub` 下载 `google/gemma-4-E4B-it`
+- `verify_install(venv_dir, model_dir)`: 校验 Python 可执行文件和模型目录是否存在且非空
+- `dependencies_installed(venv_dir)`: 通过导入关键包确认依赖已安装
+- `model_weights_present(model_dir)`: 检测 `config.json` 与至少一个 `.safetensors` / `.bin` 权重文件
+
+### Data Layout
+
+默认目录为 `~/.viberwhisper/`：
+
+- `venv/`: Python 虚拟环境
+- `model/`: Gemma 模型权重
+- `local_server.pid`: 服务 PID
+- `server.log`: Python 服务 stderr 日志
+
+## Service Manager (`src/local/service.rs`)
+
+### `LocalServiceManager`
+
+```rust
+pub struct LocalServiceManager {
+    port: u16,
+    model_dir: PathBuf,
+    venv_dir: PathBuf,
+    quantization: String,
+    process: Option<Child>,
+    log_file: Option<PathBuf>,
+    owned: bool,
+}
+```
+
+### Key Behaviors
+
+- `start()`: 如果已有健康服务则直接复用，否则启动 Python 进程并轮询 `/health`
+- `stop()`: 读取当前子进程或 PID 文件，对目标进程发送终止信号；超时后升级为强制 kill
+- `release()`: 仅在当前 manager 自己启动了服务时才停止，避免误杀复用中的后台进程
+- `status()`: 返回 `running`、`pid`、`memory_usage` 和最近一次健康检查结果
+- `base_url()`: 统一生成 `http://127.0.0.1:<port>`
+
+### Process Management
+
+- PID 会写入 `local_server.pid`
+- 非 Windows 平台通过 `ps` / `kill` 检查和结束进程
+- Windows 通过 `tasklist` / `taskkill`
+- 健康检查超时时间为 120 秒，轮询间隔 500 ms
+
+## FastAPI Server (`server/server.py`)
+
+### Startup
+
+- `create_app(runtime)` 在 lifespan 中异步调用 `runtime.load()`
+- 模型加载完成前，`/health` 返回 `503 loading`
+- 加载失败后返回 `500 error`
+
+### Exposed Endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /health` | 返回 `loading` / `ok` / `error` 状态 |
+| `POST /v1/audio/transcriptions` | 接收 multipart WAV 音频，返回 `{text, language, duration}` |
+| `POST /v1/chat/completions` | 接收 OpenAI 风格 chat 请求，返回 chat completion 响应 |
+
+### `LocalModelRuntime`
+
+- `load()`: 加载 `AutoProcessor` 与 `AutoModelForCausalLM`
+- `_try_quanto_quantization()`: 优先使用 `optimum-quanto`，不可用时回退到 `bitsandbytes`，再不行则无量化加载
+- `transcribe_audio()`: 读取 WAV 字节流，最长支持 30 秒，构造带音频输入的 chat prompt
+- `chat_complete()`: 渲染对话模板并生成文本，供后处理模块复用
+- `_flatten_content()`: 兼容字符串或 OpenAI content array 结构
+
+## Testing
+
+- Rust 侧单元测试覆盖 installer 和 service manager 的关键路径
+- Python 侧 [`server/tests/test_server.py`](../../server/tests/test_server.py) 使用 `fastapi.testclient` 验证健康检查、转写接口和 chat 接口
+- Python 项目元数据位于 [`pyproject.toml`](../../pyproject.toml)，可通过 `uv run pytest` 运行服务测试


### PR DESCRIPTION
## Summary
- update README for local Gemma mode, overlay behavior, local CLI commands, and Python test workflow
- add local runtime architecture doc covering installer, service manager, FastAPI server, and test layout
- refresh architecture index/core/input docs to match the current repository state

## Testing
- not run for this docs-only PR