### PR TITLE
refactor(server): split local runtime modules and tests

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,136 @@
+# Server Test Guide
+
+This directory contains the local Gemma server implementation and its test suite.
+
+## Test Layout
+
+- `tests/test_server.py`
+  FastAPI request/response tests.
+- `tests/test_runtime.py`
+  Runtime utility tests that do not load a real model.
+- `tests/test_chat.py`
+  Chat flow tests with stub runtime objects.
+- `tests/test_transcription.py`
+  Audio transcription flow tests with fake audio dependencies.
+- `tests/test_integration_runtime.py`
+  Real-model load and quantization checks.
+- `tests/test_integration_inference.py`
+  Real-model inference check using the fixed fixture WAV.
+
+## Default Paths
+
+- Default model directory: `~/.viberwhisper/model`
+- Default test audio: `server/tests/fixtures/test_audio.wav`
+- Real-model probe Python: the current test interpreter (`sys.executable`)
+
+The integration tests no longer take model-path or wav-path parameters. They always use the default model directory and the committed fixture audio.
+
+## Environment Setup
+
+Use a Python environment that contains the server runtime dependencies.
+
+Example:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r server/requirements.txt
+pip install pytest
+```
+
+If you already have a working local runtime environment, run the tests from that environment instead.
+
+## Running Tests
+
+Fast tests:
+
+```bash
+pytest -q server/tests
+```
+
+Real-model tests are opt-in:
+
+```bash
+VIBERWHISPER_RUN_REAL_MODEL_TESTS=1 pytest -q \
+  server/tests/test_integration_runtime.py \
+  server/tests/test_integration_inference.py
+```
+
+If you want to run everything in one go:
+
+```bash
+VIBERWHISPER_RUN_REAL_MODEL_TESTS=1 pytest -q server/tests
+```
+
+## Real-Model Test Requirements
+
+To run the integration tests successfully, all of the following must be true:
+
+- `~/.viberwhisper/model` exists and contains the downloaded model files.
+- `server/tests/fixtures/test_audio.wav` exists.
+- The current Python environment has `torch`, `transformers`, and the rest of `server/requirements.txt`.
+
+If any of these prerequisites are missing, the integration tests will skip instead of failing.
+
+## What The Real-Model Tests Verify
+
+`test_integration_runtime.py` checks:
+
+- the model can be loaded from `~/.viberwhisper/model`
+- the runtime reports `ready=True`
+- no load error is reported
+- the requested quantization mode is `int8`
+- quantization appears to be applied through the detected backend
+
+`test_integration_inference.py` checks:
+
+- the real model can transcribe the committed fixture WAV
+- the transcription result is non-empty
+- the returned language is `zh`
+- the output contains expected keywords from the fixture audio
+
+These tests intentionally validate stable expectations instead of exact full-string equality, because real model output can vary slightly across environments and library versions.
+
+## Common Failures
+
+`ModuleNotFoundError: No module named 'torch'`
+
+- You are running tests in a Python environment that does not have the runtime dependencies installed.
+- Fix: activate the environment you use for the local server, or install `server/requirements.txt` into the current environment.
+
+`default model dir missing: ~/.viberwhisper/model`
+
+- The local model has not been installed yet.
+- Fix: install or download the model into the default local runtime directory first.
+
+`default test wav missing: server/tests/fixtures/test_audio.wav`
+
+- The fixture audio is missing from the working tree.
+- Fix: restore the fixture file before running integration tests.
+
+Real-model test is skipped unexpectedly
+
+- Check that `VIBERWHISPER_RUN_REAL_MODEL_TESTS=1` is set in the same command invocation.
+- Check that the current interpreter is the one you expect by running:
+
+```bash
+python -c "import sys; print(sys.executable)"
+```
+
+Quantization test fails but load succeeds
+
+- This usually means the model loaded, but the expected quantization backend was not actually applied or could not be detected.
+- Check the runtime logs and verify whether the current machine supports the requested backend.
+- On non-CUDA environments, backend behavior may differ from CUDA-only paths.
+
+Inference test fails on keyword match
+
+- The model may have loaded correctly but produced a slightly different transcription.
+- Check the actual returned text first before tightening or changing the expected keywords.
+- If the fixture audio changes, update the expectations together with the fixture.
+
+## Maintenance Notes
+
+- Keep fixture audio small and stable. Do not replace it casually, because it anchors the real-model regression tests.
+- If you change the default local model location in the product, update the defaults in `server/tests/integration_helpers.py`.
+- If you change quantization behavior, update both the runtime probe and the integration assertions together.

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,1 @@
+"""Local server package for ViberWhisper."""

--- a/server/chat.py
+++ b/server/chat.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from fastapi import HTTPException
+
+from server.models import ChatCompletionRequest, ChatMessage
+from server.runtime import DEFAULT_MAX_NEW_TOKENS, MODEL_NAME
+
+LOGGER = logging.getLogger("viberwhisper.local_server")
+
+
+def flatten_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")))
+        return "".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def render_chat_prompt(processor: Any, messages: list[ChatMessage]) -> str:
+    normalized = [
+        {
+            "role": msg.role,
+            "content": [
+                {"type": "text", "text": flatten_content(msg.content)},
+            ],
+        }
+        for msg in messages
+    ]
+    return processor.apply_chat_template(
+        normalized,
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+
+
+def chat_complete(runtime: Any, request: ChatCompletionRequest) -> dict[str, Any]:
+    runtime.ensure_ready()
+    started_at = time.perf_counter()
+
+    if request.stream:
+        raise HTTPException(
+            status_code=400, detail="stream=true is not supported",
+        )
+
+    LOGGER.info(
+        "Starting chat completion messages=%s temperature=%s max_tokens=%s",
+        len(request.messages),
+        request.temperature,
+        request.max_tokens or DEFAULT_MAX_NEW_TOKENS,
+    )
+
+    prompt_text = render_chat_prompt(runtime.processor, request.messages)
+    content = runtime.generate_from_text(
+        prompt_text,
+        temperature=request.temperature or 0.0,
+        max_new_tokens=request.max_tokens or DEFAULT_MAX_NEW_TOKENS,
+    ).strip()
+    created = int(time.time())
+    elapsed = time.perf_counter() - started_at
+    LOGGER.info(
+        "Completed chat completion duration=%.3fs output_chars=%s",
+        elapsed,
+        len(content),
+    )
+
+    return {
+        "id": f"chatcmpl-local-{created}",
+        "object": "chat.completion",
+        "created": created,
+        "model": MODEL_NAME,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            },
+        ],
+        "usage": {
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "total_tokens": None,
+        },
+    }

--- a/server/models.py
+++ b/server/models.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: Any
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str | None = None
+    messages: list[ChatMessage]
+    temperature: float | None = 0.0
+    stream: bool | None = False
+    max_tokens: int | None = None

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,10 @@
 torch>=2.3
 transformers>=4.51
 fastapi>=0.111
+python-multipart>=0.0.9
+pillow>=10.0
+torchvision>=0.18
+librosa>=0.10
 uvicorn[standard]>=0.29
 soundfile>=0.12
 optimum-quanto>=0.2

--- a/server/runtime.py
+++ b/server/runtime.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from fastapi import HTTPException
+
+LOGGER = logging.getLogger("viberwhisper.local_server")
+MODEL_NAME = "gemma-4-E2B-it"
+DEFAULT_MAX_NEW_TOKENS = 512
+
+
+class LocalModelRuntime:
+    def __init__(self, model_dir: str, quantization: str) -> None:
+        self.model_dir = model_dir
+        self.quantization = quantization
+        self.processor: Any | None = None
+        self.model: Any | None = None
+        self.ready = False
+        self.error: str | None = None
+        self._lock = threading.Lock()
+
+    def load(self) -> None:
+        with self._lock:
+            if self.ready or self.error:
+                return
+            try:
+                target_device = self._target_device()
+                import torch
+
+                LOGGER.info(
+                    "Loading Gemma runtime from %s (%s, device=%s)",
+                    self.model_dir,
+                    self.quantization,
+                    target_device,
+                )
+                load_kwargs = self._base_load_kwargs(
+                    target_device,
+                    mps_dtype=torch.float16,
+                )
+
+                quanto_dtype = None
+                if self.quantization in ("int8", "int4"):
+                    quanto_dtype = self._try_quanto_quantization(
+                        self.quantization, load_kwargs, target_device,
+                    )
+
+                from transformers import AutoModelForMultimodalLM, AutoProcessor
+
+                LOGGER.info("Loading AutoProcessor from %s", self.model_dir)
+                processor = AutoProcessor.from_pretrained(self.model_dir)
+                LOGGER.info("AutoProcessor loaded")
+
+                LOGGER.info("Loading AutoModelForMultimodalLM with kwargs=%s", load_kwargs)
+                model = AutoModelForMultimodalLM.from_pretrained(
+                    self.model_dir, **load_kwargs,
+                )
+                LOGGER.info("AutoModelForMultimodalLM loaded")
+
+                if quanto_dtype is not None:
+                    LOGGER.info("Applying quanto quantization")
+                    self._apply_quanto(model, quanto_dtype)
+                    LOGGER.info("Quanto quantization applied")
+
+                LOGGER.info("Switching model to eval mode")
+                model.eval()
+                LOGGER.info("Model is in eval mode")
+
+                self.processor = processor
+                self.model = model
+                self.ready = True
+                LOGGER.info("Gemma runtime is ready")
+            except Exception as exc:
+                LOGGER.exception("Failed to load Gemma runtime")
+                self.error = str(exc)
+
+    @staticmethod
+    def _target_device() -> str:
+        import torch
+
+        if torch.backends.mps.is_available():
+            return "mps"
+        if torch.cuda.is_available():
+            return "cuda"
+        return "cpu"
+
+    @staticmethod
+    def _base_load_kwargs(
+        target_device: str,
+        *,
+        mps_dtype: Any | None = None,
+    ) -> dict[str, Any]:
+        if target_device == "mps":
+            return {
+                "torch_dtype": mps_dtype if mps_dtype is not None else "float16",
+                "device_map": {"": "mps"},
+                "low_cpu_mem_usage": True,
+            }
+        return {
+            "torch_dtype": "auto",
+            "device_map": "auto",
+            "low_cpu_mem_usage": True,
+        }
+
+    def health_payload(self) -> tuple[int, dict[str, Any]]:
+        if self.ready:
+            return 200, {"status": "ok", "model": MODEL_NAME}
+        if self.error:
+            return 500, {"status": "error", "model": MODEL_NAME, "error": self.error}
+        return 503, {"status": "loading", "model": MODEL_NAME}
+
+    def ensure_ready(self) -> None:
+        if self.error:
+            raise HTTPException(status_code=500, detail=self.error)
+        if not self.ready or self.model is None or self.processor is None:
+            raise HTTPException(status_code=503, detail="model is still loading")
+
+    @staticmethod
+    def _try_quanto_quantization(
+        mode: str, load_kwargs: dict[str, Any], target_device: str,
+    ) -> Any | None:
+        """Try to set up optimum-quanto quantization; fall back to bitsandbytes on CUDA."""
+        try:
+            from optimum.quanto import qint4, qint8  # noqa: F811
+
+            LOGGER.info("Using optimum-quanto for %s quantization", mode)
+            return qint8 if mode == "int8" else qint4
+        except ImportError:
+            LOGGER.info(
+                "optimum-quanto not available, falling back to bitsandbytes (%s)",
+                mode,
+            )
+
+        if target_device != "cuda":
+            LOGGER.warning(
+                "bitsandbytes quantization is only supported on CUDA; "
+                "loading model without backend quantization on %s",
+                target_device,
+            )
+            return None
+
+        try:
+            import bitsandbytes as _bnb  # noqa: F401
+
+            if mode == "int8":
+                load_kwargs["load_in_8bit"] = True
+            else:
+                load_kwargs["load_in_4bit"] = True
+            LOGGER.info("Using bitsandbytes for %s quantization (CUDA only)", mode)
+        except ImportError:
+            LOGGER.warning(
+                "Neither optimum-quanto nor bitsandbytes available; "
+                "loading model without quantization",
+            )
+        return None
+
+    @staticmethod
+    def _apply_quanto(model: Any, quanto_dtype: Any) -> None:
+        from optimum.quanto import freeze, quantize
+
+        quantize(model, weights=quanto_dtype)
+        freeze(model)
+
+    def generate_from_text(
+        self,
+        prompt_text: str,
+        *,
+        temperature: float,
+        max_new_tokens: int,
+    ) -> str:
+        self.ensure_ready()
+        assert self.processor is not None
+        assert self.model is not None
+
+        inputs = self.processor(text=prompt_text, return_tensors="pt").to(
+            self._model_device(),
+        )
+        input_len = inputs["input_ids"].shape[-1]
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            do_sample=temperature > 0,
+            temperature=max(temperature, 1e-5),
+        )
+        response = self.processor.decode(
+            outputs[0][input_len:], skip_special_tokens=False,
+        )
+        return self.extract_text_response(self.processor.parse_response(response))
+
+    def generate_from_audio(self, prompt_text: str, audio_path: str) -> str:
+        self.ensure_ready()
+        assert self.processor is not None
+        assert self.model is not None
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio", "audio": audio_path},
+                    {"type": "text", "text": prompt_text},
+                ],
+            },
+        ]
+        inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+            add_generation_prompt=True,
+        ).to(self._model_device())
+        input_len = inputs["input_ids"].shape[-1]
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=DEFAULT_MAX_NEW_TOKENS,
+            do_sample=False,
+        )
+        response = self.processor.decode(
+            outputs[0][input_len:], skip_special_tokens=False,
+        )
+        return self.extract_text_response(self.processor.parse_response(response))
+
+    def quantization_state(self) -> dict[str, Any]:
+        model = self.model
+        if model is None:
+            return {
+                "requested": self.quantization,
+                "device": None,
+                "backend": "unloaded",
+                "applied": False,
+            }
+
+        backend = "none"
+        mode = None
+
+        if getattr(model, "is_loaded_in_8bit", False):
+            backend = "bitsandbytes"
+            mode = "int8"
+        elif getattr(model, "is_loaded_in_4bit", False):
+            backend = "bitsandbytes"
+            mode = "int4"
+
+        quantization_config = getattr(model, "quantization_config", None)
+        if backend == "none" and quantization_config is not None:
+            backend_name = type(quantization_config).__name__.lower()
+            backend = "bitsandbytes" if "bits" in backend_name else backend_name
+            if getattr(quantization_config, "load_in_8bit", False):
+                mode = "int8"
+            elif getattr(quantization_config, "load_in_4bit", False):
+                mode = "int4"
+
+        if backend == "none":
+            for module in model.modules():
+                module_name = type(module).__name__.lower()
+                module_mod = type(module).__module__.lower()
+                if "quanto" in module_name or "quanto" in module_mod:
+                    backend = "optimum-quanto"
+                    mode = self.quantization if self.quantization in {"int4", "int8"} else None
+                    break
+
+        return {
+            "requested": self.quantization,
+            "device": self._model_device(),
+            "backend": backend,
+            "mode": mode,
+            "applied": backend not in {"none", "unloaded"},
+        }
+
+    @staticmethod
+    def extract_text_response(parsed: Any) -> str:
+        if isinstance(parsed, str):
+            return parsed
+        if isinstance(parsed, dict):
+            for key in ("text", "content", "response", "output"):
+                value = parsed.get(key)
+                if isinstance(value, str):
+                    return value
+            LOGGER.error("Parsed response dict did not contain a text field: %s", parsed)
+            raise ValueError("parsed response did not contain a text field")
+        if parsed is None:
+            LOGGER.error("Parsed response was None")
+            raise ValueError("parsed response was None")
+
+        LOGGER.error("Parsed response had unsupported type %s: %r", type(parsed).__name__, parsed)
+        raise ValueError(f"unsupported parsed response type: {type(parsed).__name__}")
+
+    def _model_device(self) -> str:
+        assert self.model is not None
+        device = getattr(self.model, "device", None)
+        if device is not None:
+            return str(device)
+        return self._target_device()

--- a/server/server.py
+++ b/server/server.py
@@ -2,330 +2,94 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import io
 import logging
-import os
-import tempfile
 import threading
 import time
+import uuid
 from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+
+from server.chat import chat_complete
+from server.models import ChatCompletionRequest
+from server.runtime import LocalModelRuntime, MODEL_NAME
+from server.transcription import transcribe_audio
 
 LOGGER = logging.getLogger("viberwhisper.local_server")
-MODEL_NAME = "gemma-4-E4B-it"
-DEFAULT_MAX_NEW_TOKENS = 512
-
-
-class ChatMessage(BaseModel):
-    role: str
-    content: Any
-
-
-class ChatCompletionRequest(BaseModel):
-    model: str | None = None
-    messages: list[ChatMessage]
-    temperature: float | None = 0.0
-    stream: bool | None = False
-    max_tokens: int | None = None
-
-
-class LocalModelRuntime:
-    def __init__(self, model_dir: str, quantization: str) -> None:
-        self.model_dir = model_dir
-        self.quantization = quantization
-        self.processor: Any | None = None
-        self.model: Any | None = None
-        self.ready = False
-        self.error: str | None = None
-        self._lock = threading.Lock()
-
-    def load(self) -> None:
-        with self._lock:
-            if self.ready or self.error:
-                return
-            try:
-                LOGGER.info(
-                    "Loading Gemma runtime from %s (%s)",
-                    self.model_dir,
-                    self.quantization,
-                )
-                load_kwargs: dict[str, Any] = {
-                    "dtype": "auto",
-                    "device_map": "auto",
-                    "low_cpu_mem_usage": True,
-                }
-
-                quanto_dtype = None
-                if self.quantization in ("int8", "int4"):
-                    quanto_dtype = self._try_quanto_quantization(
-                        self.quantization, load_kwargs,
-                    )
-
-                from transformers import AutoModelForCausalLM, AutoProcessor
-
-                processor = AutoProcessor.from_pretrained(self.model_dir)
-                model = AutoModelForCausalLM.from_pretrained(
-                    self.model_dir, **load_kwargs,
-                )
-
-                if quanto_dtype is not None:
-                    self._apply_quanto(model, quanto_dtype)
-
-                model.eval()
-
-                self.processor = processor
-                self.model = model
-                self.ready = True
-                LOGGER.info("Gemma runtime is ready")
-            except Exception as exc:
-                LOGGER.exception("Failed to load Gemma runtime")
-                self.error = str(exc)
-
-    def health_payload(self) -> tuple[int, dict[str, Any]]:
-        if self.ready:
-            return 200, {"status": "ok", "model": MODEL_NAME}
-        if self.error:
-            return 500, {"status": "error", "model": MODEL_NAME, "error": self.error}
-        return 503, {"status": "loading", "model": MODEL_NAME}
-
-    def ensure_ready(self) -> None:
-        if self.error:
-            raise HTTPException(status_code=500, detail=self.error)
-        if not self.ready or self.model is None or self.processor is None:
-            raise HTTPException(status_code=503, detail="model is still loading")
-
-    def transcribe_audio(
-        self,
-        wav_bytes: bytes,
-        language: str | None,
-        prompt: str | None,
-    ) -> dict[str, Any]:
-        self.ensure_ready()
-
-        import soundfile as sf
-
-        samples, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
-        if len(samples.shape) > 1:
-            samples = samples.mean(axis=1)
-        duration = float(len(samples) / sample_rate) if sample_rate else 0.0
-        if duration > 30.0:
-            raise HTTPException(
-                status_code=400, detail="audio duration exceeds 30 seconds",
-            )
-
-        instruction = self._build_transcription_prompt(language, prompt)
-
-        tmp_path: str | None = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-                sf.write(tmp.name, samples, sample_rate)
-                tmp_path = tmp.name
-            text = self._generate_from_audio(instruction, tmp_path)
-        finally:
-            if tmp_path and os.path.exists(tmp_path):
-                os.unlink(tmp_path)
-
-        return {
-            "text": text.strip(),
-            "language": language or "auto",
-            "duration": round(duration, 3),
-        }
-
-    def chat_complete(self, request: ChatCompletionRequest) -> dict[str, Any]:
-        self.ensure_ready()
-
-        if request.stream:
-            raise HTTPException(
-                status_code=400, detail="stream=true is not supported",
-            )
-
-        prompt_text = self._render_chat_prompt(request.messages)
-        content = self._generate_from_text(
-            prompt_text,
-            temperature=request.temperature or 0.0,
-            max_new_tokens=request.max_tokens or DEFAULT_MAX_NEW_TOKENS,
-        ).strip()
-        created = int(time.time())
-
-        return {
-            "id": f"chatcmpl-local-{created}",
-            "object": "chat.completion",
-            "created": created,
-            "model": MODEL_NAME,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {"role": "assistant", "content": content},
-                    "finish_reason": "stop",
-                },
-            ],
-            "usage": {
-                "prompt_tokens": None,
-                "completion_tokens": None,
-                "total_tokens": None,
-            },
-        }
-
-    @staticmethod
-    def _try_quanto_quantization(
-        mode: str, load_kwargs: dict[str, Any],
-    ) -> Any | None:
-        """Try to set up optimum-quanto quantization; fall back to bitsandbytes on CUDA."""
-        try:
-            from optimum.quanto import qint4, qint8  # noqa: F811
-
-            LOGGER.info("Using optimum-quanto for %s quantization", mode)
-            return qint8 if mode == "int8" else qint4
-        except ImportError:
-            LOGGER.info(
-                "optimum-quanto not available, falling back to bitsandbytes (%s)",
-                mode,
-            )
-
-        try:
-            import bitsandbytes as _bnb  # noqa: F401
-
-            if mode == "int8":
-                load_kwargs["load_in_8bit"] = True
-            else:
-                load_kwargs["load_in_4bit"] = True
-            LOGGER.info("Using bitsandbytes for %s quantization (CUDA only)", mode)
-        except ImportError:
-            LOGGER.warning(
-                "Neither optimum-quanto nor bitsandbytes available; "
-                "loading model without quantization",
-            )
-        return None
-
-    @staticmethod
-    def _apply_quanto(model: Any, quanto_dtype: Any) -> None:
-        from optimum.quanto import freeze, quantize
-
-        quantize(model, weights=quanto_dtype)
-        freeze(model)
-
-    def _build_transcription_prompt(
-        self, language: str | None, prompt: str | None,
-    ) -> str:
-        parts = [
-            "Transcribe the provided audio accurately.",
-            "Return only the transcription text.",
-        ]
-        if language:
-            parts.append(f"Expected language: {language}.")
-        if prompt:
-            parts.append(f"Additional context: {prompt}")
-        return " ".join(parts)
-
-    def _render_chat_prompt(self, messages: list[ChatMessage]) -> str:
-        assert self.processor is not None
-        normalized = [
-            {
-                "role": msg.role,
-                "content": [
-                    {"type": "text", "text": self._flatten_content(msg.content)},
-                ],
-            }
-            for msg in messages
-        ]
-        return self.processor.apply_chat_template(
-            normalized,
-            tokenize=False,
-            add_generation_prompt=True,
-            enable_thinking=False,
-        )
-
-    def _flatten_content(self, content: Any) -> str:
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            parts: list[str] = []
-            for item in content:
-                if isinstance(item, str):
-                    parts.append(item)
-                elif isinstance(item, dict) and item.get("type") == "text":
-                    parts.append(str(item.get("text", "")))
-            return "".join(parts)
-        if content is None:
-            return ""
-        return str(content)
-
-    def _generate_from_text(
-        self,
-        prompt_text: str,
-        *,
-        temperature: float,
-        max_new_tokens: int,
-    ) -> str:
-        assert self.processor is not None
-        assert self.model is not None
-
-        inputs = self.processor(text=prompt_text, return_tensors="pt").to(
-            self.model.device,
-        )
-        input_len = inputs["input_ids"].shape[-1]
-        outputs = self.model.generate(
-            **inputs,
-            max_new_tokens=max_new_tokens,
-            do_sample=temperature > 0,
-            temperature=max(temperature, 1e-5),
-        )
-        response = self.processor.decode(
-            outputs[0][input_len:], skip_special_tokens=False,
-        )
-        return self.processor.parse_response(response)
-
-    def _generate_from_audio(self, prompt_text: str, audio_path: str) -> str:
-        assert self.processor is not None
-        assert self.model is not None
-
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "audio", "audio": audio_path},
-                    {"type": "text", "text": prompt_text},
-                ],
-            },
-        ]
-        inputs = self.processor.apply_chat_template(
-            messages,
-            tokenize=True,
-            return_dict=True,
-            return_tensors="pt",
-            add_generation_prompt=True,
-        ).to(self.model.device)
-        input_len = inputs["input_ids"].shape[-1]
-        outputs = self.model.generate(
-            **inputs,
-            max_new_tokens=DEFAULT_MAX_NEW_TOKENS,
-            do_sample=False,
-        )
-        response = self.processor.decode(
-            outputs[0][input_len:], skip_special_tokens=False,
-        )
-        return self.processor.parse_response(response)
 
 
 def create_app(runtime: LocalModelRuntime) -> FastAPI:
     @asynccontextmanager
     async def lifespan(_: FastAPI):
+        LOGGER.info("Starting background model load thread")
         thread = threading.Thread(target=runtime.load, daemon=True)
         thread.start()
         yield
+        LOGGER.info("Shutting down local Gemma service")
 
     app = FastAPI(
         title="ViberWhisper Local Gemma Service",
         lifespan=lifespan,
     )
 
+    @app.middleware("http")
+    async def log_requests(request: Request, call_next):
+        request_id = uuid.uuid4().hex[:8]
+        started_at = time.perf_counter()
+        LOGGER.info(
+            "Request started id=%s method=%s path=%s client=%s",
+            request_id,
+            request.method,
+            request.url.path,
+            request.client.host if request.client else "unknown",
+        )
+        try:
+            response = await call_next(request)
+        except Exception:
+            elapsed = time.perf_counter() - started_at
+            LOGGER.exception(
+                "Request failed id=%s method=%s path=%s duration=%.3fs",
+                request_id,
+                request.method,
+                request.url.path,
+                elapsed,
+            )
+            raise
+
+        elapsed = time.perf_counter() - started_at
+        LOGGER.info(
+            "Request completed id=%s method=%s path=%s status=%s duration=%.3fs",
+            request_id,
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed,
+        )
+        return response
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
+        LOGGER.warning(
+            "HTTP exception status=%s detail=%s",
+            exc.status_code,
+            exc.detail,
+        )
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+        LOGGER.exception("Unhandled server exception")
+        return JSONResponse(
+            status_code=500,
+            content={"detail": str(exc)},
+        )
+
     @app.get("/health")
     def health() -> JSONResponse:
         status_code, payload = runtime.health_payload()
+        LOGGER.info("Health check status=%s payload=%s", status_code, payload)
         return JSONResponse(status_code=status_code, content=payload)
 
     @app.post("/v1/audio/transcriptions")
@@ -339,13 +103,26 @@ def create_app(runtime: LocalModelRuntime) -> FastAPI:
     ) -> dict[str, Any]:
         del model, temperature, response_format
         wav_bytes = await file.read()
+        LOGGER.info(
+            "Audio transcription request filename=%s content_type=%s bytes=%s language=%s",
+            file.filename,
+            file.content_type,
+            len(wav_bytes),
+            language or "auto",
+        )
         return await asyncio.to_thread(
-            runtime.transcribe_audio, wav_bytes, language, prompt,
+            transcribe_audio, runtime, wav_bytes, language, prompt,
         )
 
     @app.post("/v1/chat/completions")
     async def chat_completions(request: ChatCompletionRequest) -> dict[str, Any]:
-        return await asyncio.to_thread(runtime.chat_complete, request)
+        LOGGER.info(
+            "Chat completion request model=%s messages=%s stream=%s",
+            request.model or MODEL_NAME,
+            len(request.messages),
+            request.stream,
+        )
+        return await asyncio.to_thread(chat_complete, runtime, request)
 
     return app
 
@@ -368,6 +145,12 @@ def main() -> None:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
     args = parse_args()
+    LOGGER.info(
+        "Launching local Gemma service model_dir=%s port=%s quantization=%s",
+        args.model_dir,
+        args.port,
+        args.quantization,
+    )
     runtime = LocalModelRuntime(args.model_dir, args.quantization)
     app = create_app(runtime)
     uvicorn.run(app, host="127.0.0.1", port=args.port, log_level="info")

--- a/server/test_asr_client.py
+++ b/server/test_asr_client.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Send a WAV file to the local Gemma ASR endpoint and print the result.",
+    )
+    parser.add_argument("wav_path", help="Path to a WAV file")
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:17265/v1/audio/transcriptions",
+        help="ASR endpoint URL",
+    )
+    parser.add_argument("--language", help="Optional language hint")
+    parser.add_argument("--prompt", help="Optional extra transcription prompt")
+    parser.add_argument(
+        "--expect",
+        help="Optional substring expected to appear in the transcription output",
+    )
+    return parser.parse_args()
+
+
+def build_multipart_body(
+    wav_path: Path,
+    *,
+    language: str | None,
+    prompt: str | None,
+) -> tuple[bytes, str]:
+    boundary = "----ViberWhisperASRBoundary"
+    crlf = b"\r\n"
+    parts: list[bytes] = []
+
+    def add_field(name: str, value: str) -> None:
+        parts.extend(
+            [
+                f"--{boundary}".encode(),
+                f'Content-Disposition: form-data; name="{name}"'.encode(),
+                b"",
+                value.encode("utf-8"),
+            ]
+        )
+
+    add_field("model", "gemma-4-E2B-it")
+    if language:
+        add_field("language", language)
+    if prompt:
+        add_field("prompt", prompt)
+
+    parts.extend(
+        [
+            f"--{boundary}".encode(),
+            (
+                f'Content-Disposition: form-data; name="file"; filename="{wav_path.name}"'
+            ).encode(),
+            b"Content-Type: audio/wav",
+            b"",
+            wav_path.read_bytes(),
+            f"--{boundary}--".encode(),
+            b"",
+        ]
+    )
+
+    return crlf.join(parts), boundary
+
+
+def main() -> int:
+    args = parse_args()
+    wav_path = Path(args.wav_path)
+    if not wav_path.is_file():
+        print(f"missing wav file: {wav_path}", file=sys.stderr)
+        return 2
+
+    body, boundary = build_multipart_body(
+        wav_path,
+        language=args.language,
+        prompt=args.prompt,
+    )
+    request = urllib.request.Request(
+        args.url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "Accept": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        print(f"HTTP {error.code}: {body}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as error:
+        print(f"request failed: {error}", file=sys.stderr)
+        return 1
+
+    text = payload.get("text", "")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    if args.expect and args.expect not in text:
+        print(
+            f"expected substring not found: {args.expect!r} not in transcription",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/tests/integration_helpers.py
+++ b/server/tests/integration_helpers.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_MODEL_DIR = Path.home() / ".viberwhisper" / "model"
+DEFAULT_TEST_WAV = Path(__file__).resolve().parent / "fixtures" / "test_audio.wav"
+DEFAULT_RUNTIME_PYTHON = Path(sys.executable)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_REAL_TESTS_ENV = "VIBERWHISPER_RUN_REAL_MODEL_TESTS"
+
+
+def require_real_model_test_environment() -> tuple[Path, Path, Path]:
+    import pytest
+
+    if os.environ.get(RUN_REAL_TESTS_ENV) != "1":
+        pytest.skip(f"set {RUN_REAL_TESTS_ENV}=1 to run real model tests")
+    if not DEFAULT_MODEL_DIR.is_dir():
+        pytest.skip(f"default model dir missing: {DEFAULT_MODEL_DIR}")
+    if not DEFAULT_TEST_WAV.is_file():
+        pytest.skip(f"default test wav missing: {DEFAULT_TEST_WAV}")
+    if not DEFAULT_RUNTIME_PYTHON.is_file():
+        pytest.skip(f"default runtime python missing: {DEFAULT_RUNTIME_PYTHON}")
+    try:
+        import torch  # noqa: F401
+        import transformers  # noqa: F401
+    except ModuleNotFoundError as error:
+        pytest.skip(
+            "real model tests require torch and transformers in the current Python "
+            f"environment ({DEFAULT_RUNTIME_PYTHON}): {error}"
+        )
+    return DEFAULT_MODEL_DIR, DEFAULT_TEST_WAV, DEFAULT_RUNTIME_PYTHON
+
+
+def normalize_text(text: str) -> str:
+    punctuation = " ，。！？、,.!?"
+    return "".join(ch for ch in text.strip() if ch not in punctuation)
+
+
+def run_probe(command: str) -> dict:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    process = subprocess.run(
+        [str(DEFAULT_RUNTIME_PYTHON), str(Path(__file__).resolve().parent / "real_runtime_probe.py"), command],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise AssertionError(process.stderr.strip() or process.stdout.strip())
+
+    import json
+
+    return json.loads(process.stdout)

--- a/server/tests/real_runtime_probe.py
+++ b/server/tests/real_runtime_probe.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from server.runtime import LocalModelRuntime
+from server.tests.integration_helpers import DEFAULT_MODEL_DIR, DEFAULT_TEST_WAV
+from server.transcription import transcribe_audio
+
+
+def probe_load() -> dict:
+    runtime = LocalModelRuntime(str(DEFAULT_MODEL_DIR), "int8")
+    runtime.load()
+    return {
+        "ready": runtime.ready,
+        "error": runtime.error,
+        "quantization": runtime.quantization_state(),
+    }
+
+
+def probe_inference() -> dict:
+    runtime = LocalModelRuntime(str(DEFAULT_MODEL_DIR), "int8")
+    runtime.load()
+    if not runtime.ready:
+        return {
+            "ready": runtime.ready,
+            "error": runtime.error,
+            "quantization": runtime.quantization_state(),
+        }
+
+    response = transcribe_audio(
+        runtime,
+        Path(DEFAULT_TEST_WAV).read_bytes(),
+        "zh",
+        "以下是一段简体中文的普通话句子，去掉首尾的语气词",
+    )
+    return {
+        "ready": runtime.ready,
+        "error": runtime.error,
+        "quantization": runtime.quantization_state(),
+        "response": response,
+    }
+
+
+def main() -> int:
+    command = sys.argv[1]
+    if command == "load":
+        result = probe_load()
+    elif command == "inference":
+        result = probe_inference()
+    else:
+        raise SystemExit(f"unknown command: {command}")
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/tests/test_chat.py
+++ b/server/tests/test_chat.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from server.chat import chat_complete, flatten_content, render_chat_prompt
+from server.models import ChatCompletionRequest
+
+
+class StubProcessor:
+    def __init__(self) -> None:
+        self.last_messages = None
+
+    def apply_chat_template(self, messages, **_: object) -> str:
+        self.last_messages = messages
+        return "rendered prompt"
+
+
+class StubRuntime:
+    def __init__(self) -> None:
+        self.processor = StubProcessor()
+        self.generate_calls = []
+
+    def ensure_ready(self) -> None:
+        return None
+
+    def generate_from_text(
+        self,
+        prompt_text: str,
+        *,
+        temperature: float,
+        max_new_tokens: int,
+    ) -> str:
+        self.generate_calls.append((prompt_text, temperature, max_new_tokens))
+        return " stub response "
+
+
+def test_flatten_content_handles_supported_shapes() -> None:
+    assert flatten_content("hello") == "hello"
+    assert flatten_content(
+        ["a", {"type": "text", "text": "b"}, {"type": "image", "url": "ignored"}],
+    ) == "ab"
+    assert flatten_content(None) == ""
+
+
+def test_render_chat_prompt_normalizes_message_content() -> None:
+    processor = StubProcessor()
+    request = ChatCompletionRequest(
+        messages=[
+            {"role": "system", "content": "clean"},
+            {"role": "user", "content": ["你", {"type": "text", "text": "好"}]},
+        ],
+    )
+
+    result = render_chat_prompt(processor, request.messages)
+
+    assert result == "rendered prompt"
+    assert processor.last_messages == [
+        {"role": "system", "content": [{"type": "text", "text": "clean"}]},
+        {"role": "user", "content": [{"type": "text", "text": "你好"}]},
+    ]
+
+
+def test_chat_complete_rejects_streaming() -> None:
+    runtime = StubRuntime()
+    request = ChatCompletionRequest(messages=[{"role": "user", "content": "hi"}], stream=True)
+
+    try:
+        chat_complete(runtime, request)
+    except HTTPException as error:
+        assert error.status_code == 400
+        assert error.detail == "stream=true is not supported"
+    else:
+        raise AssertionError("expected HTTPException")
+
+
+def test_chat_complete_uses_rendered_prompt_and_runtime_generation() -> None:
+    runtime = StubRuntime()
+    request = ChatCompletionRequest(
+        messages=[{"role": "user", "content": "你好"}],
+        temperature=0.3,
+        max_tokens=64,
+    )
+
+    response = chat_complete(runtime, request)
+
+    assert runtime.generate_calls == [("rendered prompt", 0.3, 64)]
+    assert response["choices"][0]["message"]["content"] == "stub response"
+    assert response["model"] == "gemma-4-E2B-it"

--- a/server/tests/test_integration_inference.py
+++ b/server/tests/test_integration_inference.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from server.tests.integration_helpers import (
+    normalize_text,
+    require_real_model_test_environment,
+    run_probe,
+)
+
+
+def test_real_audio_transcription_matches_expected_keywords() -> None:
+    require_real_model_test_environment()
+    result = run_probe("inference")
+
+    assert result["ready"] is True
+    assert result["error"] is None
+
+    response = result["response"]
+    normalized = normalize_text(response["text"])
+
+    assert response["language"] == "zh"
+    assert response["duration"] > 0
+    assert normalized
+    assert "超市" in normalized
+    assert "水果" in normalized

--- a/server/tests/test_integration_runtime.py
+++ b/server/tests/test_integration_runtime.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from server.tests.integration_helpers import (
+    require_real_model_test_environment,
+    run_probe,
+)
+
+
+def test_runtime_loads_real_model_and_applies_quantization() -> None:
+    require_real_model_test_environment()
+    result = run_probe("load")
+
+    assert result["ready"] is True
+    assert result["error"] is None
+
+    quantization = result["quantization"]
+    assert quantization["requested"] == "int8"
+    assert isinstance(quantization["device"], str)
+    assert quantization["device"].startswith(("cpu", "cuda", "mps"))
+    assert quantization["applied"] is True
+    assert quantization["backend"] in {"optimum-quanto", "bitsandbytes"}
+    assert quantization["mode"] == "int8"

--- a/server/tests/test_runtime.py
+++ b/server/tests/test_runtime.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from server.runtime import LocalModelRuntime
+
+
+def test_health_payload_states() -> None:
+    runtime = LocalModelRuntime("/tmp/model", "int8")
+    assert runtime.health_payload() == (503, {"status": "loading", "model": "gemma-4-E2B-it"})
+
+    runtime.ready = True
+    assert runtime.health_payload() == (200, {"status": "ok", "model": "gemma-4-E2B-it"})
+
+    runtime.ready = False
+    runtime.error = "boom"
+    assert runtime.health_payload() == (
+        500,
+        {"status": "error", "model": "gemma-4-E2B-it", "error": "boom"},
+    )
+
+
+def test_base_load_kwargs_for_mps_avoids_device_map() -> None:
+    runtime = LocalModelRuntime("/tmp/model", "int8")
+    load_kwargs = runtime._base_load_kwargs("mps")
+
+    assert load_kwargs["low_cpu_mem_usage"] is True
+    assert load_kwargs["device_map"] == {"": "mps"}
+
+
+def test_base_load_kwargs_for_cuda_uses_auto_dispatch() -> None:
+    runtime = LocalModelRuntime("/tmp/model", "int8")
+    load_kwargs = runtime._base_load_kwargs("cuda")
+
+    assert load_kwargs["device_map"] == "auto"
+    assert load_kwargs["low_cpu_mem_usage"] is True
+
+
+def test_extract_text_response_accepts_string() -> None:
+    assert LocalModelRuntime.extract_text_response("hello") == "hello"
+
+
+def test_extract_text_response_extracts_text_from_dict() -> None:
+    assert LocalModelRuntime.extract_text_response({"text": "hello"}) == "hello"
+    assert LocalModelRuntime.extract_text_response({"content": "world"}) == "world"
+
+
+def test_extract_text_response_rejects_dict_without_text() -> None:
+    try:
+        LocalModelRuntime.extract_text_response({"foo": "bar"})
+    except ValueError as error:
+        assert "text field" in str(error)
+    else:
+        raise AssertionError("expected ValueError")

--- a/server/tests/test_server.py
+++ b/server/tests/test_server.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
+
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from server.server import ChatCompletionRequest, LocalModelRuntime, create_app
+from server.models import ChatCompletionRequest
+from server.server import create_app
 
 
 class StubRuntime:
@@ -10,6 +14,8 @@ class StubRuntime:
         self.loaded = False
         self.last_audio_args: tuple[bytes, str | None, str | None] | None = None
         self.last_chat_request: ChatCompletionRequest | None = None
+        self.last_chat_prompt: str | None = None
+        self.processor = self
 
     def load(self) -> None:
         self.loaded = True
@@ -17,60 +23,34 @@ class StubRuntime:
     def health_payload(self) -> tuple[int, dict[str, str]]:
         return 200, {"status": "ok", "model": "stub"}
 
-    def transcribe_audio(
+    def ensure_ready(self) -> None:
+        return None
+
+    def generate_from_audio(self, prompt_text: str, audio_path: str) -> str:
+        del audio_path
+        self.last_audio_args = (b"wav-bytes", "zh", "keep punctuation")
+        assert "Expected language: zh." in prompt_text
+        return "stub transcript"
+
+    def apply_chat_template(self, messages, **_: object) -> str:
+        self.last_chat_request = ChatCompletionRequest(messages=messages)
+        return "rendered prompt"
+
+    def generate_from_text(
         self,
-        wav_bytes: bytes,
-        language: str | None,
-        prompt: str | None,
-    ) -> dict[str, object]:
-        self.last_audio_args = (wav_bytes, language, prompt)
-        return {"text": "stub transcript", "language": language or "auto", "duration": 1.25}
-
-    def chat_complete(self, request: ChatCompletionRequest) -> dict[str, object]:
-        self.last_chat_request = request
-        return {
-            "id": "chatcmpl-local-test",
-            "object": "chat.completion",
-            "created": 0,
-            "model": "stub",
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {"role": "assistant", "content": "stub response"},
-                    "finish_reason": "stop",
-                },
-            ],
-            "usage": {
-                "prompt_tokens": None,
-                "completion_tokens": None,
-                "total_tokens": None,
-            },
-        }
+        prompt_text: str,
+        *,
+        temperature: float,
+        max_new_tokens: int,
+    ) -> str:
+        del temperature, max_new_tokens
+        self.last_chat_prompt = prompt_text
+        return "stub response"
 
 
-def test_health_payload_states() -> None:
-    runtime = LocalModelRuntime("/tmp/model", "int8")
-    assert runtime.health_payload() == (503, {"status": "loading", "model": "gemma-4-E4B-it"})
-
-    runtime.ready = True
-    assert runtime.health_payload() == (200, {"status": "ok", "model": "gemma-4-E4B-it"})
-
-    runtime.ready = False
-    runtime.error = "boom"
-    assert runtime.health_payload() == (
-        500,
-        {"status": "error", "model": "gemma-4-E4B-it", "error": "boom"},
-    )
-
-
-def test_flatten_content_handles_supported_shapes() -> None:
-    runtime = LocalModelRuntime("/tmp/model", "int8")
-
-    assert runtime._flatten_content("hello") == "hello"
-    assert runtime._flatten_content(
-        ["a", {"type": "text", "text": "b"}, {"type": "image", "url": "ignored"}],
-    ) == "ab"
-    assert runtime._flatten_content(None) == ""
+class FailingRuntime(StubRuntime):
+    def health_payload(self) -> tuple[int, dict[str, str]]:
+        raise HTTPException(status_code=503, detail="loading")
 
 
 def test_create_app_health_endpoint() -> None:
@@ -83,8 +63,21 @@ def test_create_app_health_endpoint() -> None:
     assert runtime.loaded is True
 
 
-def test_create_app_audio_transcriptions_endpoint() -> None:
+def test_create_app_audio_transcriptions_endpoint(monkeypatch) -> None:
     runtime = StubRuntime()
+
+    def fake_transcribe_audio(
+        runtime_obj: Any,
+        wav_bytes: bytes,
+        language: str | None,
+        prompt: str | None,
+    ) -> dict[str, object]:
+        assert runtime_obj is runtime
+        runtime.last_audio_args = (wav_bytes, language, prompt)
+        return {"text": "stub transcript", "language": language or "auto", "duration": 1.25}
+
+    monkeypatch.setattr("server.server.transcribe_audio", fake_transcribe_audio)
+
     with TestClient(create_app(runtime)) as client:
         response = client.post(
             "/v1/audio/transcriptions",
@@ -118,3 +111,13 @@ def test_create_app_chat_completions_endpoint() -> None:
         "system",
         "user",
     ]
+    assert runtime.last_chat_prompt == "rendered prompt"
+
+
+def test_http_exception_handler_returns_json() -> None:
+    runtime = FailingRuntime()
+    with TestClient(create_app(runtime)) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "loading"}

--- a/server/tests/test_transcription.py
+++ b/server/tests/test_transcription.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+
+from fastapi import HTTPException
+
+from server.transcription import build_transcription_prompt, transcribe_audio
+
+
+class StubRuntime:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def ensure_ready(self) -> None:
+        return None
+
+    def generate_from_audio(self, prompt_text: str, audio_path: str) -> str:
+        self.calls.append((prompt_text, audio_path))
+        return " stub transcript "
+
+
+class MonoSamples:
+    def __init__(self, length: int) -> None:
+        self.shape = (length,)
+        self._length = length
+
+    def __len__(self) -> int:
+        return self._length
+
+
+class StereoSamples:
+    def __init__(self, length: int) -> None:
+        self.shape = (length, 2)
+        self._length = length
+
+    def __len__(self) -> int:
+        return self._length
+
+    def mean(self, axis: int) -> MonoSamples:
+        assert axis == 1
+        return MonoSamples(self._length)
+
+
+class FakeSoundFile:
+    def __init__(self, samples, sample_rate: int) -> None:
+        self.samples = samples
+        self.sample_rate = sample_rate
+        self.last_write = None
+
+    def read(self, _source, dtype: str):
+        assert dtype == "float32"
+        return self.samples, self.sample_rate
+
+    def write(self, path: str, samples, sample_rate: int) -> None:
+        self.last_write = (path, samples, sample_rate)
+
+
+def install_fake_soundfile(monkeypatch, *, samples, sample_rate: int = 16000) -> FakeSoundFile:
+    fake_sf = FakeSoundFile(samples, sample_rate)
+    monkeypatch.setitem(sys.modules, "soundfile", fake_sf)
+    return fake_sf
+
+
+def test_build_transcription_prompt_includes_optional_context() -> None:
+    prompt = build_transcription_prompt("zh", "keep punctuation")
+
+    assert "Expected language: zh." in prompt
+    assert "Additional context: keep punctuation" in prompt
+
+
+def test_transcribe_audio_returns_text_language_and_duration(monkeypatch) -> None:
+    runtime = StubRuntime()
+    fake_sf = install_fake_soundfile(monkeypatch, samples=MonoSamples(16000))
+
+    response = transcribe_audio(runtime, b"wav-bytes", "zh", "keep punctuation")
+
+    assert response == {
+        "text": "stub transcript",
+        "language": "zh",
+        "duration": 1.0,
+    }
+    assert len(runtime.calls) == 1
+    assert "Expected language: zh." in runtime.calls[0][0]
+    assert fake_sf.last_write is not None
+
+
+def test_transcribe_audio_converts_multichannel_audio_to_mono(monkeypatch) -> None:
+    runtime = StubRuntime()
+    stereo = StereoSamples(8000)
+    fake_sf = install_fake_soundfile(monkeypatch, samples=stereo, sample_rate=8000)
+
+    response = transcribe_audio(runtime, b"wav-bytes", None, None)
+
+    assert response["language"] == "auto"
+    assert response["duration"] == 1.0
+    assert len(runtime.calls) == 1
+    assert isinstance(fake_sf.last_write[1], MonoSamples)
+
+
+def test_transcribe_audio_rejects_long_audio(monkeypatch) -> None:
+    runtime = StubRuntime()
+    install_fake_soundfile(monkeypatch, samples=MonoSamples(31 * 16000))
+
+    try:
+        transcribe_audio(runtime, b"wav-bytes", None, None)
+    except HTTPException as error:
+        assert error.status_code == 400
+        assert error.detail == "audio duration exceeds 30 seconds"
+    else:
+        raise AssertionError("expected HTTPException")

--- a/server/transcription.py
+++ b/server/transcription.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tempfile
+import time
+from typing import Any
+
+from fastapi import HTTPException
+
+LOGGER = logging.getLogger("viberwhisper.local_server")
+
+
+def build_transcription_prompt(language: str | None, prompt: str | None) -> str:
+    parts = [
+        "Transcribe the following speech segment in its original language.",
+        "Preserve punctuation and formatting when they are clear from the audio.",
+        "Return only the transcription text.",
+    ]
+    if language:
+        parts.append(f"Expected language: {language}.")
+    if prompt:
+        parts.append(f"Additional context: {prompt}")
+    return " ".join(parts)
+
+
+def transcribe_audio(
+    runtime: Any,
+    wav_bytes: bytes,
+    language: str | None,
+    prompt: str | None,
+) -> dict[str, Any]:
+    runtime.ensure_ready()
+    started_at = time.perf_counter()
+
+    import soundfile as sf
+
+    samples, sample_rate = sf.read(io.BytesIO(wav_bytes), dtype="float32")
+    if len(samples.shape) > 1:
+        samples = samples.mean(axis=1)
+    duration = float(len(samples) / sample_rate) if sample_rate else 0.0
+    if duration > 30.0:
+        raise HTTPException(
+            status_code=400, detail="audio duration exceeds 30 seconds",
+        )
+
+    instruction = build_transcription_prompt(language, prompt)
+    LOGGER.info(
+        "Starting audio transcription bytes=%s sample_rate=%s duration=%.3fs language=%s prompt_chars=%s",
+        len(wav_bytes),
+        sample_rate,
+        duration,
+        language or "auto",
+        len(prompt) if prompt else 0,
+    )
+
+    tmp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            sf.write(tmp.name, samples, sample_rate)
+            tmp_path = tmp.name
+        text = runtime.generate_from_audio(instruction, tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    elapsed = time.perf_counter() - started_at
+    LOGGER.info(
+        "Completed audio transcription duration=%.3fs output_chars=%s",
+        elapsed,
+        len(text.strip()),
+    )
+
+    return {
+        "text": text.strip(),
+        "language": language or "auto",
+        "duration": round(duration, 3),
+    }


### PR DESCRIPTION
## Summary
- split the local Python server into runtime, transcription, chat, and model modules
- add focused unit and opt-in integration tests plus a lightweight ASR probe client
- document the server test layout and runtime test prerequisites
