### PR TITLE
fix(test): satisfy clippy default-init lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -699,10 +699,12 @@ mod integration_tests {
 
     #[test]
     fn test_apply_local_endpoint_overrides_enabled_post_process() {
-        let mut config = AppConfig::default();
-        config.local_server_port = 17265;
-        config.post_process_enabled = true;
-        config.post_process_model = Some("gpt-4o-mini".to_string());
+        let config = AppConfig {
+            local_server_port: 17265,
+            post_process_enabled: true,
+            post_process_model: Some("gpt-4o-mini".to_string()),
+            ..Default::default()
+        };
 
         let local = apply_local_endpoint_overrides(&config, "http://127.0.0.1:17265");
 
@@ -722,10 +724,12 @@ mod integration_tests {
 
     #[test]
     fn test_apply_local_endpoint_overrides_keeps_post_process_disabled() {
-        let mut config = AppConfig::default();
-        config.local_server_port = 17265;
-        config.post_process_enabled = false;
-        config.post_process_model = Some("gpt-4o-mini".to_string());
+        let config = AppConfig {
+            local_server_port: 17265,
+            post_process_enabled: false,
+            post_process_model: Some("gpt-4o-mini".to_string()),
+            ..Default::default()
+        };
 
         let local = apply_local_endpoint_overrides(&config, "http://127.0.0.1:17265");
 

--- a/src/postprocess/factory.rs
+++ b/src/postprocess/factory.rs
@@ -34,8 +34,10 @@ mod tests {
 
     #[test]
     fn test_enabled_incomplete_config_falls_back_to_noop() {
-        let mut config = AppConfig::default();
-        config.post_process_enabled = true;
+        let config = AppConfig {
+            post_process_enabled: true,
+            ..Default::default()
+        };
         // Missing api_key, api_url, model — should silently fall back to noop.
         let p = create_post_processor(&config);
         assert_eq!(p.process("hello").unwrap(), "hello");
@@ -43,12 +45,13 @@ mod tests {
 
     #[test]
     fn test_enabled_complete_config_returns_llm_processor() {
-        let mut config = AppConfig::default();
-        config.post_process_enabled = true;
-        config.post_process_api_key = Some("key".to_string());
-        config.post_process_api_url =
-            Some("https://api.example.com/v1/chat/completions".to_string());
-        config.post_process_model = Some("gpt-4o-mini".to_string());
+        let config = AppConfig {
+            post_process_enabled: true,
+            post_process_api_key: Some("key".to_string()),
+            post_process_api_url: Some("https://api.example.com/v1/chat/completions".to_string()),
+            post_process_model: Some("gpt-4o-mini".to_string()),
+            ..Default::default()
+        };
         let p = create_post_processor(&config);
         // LlmPostProcessor passes empty text through without a network call.
         assert_eq!(p.process("").unwrap(), "");

--- a/src/postprocess/llm.rs
+++ b/src/postprocess/llm.rs
@@ -334,13 +334,13 @@ mod tests {
     use crate::core::config::AppConfig;
 
     fn config_with_postprocess() -> AppConfig {
-        let mut config = AppConfig::default();
-        config.post_process_enabled = true;
-        config.post_process_api_key = Some("test_key".to_string());
-        config.post_process_api_url =
-            Some("https://api.example.com/v1/chat/completions".to_string());
-        config.post_process_model = Some("gpt-4o-mini".to_string());
-        config
+        AppConfig {
+            post_process_enabled: true,
+            post_process_api_key: Some("test_key".to_string()),
+            post_process_api_url: Some("https://api.example.com/v1/chat/completions".to_string()),
+            post_process_model: Some("gpt-4o-mini".to_string()),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -351,16 +351,20 @@ mod tests {
 
     #[test]
     fn test_from_config_missing_url() {
-        let mut config = AppConfig::default();
-        config.post_process_api_key = Some("key".to_string());
+        let config = AppConfig {
+            post_process_api_key: Some("key".to_string()),
+            ..Default::default()
+        };
         assert!(LlmPostProcessor::from_config(&config).is_err());
     }
 
     #[test]
     fn test_from_config_missing_model() {
-        let mut config = AppConfig::default();
-        config.post_process_api_key = Some("key".to_string());
-        config.post_process_api_url = Some("https://example.com/v1/chat/completions".to_string());
+        let config = AppConfig {
+            post_process_api_key: Some("key".to_string()),
+            post_process_api_url: Some("https://example.com/v1/chat/completions".to_string()),
+            ..Default::default()
+        };
         assert!(LlmPostProcessor::from_config(&config).is_err());
     }
 

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -376,8 +376,10 @@ mod tests {
 
     #[test]
     fn test_api_transcriber_from_config_with_key() {
-        let mut config = AppConfig::default();
-        config.api_key = Some("test_key".to_string());
+        let config = AppConfig {
+            api_key: Some("test_key".to_string()),
+            ..Default::default()
+        };
         let result = ApiTranscriber::from_config(&config);
         assert!(result.is_ok());
         let t = result.unwrap();
@@ -394,20 +396,24 @@ mod tests {
 
     #[test]
     fn test_api_transcriber_custom_url() {
-        let mut config = AppConfig::default();
-        config.api_key = Some("key".to_string());
-        config.transcription_api_url = "https://api.openai.com/v1/audio/transcriptions".to_string();
+        let config = AppConfig {
+            api_key: Some("key".to_string()),
+            transcription_api_url: "https://api.openai.com/v1/audio/transcriptions".to_string(),
+            ..Default::default()
+        };
         let t = ApiTranscriber::from_config(&config).unwrap();
         assert_eq!(t.api_url, "https://api.openai.com/v1/audio/transcriptions");
     }
 
     #[test]
     fn test_api_transcriber_chunk_config_from_config() {
-        let mut config = AppConfig::default();
-        config.api_key = Some("key".to_string());
-        config.max_chunk_duration_secs = 60;
-        config.max_chunk_size_bytes = 10_000_000;
-        config.max_retries = 5;
+        let config = AppConfig {
+            api_key: Some("key".to_string()),
+            max_chunk_duration_secs: 60,
+            max_chunk_size_bytes: 10_000_000,
+            max_retries: 5,
+            ..Default::default()
+        };
         let t = ApiTranscriber::from_config(&config).unwrap();
         assert_eq!(t.max_chunk_duration_secs, 60);
         assert_eq!(t.max_chunk_size_bytes, 10_000_000);
@@ -467,8 +473,10 @@ mod tests {
 
     #[test]
     fn test_local_service_diagnostics_enabled_for_local_mode() {
-        let mut config = AppConfig::default();
-        config.local_mode = true;
+        let config = AppConfig {
+            local_mode: true,
+            ..Default::default()
+        };
         let diagnostics = local_service_diagnostics(&config).unwrap();
         assert_eq!(diagnostics.port, 17265);
         assert!(

--- a/src/transcriber/factory.rs
+++ b/src/transcriber/factory.rs
@@ -40,8 +40,10 @@ mod tests {
 
     #[test]
     fn test_create_transcriber_with_key() {
-        let mut config = AppConfig::default();
-        config.api_key = Some("test_key".to_string());
+        let config = AppConfig {
+            api_key: Some("test_key".to_string()),
+            ..Default::default()
+        };
         // Returns ApiTranscriber; won't actually call the API
         let _t = create_transcriber(&config);
     }
@@ -49,8 +51,10 @@ mod tests {
     #[test]
     fn test_create_transcriber_groq_api_key_compat() {
         // Simulate GROQ_API_KEY being set via config compat path
-        let mut config = AppConfig::default();
-        config.api_key = Some("gsk_compat_key".to_string());
+        let config = AppConfig {
+            api_key: Some("gsk_compat_key".to_string()),
+            ..Default::default()
+        };
         let t = create_transcriber(&config);
         // ApiTranscriber: transcribing a nonexistent file fails with IO error, not mock text
         let result = t.transcribe("/nonexistent/path.wav");


### PR DESCRIPTION
## Summary
- replace `AppConfig::default()` plus follow-up field assignments in tests with struct literals
- satisfy `clippy::field_reassign_with_default` across postprocess, transcriber, and main test cases
- keep behavior unchanged while making `cargo clippy --all-targets --all-features -- -D warnings` pass

## Validation
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build`
- [x] `cargo test`