### PR TITLE
chore: update local runtime workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   - macOS：文字输入通过 System Events（osascript）实现，需在「系统设置 → 隐私与安全性 → 辅助功能」中授权终端应用
   - Windows：使用 SendInput API，无需额外权限
 - **Rust**：1.70 及以上版本
-- **Python**：本地模式需要 Python 3.11+（用于 FastAPI + Transformers 服务）
+- **Python**：本地模式需要 Python 3.10+；安装时优先使用 `uv`，若未安装则回退到系统 Python（用于 FastAPI + Transformers 服务）
 
 ## 快速开始
 
@@ -79,7 +79,7 @@ cargo run -- local install
 cargo run -- local start
 ```
 
-`local install` 会创建虚拟环境、安装 `server/requirements.txt` 中的依赖、下载 `google/gemma-4-E4B-it` 模型并校验安装结果。默认数据目录为 `~/.viberwhisper`，可通过 `local_data_dir` 覆盖；如需 Hugging Face 镜像，可在安装前设置 `HF_ENDPOINT`。
+`local install` 会先校验本机 Python 版本是否为 3.10 或以上，然后优先使用 `uv` 创建虚拟环境和安装 `server/requirements.txt` 中的依赖；若未安装 `uv`，则回退到系统 Python。随后会下载 `google/gemma-4-E2B-it` 模型并校验安装结果。默认数据目录为 `~/.viberwhisper`，可通过 `local_data_dir` 覆盖；如需 Hugging Face 镜像，可在安装前设置 `HF_ENDPOINT`。
 
 ### 4. 使用
 
@@ -173,7 +173,7 @@ viberwhisper convert input.wav --output output.txt
 | `local_server_port` | 数字 | `17265` | 本地 FastAPI 服务端口 |
 | `local_quantization` | 字符串 | `int8` | 量化模式，可选 `int4` / `int8` / `bf16` |
 
-启用 `local_mode` 后，程序会在启动监听前自动确保本地运行时已安装、拉起本地服务，并把转写端点重写为本地服务地址；如果同时启用了 `post_process_enabled`，后处理端点也会改写到本地 `/v1/chat/completions`。当前本地服务固定使用 `gemma-4-E4B-it` 作为模型名。
+启用 `local_mode` 后，程序会在启动监听前自动确保本地运行时已安装、拉起本地服务，并把转写端点重写为本地服务地址；如果同时启用了 `post_process_enabled`，后处理端点也会改写到本地 `/v1/chat/completions`。当前本地服务固定使用 `gemma-4-E2B-it` 作为模型名。
 
 ### 切换转写服务
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -2,4 +2,4 @@ pub mod recorder;
 pub mod splitter;
 pub use recorder::{AudioRecorder, StopResult};
 #[allow(unused_imports)]
-pub use splitter::{split_wav, TmpChunk};
+pub use splitter::{TmpChunk, split_wav};

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -192,7 +192,14 @@ impl AudioRecorder {
                                 (avg * gain).clamp(i16::MIN as f32, i16::MAX as f32) as i16
                             })
                             .collect();
-                        push_mono_chunk(mono, &buffer, &sample_count, &flush_needed, sample_rate, chunk_max_samples);
+                        push_mono_chunk(
+                            mono,
+                            &buffer,
+                            &sample_count,
+                            &flush_needed,
+                            sample_rate,
+                            chunk_max_samples,
+                        );
                     }
                 },
                 move |err| error!(error = %err, "Stream error"),
@@ -210,7 +217,14 @@ impl AudioRecorder {
                             })
                             .map(|s| s as i16)
                             .collect();
-                        push_mono_chunk(mono, &buffer, &sample_count, &flush_needed, sample_rate, chunk_max_samples);
+                        push_mono_chunk(
+                            mono,
+                            &buffer,
+                            &sample_count,
+                            &flush_needed,
+                            sample_rate,
+                            chunk_max_samples,
+                        );
                     }
                 },
                 move |err| error!(error = %err, "Stream error"),

--- a/src/audio/splitter.rs
+++ b/src/audio/splitter.rs
@@ -85,9 +85,7 @@ pub fn split_wav(
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("audio");
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .as_secs();
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
     std::fs::create_dir_all("./tmp")?;
 
@@ -196,7 +194,11 @@ mod tests {
         // 5 s at 16 kHz = 80 000 samples; 2 s chunks → 3 chunks (32k, 32k, 16k)
         write_test_wav(path, 16000, 80000);
         let chunks = split_wav(path, 2, 0).unwrap();
-        assert_eq!(chunks.len(), 3, "5s audio split into 2s chunks should produce 3 chunks");
+        assert_eq!(
+            chunks.len(),
+            3,
+            "5s audio split into 2s chunks should produce 3 chunks"
+        );
         let _ = std::fs::remove_file(path);
     }
 
@@ -208,7 +210,11 @@ mod tests {
         assert!(!chunks.is_empty());
         for chunk in &chunks {
             let reader = WavReader::open(&chunk.path);
-            assert!(reader.is_ok(), "Chunk should be a valid WAV: {:?}", chunk.path);
+            assert!(
+                reader.is_ok(),
+                "Chunk should be a valid WAV: {:?}",
+                chunk.path
+            );
         }
         let _ = std::fs::remove_file(path);
     }
@@ -261,7 +267,11 @@ mod tests {
         write_test_wav(path, 16000, 10000);
         let max_bytes: u64 = 44 + 5000 * 2; // exactly 5000 samples per chunk
         let chunks = split_wav(path, 0, max_bytes).unwrap();
-        assert_eq!(chunks.len(), 2, "10 000 samples split into 5 000-sample chunks should give 2 chunks");
+        assert_eq!(
+            chunks.len(),
+            2,
+            "10 000 samples split into 5 000-sample chunks should give 2 chunks"
+        );
         let _ = std::fs::remove_file(path);
     }
 }

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -100,8 +100,7 @@ mod tests {
 
     #[test]
     fn test_cli_config_set() {
-        let cli =
-            Cli::try_parse_from(["viberwhisper", "config", "set", "hotkey", "F9"]).unwrap();
+        let cli = Cli::try_parse_from(["viberwhisper", "config", "set", "hotkey", "F9"]).unwrap();
         if let Some(Commands::Config {
             action: ConfigAction::Set { key, value },
         }) = cli.command
@@ -126,14 +125,9 @@ mod tests {
 
     #[test]
     fn test_cli_convert_with_output() {
-        let cli = Cli::try_parse_from([
-            "viberwhisper",
-            "convert",
-            "test.wav",
-            "--output",
-            "out.txt",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["viberwhisper", "convert", "test.wav", "--output", "out.txt"])
+                .unwrap();
         if let Some(Commands::Convert { input, output }) = cli.command {
             assert_eq!(input, "test.wav");
             assert_eq!(output, Some("out.txt".to_string()));

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -5,8 +5,7 @@ use tracing::{info, warn};
 const CONFIG_FILE: &str = "config.json";
 
 /// Default transcription API URL (Groq Whisper endpoint).
-const DEFAULT_TRANSCRIPTION_API_URL: &str =
-    "https://api.groq.com/openai/v1/audio/transcriptions";
+const DEFAULT_TRANSCRIPTION_API_URL: &str = "https://api.groq.com/openai/v1/audio/transcriptions";
 
 fn default_chunk_duration() -> u32 {
     30
@@ -78,7 +77,6 @@ pub struct AppConfig {
     pub convergence_timeout_secs: u64,
 
     // --- LLM text post-processing ---
-
     /// Enable LLM-based text post-processing after STT. Default: false.
     #[serde(default)]
     pub post_process_enabled: bool,
@@ -173,9 +171,10 @@ impl AppConfig {
 
         // Env var override: GROQ_API_KEY for backward compat, api_key for new configs
         if let Ok(key) = std::env::var("GROQ_API_KEY")
-            && config.api_key.is_none() {
-                config.api_key = Some(key);
-            }
+            && config.api_key.is_none()
+        {
+            config.api_key = Some(key);
+        }
         if let Ok(key) = std::env::var("TRANSCRIPTION_API_KEY") {
             config.api_key = Some(key);
         }
@@ -196,9 +195,7 @@ impl AppConfig {
     /// Get the string value of a config field
     pub fn get_field(&self, key: &str) -> Option<String> {
         match key {
-            "api_key" | "groq_api_key" => {
-                self.api_key.as_ref().map(|_| "*** (set)".to_string())
-            }
+            "api_key" | "groq_api_key" => self.api_key.as_ref().map(|_| "*** (set)".to_string()),
             "transcription_api_url" => Some(self.transcription_api_url.clone()),
             "provider" => self.provider.clone(),
             "model" => Some(self.model.clone()),
@@ -281,9 +278,9 @@ impl AppConfig {
                 Ok(())
             }
             "max_chunk_duration_secs" => {
-                self.max_chunk_duration_secs = value
-                    .parse::<u32>()
-                    .map_err(|_| format!("max_chunk_duration_secs must be a u32, got: {}", value))?;
+                self.max_chunk_duration_secs = value.parse::<u32>().map_err(|_| {
+                    format!("max_chunk_duration_secs must be a u32, got: {}", value)
+                })?;
                 Ok(())
             }
             "max_chunk_size_bytes" => {
@@ -299,15 +296,15 @@ impl AppConfig {
                 Ok(())
             }
             "convergence_timeout_secs" => {
-                self.convergence_timeout_secs = value
-                    .parse::<u64>()
-                    .map_err(|_| format!("convergence_timeout_secs must be a u64, got: {}", value))?;
+                self.convergence_timeout_secs = value.parse::<u64>().map_err(|_| {
+                    format!("convergence_timeout_secs must be a u64, got: {}", value)
+                })?;
                 Ok(())
             }
             "post_process_enabled" => {
-                self.post_process_enabled = value
-                    .parse::<bool>()
-                    .map_err(|_| format!("post_process_enabled must be true/false, got: {}", value))?;
+                self.post_process_enabled = value.parse::<bool>().map_err(|_| {
+                    format!("post_process_enabled must be true/false, got: {}", value)
+                })?;
                 Ok(())
             }
             "post_process_streaming_enabled" => {
@@ -385,9 +382,10 @@ impl AppConfig {
         }
         // Backward compat: old groq_api_key maps to api_key
         if let Some(key) = json["groq_api_key"].as_str()
-            && self.api_key.is_none() {
-                self.api_key = Some(key.to_string());
-            }
+            && self.api_key.is_none()
+        {
+            self.api_key = Some(key.to_string());
+        }
         if let Some(url) = json["transcription_api_url"].as_str() {
             self.transcription_api_url = url.to_string();
         }
@@ -717,13 +715,12 @@ mod tests {
             config.get_field("max_chunk_duration_secs"),
             Some("30".to_string())
         );
-        assert_eq!(
-            config.get_field("max_retries"),
-            Some("3".to_string())
-        );
+        assert_eq!(config.get_field("max_retries"), Some("3".to_string()));
         config.set_field("max_chunk_duration_secs", "45").unwrap();
         assert_eq!(config.max_chunk_duration_secs, 45);
-        config.set_field("max_chunk_size_bytes", "10485760").unwrap();
+        config
+            .set_field("max_chunk_size_bytes", "10485760")
+            .unwrap();
         assert_eq!(config.max_chunk_size_bytes, 10485760);
         config.set_field("max_retries", "5").unwrap();
         assert_eq!(config.max_retries, 5);
@@ -780,10 +777,7 @@ mod tests {
         config
             .set_field("post_process_model", "gpt-4o-mini")
             .unwrap();
-        assert_eq!(
-            config.post_process_model.as_deref(),
-            Some("gpt-4o-mini")
-        );
+        assert_eq!(config.post_process_model.as_deref(), Some("gpt-4o-mini"));
         assert_eq!(
             config.get_field("post_process_model"),
             Some("gpt-4o-mini".to_string())
@@ -796,16 +790,17 @@ mod tests {
         config
             .set_field("post_process_prompt", "custom prompt")
             .unwrap();
-        assert_eq!(config.get_field("post_process_prompt"), Some("custom prompt".to_string()));
+        assert_eq!(
+            config.get_field("post_process_prompt"),
+            Some("custom prompt".to_string())
+        );
     }
 
     #[test]
     fn test_get_set_post_process_api_key_masked() {
         let mut config = AppConfig::default();
         assert_eq!(config.get_field("post_process_api_key"), None);
-        config
-            .set_field("post_process_api_key", "secret")
-            .unwrap();
+        config.set_field("post_process_api_key", "secret").unwrap();
         assert_eq!(config.post_process_api_key.as_deref(), Some("secret"));
         assert_eq!(
             config.get_field("post_process_api_key"),
@@ -864,7 +859,10 @@ mod tests {
             config.get_field("local_data_dir").as_deref(),
             Some("/tmp/viberwhisper")
         );
-        assert_eq!(config.get_field("local_server_port").as_deref(), Some("9000"));
+        assert_eq!(
+            config.get_field("local_server_port").as_deref(),
+            Some("9000")
+        );
         assert_eq!(
             config.get_field("local_quantization").as_deref(),
             Some("bf16")

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -4,8 +4,8 @@
 //! chunk tracking, background transcription, convergence wait, and result merging.
 
 use std::fmt;
-use std::sync::{Arc, Mutex};
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -98,7 +98,10 @@ enum ChunkState {
     /// Worker is transcribing this chunk.
     /// `attempt` is reserved for future retry logic (see `max_retries` in AppConfig);
     /// retry is not yet implemented — on failure the chunk transitions directly to `Failed`.
-    Uploading { #[allow(dead_code)] attempt: u32 },
+    Uploading {
+        #[allow(dead_code)]
+        attempt: u32,
+    },
     /// Successfully transcribed.
     Transcribed(String),
     /// Transcription failed (all retries exhausted, or timeout).
@@ -178,7 +181,9 @@ impl SessionOrchestrator {
 
         let mut inner = self.inner.lock().unwrap();
         if inner.is_some() {
-            warn!("start_session called while a session is already active; discarding previous session");
+            warn!(
+                "start_session called while a session is already active; discarding previous session"
+            );
         }
         *inner = Some(ActiveSessionInner {
             mode,
@@ -208,15 +213,16 @@ impl SessionOrchestrator {
             state: ChunkState::Flushed,
         });
 
-        if let Err(e) = session
-            .chunk_tx
-            .send(WorkerMsg::Chunk { index, path: path.clone() })
-        {
+        if let Err(e) = session.chunk_tx.send(WorkerMsg::Chunk {
+            index,
+            path: path.clone(),
+        }) {
             error!(path = %path, error = %e, "Failed to enqueue chunk; marking as failed");
             let mut chunks = session.chunks.lock().unwrap();
             if let Some(entry) = chunks.iter_mut().find(|e| e.index == index) {
-                entry.state =
-                    ChunkState::Failed(TranscribeError::Network("worker channel closed".to_string()));
+                entry.state = ChunkState::Failed(TranscribeError::Network(
+                    "worker channel closed".to_string(),
+                ));
             }
         } else {
             info!(index = index, path = %path, "Chunk enqueued for background transcription");
@@ -260,11 +266,7 @@ impl SessionOrchestrator {
         let mut timed_out = false;
 
         loop {
-            let all_terminal = chunks
-                .lock()
-                .unwrap()
-                .iter()
-                .all(|e| e.state.is_terminal());
+            let all_terminal = chunks.lock().unwrap().iter().all(|e| e.state.is_terminal());
             if all_terminal {
                 break;
             }
@@ -382,9 +384,10 @@ fn classify_error(error_msg: &str) -> TranscribeError {
 fn extract_http_status(msg: &str) -> Option<u16> {
     for token in msg.split_whitespace() {
         if let Ok(n) = token.parse::<u16>()
-            && (100..=599).contains(&n) {
-                return Some(n);
-            }
+            && (100..=599).contains(&n)
+        {
+            return Some(n);
+        }
     }
     None
 }

--- a/src/input/hotkey.rs
+++ b/src/input/hotkey.rs
@@ -1,9 +1,9 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use rdev::{listen, Event, EventType, Key};
+use rdev::{Event, EventType, Key, listen};
 use tracing::{debug, error, info};
 
 // Thread-safe state for tracking key states
@@ -46,15 +46,15 @@ pub struct HotkeyManager {
 }
 
 impl HotkeyManager {
-    pub fn new(
-        hold_hotkey: &str,
-        toggle_hotkey: &str,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(hold_hotkey: &str, toggle_hotkey: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let hold_key = parse_key(hold_hotkey);
         let toggle_key = parse_key(toggle_hotkey);
 
         if hold_key.is_none() && toggle_key.is_none() {
-            return Err("At least one valid hotkey must be configured (hold_hotkey or toggle_hotkey)".into());
+            return Err(
+                "At least one valid hotkey must be configured (hold_hotkey or toggle_hotkey)"
+                    .into(),
+            );
         }
 
         let running = Arc::new(AtomicBool::new(true));
@@ -62,26 +62,27 @@ impl HotkeyManager {
         thread::spawn(move || {
             debug!("rdev listener thread started");
 
-            let callback = move |event: Event| {
-                match &event.event_type {
-                    EventType::KeyPress(key) => {
-                        if let Some(hk) = hold_key
-                            && *key == hk {
-                                HOLD_PRESSED.store(true, Ordering::Relaxed);
-                            }
-                        if let Some(tk) = toggle_key
-                            && *key == tk {
-                                TOGGLE_PRESSED.store(true, Ordering::Relaxed);
-                            }
+            let callback = move |event: Event| match &event.event_type {
+                EventType::KeyPress(key) => {
+                    if let Some(hk) = hold_key
+                        && *key == hk
+                    {
+                        HOLD_PRESSED.store(true, Ordering::Relaxed);
                     }
-                    EventType::KeyRelease(key) => {
-                        if let Some(hk) = hold_key
-                            && *key == hk {
-                                HOLD_RELEASED.store(true, Ordering::Relaxed);
-                            }
+                    if let Some(tk) = toggle_key
+                        && *key == tk
+                    {
+                        TOGGLE_PRESSED.store(true, Ordering::Relaxed);
                     }
-                    _ => {}
                 }
+                EventType::KeyRelease(key) => {
+                    if let Some(hk) = hold_key
+                        && *key == hk
+                    {
+                        HOLD_RELEASED.store(true, Ordering::Relaxed);
+                    }
+                }
+                _ => {}
             };
 
             if let Err(e) = listen(callback) {

--- a/src/input/overlay/macos.rs
+++ b/src/input/overlay/macos.rs
@@ -4,8 +4,8 @@ use objc2::{MainThreadMarker, MainThreadOnly, define_class, extern_methods};
 use objc2_app_kit::{
     NSApp, NSAppearance, NSAppearanceNameAccessibilityHighContrastDarkAqua,
     NSAppearanceNameDarkAqua, NSAppearanceNameVibrantDark, NSApplication,
-    NSApplicationActivationPolicy, NSBackingStoreType, NSBezierPath, NSColor, NSEvent,
-    NSEventMask, NSScreen, NSView, NSWindow, NSWindowCollectionBehavior, NSWindowStyleMask,
+    NSApplicationActivationPolicy, NSBackingStoreType, NSBezierPath, NSColor, NSEvent, NSEventMask,
+    NSScreen, NSView, NSWindow, NSWindowCollectionBehavior, NSWindowStyleMask,
 };
 use objc2_foundation::{NSDate, NSDefaultRunLoopMode, NSPoint, NSRect, NSSize, NSString};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -58,8 +58,7 @@ impl OverlayManager {
         window.setIgnoresMouseEvents(false);
         window.setAlphaValue(0.95);
         window.setCollectionBehavior(
-            NSWindowCollectionBehavior::CanJoinAllSpaces
-                | NSWindowCollectionBehavior::Stationary,
+            NSWindowCollectionBehavior::CanJoinAllSpaces | NSWindowCollectionBehavior::Stationary,
         );
 
         let content_view = create_overlay_view(window_rect.size, mtm);

--- a/src/local/installer.rs
+++ b/src/local/installer.rs
@@ -1,8 +1,16 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const DEPENDENCY_CHECK_SCRIPT: &str =
-    "import accelerate, fastapi, huggingface_hub, soundfile, torch, transformers, uvicorn";
+const DEPENDENCY_CHECK_SCRIPT: &str = "import accelerate, fastapi, huggingface_hub, librosa, multipart, PIL, soundfile, torch, torchvision, transformers, uvicorn";
+const MIN_PYTHON_MAJOR: u32 = 3;
+const MIN_PYTHON_MINOR: u32 = 10;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonRuntime {
+    pub python: PathBuf,
+    pub version: (u32, u32),
+    pub uv: Option<PathBuf>,
+}
 
 /// Creates a Python virtual environment for the local service.
 pub fn setup_venv(venv_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -15,11 +23,21 @@ pub fn setup_venv(venv_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
         std::fs::create_dir_all(parent)?;
     }
 
-    run_command(
-        find_python()?,
-        ["-m", "venv", &venv_dir.to_string_lossy()],
-        None,
-    )
+    let python = find_python()?;
+    if let Some(uv) = find_uv() {
+        return run_command(
+            uv,
+            [
+                "venv",
+                "--python",
+                &python.to_string_lossy(),
+                &venv_dir.to_string_lossy(),
+            ],
+            None,
+        );
+    }
+
+    run_command(python, ["-m", "venv", &venv_dir.to_string_lossy()], None)
 }
 
 /// Installs Python requirements into the virtual environment.
@@ -34,6 +52,21 @@ pub fn install_requirements(
     let python = venv_python_path(venv_dir);
     if !python.exists() {
         return Err(format!("virtualenv python not found: {}", python.display()).into());
+    }
+
+    if let Some(uv) = find_uv() {
+        return run_command(
+            uv,
+            [
+                "pip",
+                "install",
+                "--python",
+                &python.to_string_lossy(),
+                "-r",
+                &reqs.to_string_lossy(),
+            ],
+            None,
+        );
     }
 
     run_command(
@@ -67,15 +100,27 @@ pub fn download_model(
         .into());
     }
 
+    let hf = venv_bin_path(&venv_dir, "hf");
+    if hf.exists() {
+        return run_command(
+            hf,
+            [
+                "download",
+                "google/gemma-4-E2B-it",
+                "--local-dir",
+                &model_dir.to_string_lossy(),
+            ],
+            Some(("HF_ENDPOINT", hf_endpoint)),
+        );
+    }
+
     run_command(
         python,
         [
-            "-m",
-            "huggingface_hub.commands.huggingface_cli",
-            "download",
-            "google/gemma-4-E4B-it",
-            "--local-dir",
-            &model_dir.to_string_lossy(),
+            "-c",
+            "from huggingface_hub import snapshot_download; snapshot_download(repo_id='google/gemma-4-E2B-it', local_dir=r'''__MODEL_DIR__''')"
+                .replace("__MODEL_DIR__", &model_dir.to_string_lossy())
+                .as_str(),
         ],
         Some(("HF_ENDPOINT", hf_endpoint)),
     )
@@ -150,11 +195,48 @@ pub(crate) fn venv_python_path(venv_dir: &Path) -> PathBuf {
     }
 }
 
+fn venv_bin_path(venv_dir: &Path, executable: &str) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        venv_dir.join("Scripts").join(format!("{executable}.exe"))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        venv_dir.join("bin").join(executable)
+    }
+}
+
+pub(crate) fn find_uv() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("UV")
+        && !path.is_empty()
+    {
+        let uv = PathBuf::from(path);
+        if command_succeeds(&uv, ["--version"]) {
+            return Some(uv);
+        }
+    }
+
+    let uv = PathBuf::from("uv");
+    command_succeeds(&uv, ["--version"]).then_some(uv)
+}
+
+pub fn detect_python_runtime() -> Result<PythonRuntime, Box<dyn std::error::Error>> {
+    let python = find_python()?;
+    let version = python_version(&python)?;
+    Ok(PythonRuntime {
+        python,
+        version,
+        uv: find_uv(),
+    })
+}
+
 fn find_python() -> Result<PathBuf, Box<dyn std::error::Error>> {
     if let Ok(path) = std::env::var("PYTHON")
         && !path.is_empty()
     {
-        return Ok(PathBuf::from(path));
+        let python = PathBuf::from(path);
+        ensure_supported_python(&python)?;
+        return Ok(python);
     }
 
     #[cfg(target_os = "windows")]
@@ -163,17 +245,76 @@ fn find_python() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let candidates = ["python3", "python"];
 
     for candidate in candidates {
-        let status = Command::new(candidate)
-            .arg("--version")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-        if status.is_ok_and(|status| status.success()) {
-            return Ok(PathBuf::from(candidate));
+        let python = PathBuf::from(candidate);
+        if ensure_supported_python(&python).is_ok() {
+            return Ok(python);
         }
     }
 
-    Err("python executable not found".into())
+    Err(format!(
+        "python executable not found, or no supported version >= {}.{} is available",
+        MIN_PYTHON_MAJOR, MIN_PYTHON_MINOR
+    )
+    .into())
+}
+
+fn ensure_supported_python(python: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let (major, minor) = python_version(python)?;
+    if is_supported_python_version(major, minor) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Python {}.{} is not supported; require >= {}.{}",
+            major, minor, MIN_PYTHON_MAJOR, MIN_PYTHON_MINOR
+        )
+        .into())
+    }
+}
+
+fn python_version(python: &Path) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+    let output = Command::new(python)
+        .args([
+            "-c",
+            "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(format!("failed to query python version from {}", python.display()).into());
+    }
+
+    parse_python_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_python_version(version: &str) -> Result<(u32, u32), Box<dyn std::error::Error>> {
+    let version = version.trim();
+    let mut parts = version.split('.');
+    let major = parts
+        .next()
+        .ok_or("missing python major version")?
+        .parse::<u32>()?;
+    let minor = parts
+        .next()
+        .ok_or("missing python minor version")?
+        .parse::<u32>()?;
+    Ok((major, minor))
+}
+
+fn is_supported_python_version(major: u32, minor: u32) -> bool {
+    major > MIN_PYTHON_MAJOR || (major == MIN_PYTHON_MAJOR && minor >= MIN_PYTHON_MINOR)
+}
+
+fn command_succeeds<I, S>(program: &Path, args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    Command::new(program)
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 fn run_command<I, S>(
@@ -232,8 +373,12 @@ mod tests {
             "accelerate",
             "fastapi",
             "huggingface_hub",
+            "librosa",
+            "multipart",
+            "PIL",
             "soundfile",
             "torch",
+            "torchvision",
             "transformers",
             "uvicorn",
         ] {
@@ -242,6 +387,35 @@ mod tests {
                 "missing package in dependency check: {package}"
             );
         }
+    }
+
+    #[test]
+    fn test_parse_python_version() {
+        assert_eq!(parse_python_version("3.10\n").unwrap(), (3, 10));
+        assert_eq!(parse_python_version("3.12").unwrap(), (3, 12));
+    }
+
+    #[test]
+    fn test_parse_python_version_rejects_invalid_input() {
+        assert!(parse_python_version("3").is_err());
+        assert!(parse_python_version("").is_err());
+    }
+
+    #[test]
+    fn test_python_version_support_floor() {
+        assert!(!is_supported_python_version(3, 9));
+        assert!(is_supported_python_version(3, 10));
+        assert!(is_supported_python_version(3, 11));
+        assert!(is_supported_python_version(4, 0));
+    }
+
+    #[test]
+    fn test_detect_python_runtime_reports_supported_version() {
+        let runtime = detect_python_runtime().unwrap();
+        assert!(is_supported_python_version(
+            runtime.version.0,
+            runtime.version.1
+        ));
     }
 
     #[cfg(feature = "integration")]

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -2,7 +2,7 @@ pub mod installer;
 pub mod service;
 
 pub use installer::{
-    dependencies_installed, download_model, install_requirements, model_weights_present,
-    setup_venv, verify_install,
+    PythonRuntime, dependencies_installed, detect_python_runtime, download_model,
+    install_requirements, model_weights_present, setup_venv, verify_install,
 };
 pub use service::LocalServiceManager;

--- a/src/local/service.rs
+++ b/src/local/service.rs
@@ -1,12 +1,14 @@
-use crate::local::installer::venv_python_path;
+use crate::local::installer::{find_uv, venv_python_path};
 use reqwest::StatusCode;
-use std::fs::{self, File};
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(120);
-const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const HEALTH_INITIAL_DELAY: Duration = Duration::from_secs(20);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Runtime status for the local inference service.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,9 +50,7 @@ impl LocalServiceManager {
         venv_dir: PathBuf,
         quantization: String,
     ) -> Self {
-        let log_file = model_dir
-            .parent()
-            .map(|dir| dir.join("server.log"));
+        let log_file = model_dir.parent().map(Self::default_log_file_path);
         Self {
             port,
             model_dir,
@@ -64,50 +64,117 @@ impl LocalServiceManager {
 
     /// Spawns the local server process and waits for health.
     pub fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.cleanup_stale_pid_file();
         if self.is_running()
-            && health_check(&self.base_url(), HEALTH_TIMEOUT, HEALTH_POLL_INTERVAL).is_ok()
+            && health_check(
+                &self.base_url(),
+                HEALTH_TIMEOUT,
+                HEALTH_INITIAL_DELAY,
+                HEALTH_POLL_INTERVAL,
+            )
+            .is_ok()
         {
             return Ok(());
         }
 
-        fs::create_dir_all(self.state_dir())?;
+        fs::create_dir_all(self.state_dir()).map_err(|error| {
+            format!(
+                "failed to create local service state dir {}: {error}",
+                self.state_dir().display()
+            )
+        })?;
 
         let python = venv_python_path(&self.venv_dir);
         if !python.exists() {
             return Err(format!("local Python interpreter not found: {}", python.display()).into());
         }
         if !self.model_dir.exists() {
-            return Err(format!("local model directory not found: {}", self.model_dir.display()).into());
+            return Err(format!(
+                "local model directory not found: {}",
+                self.model_dir.display()
+            )
+            .into());
         }
 
-        let stderr_stdio = match &self.log_file {
-            Some(path) => Stdio::from(File::create(path)?),
-            None => Stdio::null(),
+        let (stdout_stdio, stderr_stdio) = self.log_stdio()?;
+
+        let script_path = self.server_script_path();
+        let child = match find_uv() {
+            Some(uv) => {
+                let mut uv_command = Command::new(&uv);
+                uv_command.args(server_launch_args(
+                    &python,
+                    &script_path,
+                    &self.model_dir,
+                    self.port,
+                    &self.quantization,
+                ));
+                uv_command
+                    .stdin(Stdio::null())
+                    .stdout(stdout_stdio)
+                    .stderr(stderr_stdio);
+
+                match uv_command.spawn() {
+                    Ok(child) => child,
+                    Err(uv_error) => {
+                        let (stdout, stderr) = self.log_stdio()?;
+                        let mut python_command = Command::new(&python);
+                        python_command
+                            .arg(&script_path)
+                            .arg("--model-dir")
+                            .arg(&self.model_dir)
+                            .arg("--port")
+                            .arg(self.port.to_string())
+                            .arg("--quantization")
+                            .arg(&self.quantization)
+                            .stdin(Stdio::null())
+                            .stdout(stdout)
+                            .stderr(stderr);
+                        python_command.spawn().map_err(|python_error| {
+                            format!(
+                                "failed to start local service with uv ({uv_error}) and direct python ({python_error})"
+                            )
+                        })?
+                    }
+                }
+            }
+            None => {
+                let mut python_command = Command::new(&python);
+                python_command
+                    .arg(&script_path)
+                    .arg("--model-dir")
+                    .arg(&self.model_dir)
+                    .arg("--port")
+                    .arg(self.port.to_string())
+                    .arg("--quantization")
+                    .arg(&self.quantization)
+                    .stdin(Stdio::null())
+                    .stdout(stdout_stdio)
+                    .stderr(stderr_stdio);
+                python_command
+                    .spawn()
+                    .map_err(|error| format!("failed to start local service with direct python: {error}"))?
+            }
         };
 
-        let child = Command::new(python)
-            .arg(self.server_script_path())
-            .arg("--model-dir")
-            .arg(&self.model_dir)
-            .arg("--port")
-            .arg(self.port.to_string())
-            .arg("--quantization")
-            .arg(&self.quantization)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(stderr_stdio)
-            .spawn()?;
-
-        fs::write(self.pid_file_path(), child.id().to_string())?;
+        fs::write(self.pid_file_path(), child.id().to_string()).map_err(|error| {
+            format!(
+                "failed to write local service pid file {}: {error}",
+                self.pid_file_path().display()
+            )
+        })?;
         self.process = Some(child);
         self.owned = true;
 
-        if let Err(error) = health_check(&self.base_url(), HEALTH_TIMEOUT, HEALTH_POLL_INTERVAL) {
+        if let Err(error) = health_check(
+            &self.base_url(),
+            HEALTH_TIMEOUT,
+            HEALTH_INITIAL_DELAY,
+            HEALTH_POLL_INTERVAL,
+        )
+        {
             let msg = match &self.log_file {
-                Some(path) => format!(
-                    "{error} (see server log for details: {})",
-                    path.display()
-                ),
+                Some(path) => format!("{error} (see server log for details: {})", path.display()),
                 None => error.to_string(),
             };
             self.stop();
@@ -125,7 +192,9 @@ impl LocalServiceManager {
             self.read_pid()
         };
 
-        if let Some(pid) = pid {
+        if let Some(pid) = pid
+            && is_pid_running(pid)
+        {
             let _ = terminate_pid(pid);
             wait_for_exit_or_kill(pid);
         }
@@ -160,22 +229,31 @@ impl LocalServiceManager {
         format!("http://127.0.0.1:{}", self.port)
     }
 
+    pub fn default_log_file_path(base_dir: &Path) -> PathBuf {
+        base_dir.join("server.log")
+    }
+
     /// Returns the best-effort persisted service status.
     pub fn status(&self) -> Result<LocalServiceStatus, Box<dyn std::error::Error>> {
-        let pid = self.read_pid().or_else(|| self.process.as_ref().map(Child::id));
+        let pid = self
+            .read_pid()
+            .or_else(|| self.process.as_ref().map(Child::id));
         let running = pid.is_some_and(is_pid_running);
+        if pid.is_some() && !running {
+            let _ = fs::remove_file(self.pid_file_path());
+        }
         let health = match health_once(&self.base_url()) {
             Ok(StatusCode::OK) => "ok".to_string(),
             Ok(status) => format!("http {}", status.as_u16()),
             Err(error) => error.to_string(),
         };
-        let memory_usage = pid.and_then(read_memory_usage);
+        let memory_usage = if running { pid.and_then(read_memory_usage) } else { None };
 
         Ok(LocalServiceStatus {
             running,
             port: self.port,
             health,
-            pid,
+            pid: if running { pid } else { None },
             memory_usage,
         })
     }
@@ -200,6 +278,40 @@ impl LocalServiceManager {
             .ok()
             .and_then(|value| value.trim().parse::<u32>().ok())
     }
+
+    fn cleanup_stale_pid_file(&self) {
+        if self.read_pid().is_some_and(|pid| !is_pid_running(pid)) {
+            let _ = fs::remove_file(self.pid_file_path());
+        }
+    }
+
+    fn log_stdio(&self) -> Result<(Stdio, Stdio), Box<dyn std::error::Error>> {
+        let Some(path) = &self.log_file else {
+            return Ok((Stdio::null(), Stdio::null()));
+        };
+
+        File::create(path).map_err(|error| {
+            format!(
+                "failed to create local service log file {}: {error}",
+                path.display()
+            )
+        })?;
+
+        let stdout = OpenOptions::new().append(true).open(path).map_err(|error| {
+            format!(
+                "failed to open local service log file for stdout {}: {error}",
+                path.display()
+            )
+        })?;
+        let stderr = OpenOptions::new().append(true).open(path).map_err(|error| {
+            format!(
+                "failed to open local service log file for stderr {}: {error}",
+                path.display()
+            )
+        })?;
+
+        Ok((Stdio::from(stdout), Stdio::from(stderr)))
+    }
 }
 
 /// Locates a file inside the `server/` directory, trying the packaged location
@@ -220,9 +332,33 @@ fn find_server_file(filename: &str) -> PathBuf {
         .join(filename)
 }
 
+fn server_launch_args(
+    python: &Path,
+    script_path: &Path,
+    model_dir: &Path,
+    port: u16,
+    quantization: &str,
+) -> Vec<OsString> {
+    vec![
+        OsString::from("run"),
+        OsString::from("--python"),
+        python.as_os_str().to_os_string(),
+        OsString::from("--no-project"),
+        python.as_os_str().to_os_string(),
+        script_path.as_os_str().to_os_string(),
+        OsString::from("--model-dir"),
+        model_dir.as_os_str().to_os_string(),
+        OsString::from("--port"),
+        OsString::from(port.to_string()),
+        OsString::from("--quantization"),
+        OsString::from(quantization),
+    ]
+}
+
 fn health_check(
     base_url: &str,
     timeout: Duration,
+    initial_delay: Duration,
     poll_interval: Duration,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::blocking::Client::builder()
@@ -231,6 +367,8 @@ fn health_check(
     let deadline = Instant::now() + timeout;
     let url = format!("{base_url}/health");
     let mut last_error = "health check did not start".to_string();
+
+    std::thread::sleep(initial_delay);
 
     while Instant::now() < deadline {
         match client.get(&url).send() {
@@ -310,7 +448,8 @@ fn is_pid_running(pid: u32) -> bool {
             .output()
             .ok()
             .map(|output| {
-                output.status.success() && !String::from_utf8_lossy(&output.stdout).trim().is_empty()
+                output.status.success()
+                    && !String::from_utf8_lossy(&output.stdout).trim().is_empty()
             })
             .unwrap_or(false)
     }
@@ -342,7 +481,11 @@ fn read_memory_usage(pid: u32) -> Option<String> {
             .output()
             .ok()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let columns = stdout.trim().trim_matches('"').split("\",\"").collect::<Vec<_>>();
+        let columns = stdout
+            .trim()
+            .trim_matches('"')
+            .split("\",\"")
+            .collect::<Vec<_>>();
         columns.get(4).map(|value| value.to_string())
     }
 
@@ -397,6 +540,7 @@ mod tests {
         let result = health_check(
             &format!("http://127.0.0.1:{port}"),
             Duration::from_secs(1),
+            Duration::from_secs(0),
             Duration::from_millis(25),
         );
         assert!(result.is_ok());
@@ -405,10 +549,15 @@ mod tests {
     #[test]
     fn test_health_check_times_out_on_unhealthy_server() {
         let port = 18766;
-        spawn_health_stub(port, "HTTP/1.1 503 Service Unavailable", "{\"status\":\"loading\"}");
+        spawn_health_stub(
+            port,
+            "HTTP/1.1 503 Service Unavailable",
+            "{\"status\":\"loading\"}",
+        );
         let result = health_check(
             &format!("http://127.0.0.1:{port}"),
             Duration::from_millis(150),
+            Duration::from_secs(0),
             Duration::from_millis(25),
         );
         assert!(result.is_err());
@@ -420,5 +569,57 @@ mod tests {
             pid_file_path(Path::new("/tmp/viberwhisper")),
             PathBuf::from("/tmp/viberwhisper/local_server.pid")
         );
+    }
+
+    #[test]
+    fn test_server_launch_args_uses_uv_run_with_explicit_python() {
+        let args = server_launch_args(
+            Path::new("/tmp/venv/bin/python"),
+            Path::new("/tmp/server.py"),
+            Path::new("/tmp/model"),
+            17265,
+            "int8",
+        );
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "--python",
+                "/tmp/venv/bin/python",
+                "--no-project",
+                "/tmp/venv/bin/python",
+                "/tmp/server.py",
+                "--model-dir",
+                "/tmp/model",
+                "--port",
+                "17265",
+                "--quantization",
+                "int8",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_status_clears_stale_pid_file() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "viberwhisper-local-service-{}",
+            std::process::id()
+        ));
+        let model_dir = temp_dir.join("model");
+        let venv_dir = temp_dir.join("venv");
+        fs::create_dir_all(&model_dir).unwrap();
+        fs::write(temp_dir.join("local_server.pid"), "999999").unwrap();
+
+        let manager = LocalServiceManager::new(17265, model_dir, venv_dir);
+        let status = manager.status().unwrap();
+
+        assert!(!status.running);
+        assert_eq!(status.pid, None);
+        assert!(!temp_dir.join("local_server.pid").exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,14 @@ use clap::Parser;
 use core::cli::{Cli, Commands, ConfigAction, LocalCommand};
 use core::config::AppConfig;
 use local::{
-    LocalServiceManager, dependencies_installed, download_model, install_requirements,
-    model_weights_present, setup_venv, verify_install,
+    LocalServiceManager, PythonRuntime, dependencies_installed, detect_python_runtime,
+    download_model, install_requirements, model_weights_present, setup_venv, verify_install,
 };
 use std::path::PathBuf;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 
-const LOCAL_MODEL_NAME: &str = "gemma-4-E4B-it";
+const LOCAL_MODEL_NAME: &str = "gemma-4-E2B-it";
 
 struct LocalServiceGuard(Option<LocalServiceManager>);
 
@@ -142,6 +142,9 @@ fn ensure_local_install(
     let paths = local_paths(config)?;
     let hf_endpoint =
         std::env::var("HF_ENDPOINT").unwrap_or_else(|_| "https://huggingface.co".to_string());
+    let runtime = detect_python_runtime()?;
+
+    print_python_runtime(&runtime);
 
     println!("[local] step 1/4 – python venv");
     setup_venv(&paths.venv_dir)?;
@@ -159,7 +162,7 @@ fn ensure_local_install(
     }
 
     if !model_weights_present(&paths.model_dir) {
-        println!("[local] step 3/4 – downloading google/gemma-4-E4B-it");
+        println!("[local] step 3/4 – downloading google/gemma-4-E2B-it");
         println!("[local]   set HF_ENDPOINT env var to use a mirror");
     } else {
         println!("[local] step 3/4 – model already present, skipping download");
@@ -170,6 +173,20 @@ fn ensure_local_install(
     verify_install(&paths.venv_dir, &paths.model_dir)?;
 
     Ok(paths)
+}
+
+fn print_python_runtime(runtime: &PythonRuntime) {
+    let (major, minor) = runtime.version;
+    println!(
+        "[local] python: {} ({}.{}; require >= 3.10)",
+        runtime.python.display(),
+        major,
+        minor
+    );
+    match &runtime.uv {
+        Some(uv) => println!("[local] package runner: uv ({})", uv.display()),
+        None => println!("[local] package runner: system python fallback"),
+    }
 }
 
 fn local_paths(config: &AppConfig) -> Result<LocalPaths, Box<dyn std::error::Error>> {
@@ -698,7 +715,7 @@ mod integration_tests {
             Some("http://127.0.0.1:17265/v1/chat/completions")
         );
         assert!(local.post_process_enabled);
-        assert_eq!(local.post_process_model.as_deref(), Some("gemma-4-E4B-it"));
+        assert_eq!(local.post_process_model.as_deref(), Some("gemma-4-E2B-it"));
         assert_eq!(local.api_key.as_deref(), Some("local"));
         assert_eq!(local.post_process_api_key.as_deref(), Some("local"));
     }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -28,12 +28,7 @@ impl TextTyper for WindowsTyper {
         };
 
         if sent as usize != inputs.len() {
-            return Err(format!(
-                "SendInput only sent {}/{} events",
-                sent,
-                inputs.len()
-            )
-            .into());
+            return Err(format!("SendInput only sent {}/{} events", sent, inputs.len()).into());
         }
 
         info!(text = %text, "Text typed");

--- a/src/postprocess/llm.rs
+++ b/src/postprocess/llm.rs
@@ -49,7 +49,14 @@ impl LlmPostProcessor {
     }
 
     fn call_llm(&self, text: &str) -> Result<String, Box<dyn std::error::Error>> {
-        call_llm_impl(&self.api_key, &self.api_url, &self.model, &self.prompt, self.temperature, text)
+        call_llm_impl(
+            &self.api_key,
+            &self.api_url,
+            &self.model,
+            &self.prompt,
+            self.temperature,
+            text,
+        )
     }
 }
 
@@ -298,7 +305,10 @@ impl TextPostProcessorSession for PreheatLlmSession {
         let result = st.latest_result.take().unwrap();
         match result {
             Ok(text) => {
-                info!(result_len = text.len(), "Preheat: LLM post-processing complete");
+                info!(
+                    result_len = text.len(),
+                    "Preheat: LLM post-processing complete"
+                );
                 Ok(text)
             }
             Err(e) => {
@@ -350,8 +360,7 @@ mod tests {
     fn test_from_config_missing_model() {
         let mut config = AppConfig::default();
         config.post_process_api_key = Some("key".to_string());
-        config.post_process_api_url =
-            Some("https://example.com/v1/chat/completions".to_string());
+        config.post_process_api_url = Some("https://example.com/v1/chat/completions".to_string());
         assert!(LlmPostProcessor::from_config(&config).is_err());
     }
 
@@ -363,10 +372,7 @@ mod tests {
         let p = result.unwrap();
         assert_eq!(p.api_key, "test_key");
         assert_eq!(p.model, "gpt-4o-mini");
-        assert_eq!(
-            p.api_url,
-            "https://api.example.com/v1/chat/completions"
-        );
+        assert_eq!(p.api_url, "https://api.example.com/v1/chat/completions");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- prefer uv for local Python environment creation, dependency install, model download, and server startup
- add Python version validation with a minimum supported version of 3.10
- print the detected Python runtime and whether uv or the system Python fallback is being used during local install

## Validation
- cargo fmt --all
- cargo test installer
- cargo test service
- cargo check

Note: this PR also includes other existing changes that were already present in the working copy for this change.