### PR TITLE
fix(postprocess): tighten LLM cleanup configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ viberwhisper convert input.wav --output output.txt
 | `post_process_streaming_enabled` | 布尔 | `true` | 是否启用预热模式（录音中提前发送 LLM 请求） |
 | `post_process_api_url` | 字符串 | 无 | LLM chat completions API 地址 |
 | `post_process_api_key` | 字符串 | 无 | LLM API 密钥（不写入配置文件，可通过 `POST_PROCESS_API_KEY` 环境变量设置） |
-| `post_process_api_format` | 字符串 | `openai` | API 格式（目前仅支持 openai） |
 | `post_process_model` | 字符串 | 无 | LLM 模型名（如 `gpt-4o-mini`） |
 | `post_process_prompt` | 字符串 | 内置默认 | 后处理系统提示词 |
 | `post_process_temperature` | 数字 | `0.0` | 后处理温度 |
 
 > **注意**：`config.json` 已在 `.gitignore` 中排除，避免误提交真实密钥。`api_key` 和 `post_process_api_key` 不会被程序写回磁盘。
+> 后处理当前固定使用 OpenAI-compatible chat completions 请求格式。
 
 ### 本地模式
 

--- a/config.example.json
+++ b/config.example.json
@@ -17,7 +17,6 @@
   "post_process_streaming_enabled": true,
   "post_process_api_url": "https://api.openai.com/v1/chat/completions",
   "post_process_model": "gpt-4o-mini",
-  "post_process_api_format": "openai",
   "post_process_temperature": 0.0,
   "local_mode": false,
   "local_data_dir": "~/.viberwhisper",

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -37,7 +37,6 @@ pub struct AppConfig {
     pub post_process_streaming_enabled: bool, // default: true (preheat mode)
     pub post_process_api_url: Option<String>,
     pub post_process_api_key: Option<String>, // not saved to file
-    pub post_process_api_format: String,      // default: "openai"
     pub post_process_model: Option<String>,
     pub post_process_prompt: Option<String>,
     pub post_process_temperature: f32,        // default: 0.0
@@ -69,7 +68,6 @@ Serialized to/from `config.json` via `serde_json`. `api_key` and `post_process_a
 | `convergence_timeout_secs` | `30` |
 | `post_process_enabled` | `false` |
 | `post_process_streaming_enabled` | `true` |
-| `post_process_api_format` | `"openai"` |
 | `post_process_temperature` | `0.0` |
 | `local_mode` | `false` |
 | `local_server_port` | `17265` |
@@ -92,7 +90,7 @@ Serializes to pretty-printed JSON. `api_key` and `post_process_api_key` are neve
 
 **`get_field(&self, key: &str) -> Option<String>`**
 
-Returns a string representation of the named field. Supported keys: `api_key`, `groq_api_key`, `transcription_api_url`, `provider`, `model`, `hold_hotkey`, `toggle_hotkey`, `temperature`, `mic_gain`, `language`, `prompt`, `max_chunk_duration_secs`, `max_chunk_size_bytes`, `max_retries`, `convergence_timeout_secs`, `post_process_enabled`, `post_process_streaming_enabled`, `post_process_api_url`, `post_process_api_key`, `post_process_api_format`, `post_process_model`, `post_process_prompt`, `post_process_temperature`, `local_mode`, `local_data_dir`, `local_server_port`, `local_quantization`. Returns `"*** (set)"` for API key fields if present; `None` for unknown keys.
+Returns a string representation of the named field. Supported keys: `api_key`, `groq_api_key`, `transcription_api_url`, `provider`, `model`, `hold_hotkey`, `toggle_hotkey`, `temperature`, `mic_gain`, `language`, `prompt`, `max_chunk_duration_secs`, `max_chunk_size_bytes`, `max_retries`, `convergence_timeout_secs`, `post_process_enabled`, `post_process_streaming_enabled`, `post_process_api_url`, `post_process_api_key`, `post_process_model`, `post_process_prompt`, `post_process_temperature`, `local_mode`, `local_data_dir`, `local_server_port`, `local_quantization`. Returns `"*** (set)"` for API key fields if present; `None` for unknown keys.
 
 **`set_field(&mut self, key: &str, value: &str) -> Result<(), String>`**
 

--- a/docs/architecture/postprocess.md
+++ b/docs/architecture/postprocess.md
@@ -45,7 +45,7 @@ Passes text through unchanged. Used when post-processing is disabled or as a fal
 
 ### `LlmPostProcessor`
 
-Calls an OpenAI-compatible chat completions API to clean up transcribed text.
+Calls an OpenAI-compatible chat completions API to clean up transcribed text. This is the only supported post-processing API format.
 
 **Construction:** `LlmPostProcessor::from_config(config) -> Result<Self>`
 
@@ -116,6 +116,8 @@ pub fn create_post_processor(config: &AppConfig) -> Box<dyn TextPostProcessor>
 | `post_process_enabled = true`, config invalid | `NoopPostProcessor` (with warning log) |
 
 Ensures the main pipeline is never blocked by a missing or broken LLM setup.
+
+Configuration errors fall back to `NoopPostProcessor` because post-processing is optional. Runtime LLM request failures and empty LLM outputs are returned to the caller, which keeps the original STT text.
 
 ## Dependencies
 

--- a/docs/plan/08-llm-post-processing.md
+++ b/docs/plan/08-llm-post-processing.md
@@ -191,7 +191,6 @@ pub post_process_enabled: bool,
 pub post_process_streaming_enabled: bool,
 pub post_process_api_url: Option<String>,
 pub post_process_api_key: Option<String>,
-pub post_process_api_format: String,
 pub post_process_model: Option<String>,
 pub post_process_prompt: Option<String>,
 pub post_process_temperature: f32,
@@ -205,7 +204,6 @@ pub post_process_temperature: f32,
 | `post_process_streaming_enabled` | `true` | 启用后优先采用增量输入 + 流式 LLM 调用 |
 | `post_process_api_url` | `None` | 未启用时不需要 |
 | `post_process_api_key` | `None` | 建议支持环境变量覆盖 |
-| `post_process_api_format` | `"openai"` | 后处理层直接兼容 OpenAI 格式 API |
 | `post_process_model` | `None` | 未启用时不需要 |
 | `post_process_prompt` | 内置默认 prompt 或 `None` | 用户可覆盖 |
 | `post_process_temperature` | `0.0` | 保守输出，降低发散 |
@@ -271,7 +269,7 @@ pub struct LlmPostProcessor {
 
 - STT 层：维持当前接口与 provider 兼容面，不在本期借这个 feature 额外扩张范围
 - 后处理层：优先对接 OpenAI-compatible text generation / streaming API
-- 配置层通过 `post_process_api_url` + `post_process_api_format = "openai"` 保持明确语义
+- 配置层通过 `post_process_api_url` 指向 OpenAI-compatible chat completions 端点
 - 第一阶段先把 OpenAI 格式跑通；其他 provider 如有必要再在此基础上扩展
 
 换句话说，这里不是“顺手重做整套识别协议”，而是“**在现有 STT 边界之外，把后处理层的 OpenAI 兼容流式调用先跑通**”。

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -27,10 +27,6 @@ fn default_post_process_streaming_enabled() -> bool {
     true
 }
 
-fn default_post_process_api_format() -> String {
-    "openai".to_string()
-}
-
 fn default_local_server_port() -> u16 {
     17265
 }
@@ -92,9 +88,6 @@ pub struct AppConfig {
     /// `POST_PROCESS_API_KEY` env var.
     #[serde(skip)]
     pub post_process_api_key: Option<String>,
-    /// API format for the post-processor (currently only "openai" is supported).
-    #[serde(default = "default_post_process_api_format")]
-    pub post_process_api_format: String,
     /// LLM model name for post-processing (e.g., "gpt-4o-mini").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_process_model: Option<String>,
@@ -139,7 +132,6 @@ impl Default for AppConfig {
             post_process_streaming_enabled: default_post_process_streaming_enabled(),
             post_process_api_url: None,
             post_process_api_key: None,
-            post_process_api_format: default_post_process_api_format(),
             post_process_model: None,
             post_process_prompt: None,
             post_process_temperature: 0.0,
@@ -218,7 +210,6 @@ impl AppConfig {
                 .post_process_api_key
                 .as_ref()
                 .map(|_| "*** (set)".to_string()),
-            "post_process_api_format" => Some(self.post_process_api_format.clone()),
             "post_process_model" => self.post_process_model.clone(),
             "post_process_prompt" => self.post_process_prompt.clone(),
             "post_process_temperature" => Some(self.post_process_temperature.to_string()),
@@ -324,10 +315,6 @@ impl AppConfig {
                 self.post_process_api_key = Some(value.to_string());
                 Ok(())
             }
-            "post_process_api_format" => {
-                self.post_process_api_format = value.to_string();
-                Ok(())
-            }
             "post_process_model" => {
                 self.post_process_model = Some(value.to_string());
                 Ok(())
@@ -367,8 +354,8 @@ impl AppConfig {
                  hold_hotkey, toggle_hotkey, language, prompt, temperature, mic_gain, \
                  max_chunk_duration_secs, max_chunk_size_bytes, max_retries, \
                  convergence_timeout_secs, post_process_enabled, post_process_streaming_enabled, \
-                 post_process_api_url, post_process_api_key, post_process_api_format, \
-                 post_process_model, post_process_prompt, post_process_temperature, \
+                 post_process_api_url, post_process_api_key, post_process_model, \
+                 post_process_prompt, post_process_temperature, \
                  local_mode, local_data_dir, local_server_port, local_quantization",
                 key
             )),
@@ -440,9 +427,6 @@ impl AppConfig {
         }
         if let Some(v) = json["post_process_api_key"].as_str() {
             self.post_process_api_key = Some(v.to_string());
-        }
-        if let Some(v) = json["post_process_api_format"].as_str() {
-            self.post_process_api_format = v.to_string();
         }
         if let Some(v) = json["post_process_model"].as_str() {
             self.post_process_model = Some(v.to_string());
@@ -741,12 +725,6 @@ mod tests {
     }
 
     #[test]
-    fn test_default_post_process_api_format() {
-        let config = AppConfig::default();
-        assert_eq!(config.post_process_api_format, "openai");
-    }
-
-    #[test]
     fn test_get_set_post_process_enabled() {
         let mut config = AppConfig::default();
         assert_eq!(
@@ -839,7 +817,6 @@ mod tests {
         config.apply_json(&json);
         assert!(!config.post_process_enabled);
         assert!(config.post_process_streaming_enabled);
-        assert_eq!(config.post_process_api_format, "openai");
         assert!(config.post_process_api_key.is_none());
         assert!(config.post_process_model.is_none());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,10 +336,12 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
                     match session.finish() {
                         Ok(processed) if !processed.is_empty() => processed,
                         Ok(_) => {
+                            // Empty post-process output is not useful; keep the STT text.
                             warn!("Post-processing returned empty text, using original STT text");
                             stt_text
                         }
                         Err(e) => {
+                            // Runtime LLM errors should not discard a successful STT result.
                             warn!(error = %e, "Post-processing failed, using original STT text");
                             stt_text
                         }
@@ -542,7 +544,6 @@ fn handle_config(action: ConfigAction) {
                 "post_process_streaming_enabled",
                 "post_process_api_url",
                 "post_process_api_key",
-                "post_process_api_format",
                 "post_process_model",
                 "post_process_prompt",
                 "post_process_temperature",
@@ -611,10 +612,12 @@ fn handle_convert(input: &str, output: Option<&str>) {
             let text = match post_processor.process(&stt_text) {
                 Ok(processed) if !processed.is_empty() => processed,
                 Ok(_) => {
+                    // Empty post-process output is not useful; keep the STT text.
                     warn!("Post-processing returned empty text, using original STT text");
                     stt_text
                 }
                 Err(e) => {
+                    // Runtime LLM errors should not discard a successful STT result.
                     warn!(error = %e, "Post-processing failed, using original STT text");
                     stt_text
                 }

--- a/src/postprocess/factory.rs
+++ b/src/postprocess/factory.rs
@@ -6,6 +6,11 @@ use tracing::warn;
 ///
 /// Returns `NoopPostProcessor` if post-processing is disabled or misconfigured,
 /// ensuring the main pipeline is never blocked by a missing LLM setup.
+///
+/// Error layering:
+/// - configuration errors fall back to noop here because post-processing is optional;
+/// - runtime LLM request errors are returned by the processor and handled by callers;
+/// - empty LLM outputs are treated as runtime errors by `LlmPostProcessor`.
 pub fn create_post_processor(config: &AppConfig) -> Box<dyn TextPostProcessor> {
     if !config.post_process_enabled {
         return Box::new(NoopPostProcessor);
@@ -14,6 +19,8 @@ pub fn create_post_processor(config: &AppConfig) -> Box<dyn TextPostProcessor> {
     match LlmPostProcessor::from_config(config) {
         Ok(processor) => Box::new(processor),
         Err(e) => {
+            // Keep this fallback quiet for users who enable local transcription
+            // without enabling an LLM cleanup service; STT remains usable.
             warn!(error = %e, "Failed to create LLM post-processor, falling back to noop");
             Box::new(NoopPostProcessor)
         }
@@ -38,7 +45,8 @@ mod tests {
             post_process_enabled: true,
             ..Default::default()
         };
-        // Missing api_key, api_url, model — should silently fall back to noop.
+        // Missing api_key, api_url, model should fall back to noop because
+        // post-processing is optional and STT output remains valid.
         let p = create_post_processor(&config);
         assert_eq!(p.process("hello").unwrap(), "hello");
     }

--- a/src/postprocess/llm.rs
+++ b/src/postprocess/llm.rs
@@ -1,8 +1,12 @@
 use crate::core::config::AppConfig;
 use crate::postprocess::{TextPostProcessor, TextPostProcessorSession};
+use reqwest::blocking::Client;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
+use std::time::Duration;
 use tracing::info;
+
+const LLM_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 const DEFAULT_PROMPT: &str = "请将下面的语音转写结果整理为适合直接发送的中文文本：\n\
     - 保留原意，不要扩写\n\
@@ -18,6 +22,7 @@ pub struct LlmPostProcessor {
     prompt: String,
     temperature: f32,
     streaming_enabled: bool,
+    client: Client,
 }
 
 impl LlmPostProcessor {
@@ -45,11 +50,13 @@ impl LlmPostProcessor {
             prompt,
             temperature: config.post_process_temperature,
             streaming_enabled: config.post_process_streaming_enabled,
+            client: Client::builder().timeout(LLM_REQUEST_TIMEOUT).build()?,
         })
     }
 
     fn call_llm(&self, text: &str) -> Result<String, Box<dyn std::error::Error>> {
         call_llm_impl(
+            &self.client,
             &self.api_key,
             &self.api_url,
             &self.model,
@@ -61,6 +68,7 @@ impl LlmPostProcessor {
 }
 
 fn call_llm_impl(
+    client: &Client,
     api_key: &str,
     api_url: &str,
     model: &str,
@@ -78,7 +86,6 @@ fn call_llm_impl(
         "stream": false
     });
 
-    let client = reqwest::blocking::Client::new();
     let response = client
         .post(api_url)
         .header("Authorization", format!("Bearer {}", api_key))
@@ -126,6 +133,7 @@ impl TextPostProcessor for LlmPostProcessor {
                 self.model.clone(),
                 self.prompt.clone(),
                 self.temperature,
+                self.client.clone(),
             ))
         } else {
             Box::new(ConservativeLlmSession {
@@ -134,6 +142,7 @@ impl TextPostProcessor for LlmPostProcessor {
                 model: self.model.clone(),
                 prompt: self.prompt.clone(),
                 temperature: self.temperature,
+                client: self.client.clone(),
                 chunks: Vec::new(),
             })
         }
@@ -150,6 +159,7 @@ struct ConservativeLlmSession {
     model: String,
     prompt: String,
     temperature: f32,
+    client: Client,
     chunks: Vec<String>,
 }
 
@@ -161,11 +171,14 @@ impl TextPostProcessorSession for ConservativeLlmSession {
     }
 
     fn finish(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        // Post-processing receives already ordered stable text fragments; joining
+        // without separators preserves the STT layer's chosen spacing/punctuation.
         let combined = self.chunks.join("");
         if combined.is_empty() {
             return Ok(combined);
         }
         call_llm_impl(
+            &self.client,
             &self.api_key,
             &self.api_url,
             &self.model,
@@ -194,6 +207,7 @@ struct PreheatLlmSession {
     model: String,
     prompt: String,
     temperature: f32,
+    client: Client,
     chunks: Vec<String>,
     generation: u64,
     state: Arc<(Mutex<PreheatState>, Condvar)>,
@@ -206,6 +220,7 @@ impl PreheatLlmSession {
         model: String,
         prompt: String,
         temperature: f32,
+        client: Client,
     ) -> Self {
         Self {
             api_key,
@@ -213,6 +228,7 @@ impl PreheatLlmSession {
             model,
             prompt,
             temperature,
+            client,
             chunks: Vec::new(),
             generation: 0,
             state: Arc::new((
@@ -226,6 +242,8 @@ impl PreheatLlmSession {
     }
 
     fn fire_request(&mut self) {
+        // Post-processing accumulates stable text exactly as received; it does
+        // not add separators because upstream text already owns word spacing.
         let combined = self.chunks.join("");
         if combined.is_empty() {
             return;
@@ -246,10 +264,19 @@ impl PreheatLlmSession {
         let model = self.model.clone();
         let prompt = self.prompt.clone();
         let temperature = self.temperature;
+        let client = self.client.clone();
         let state = Arc::clone(&self.state);
 
         thread::spawn(move || {
-            let result = call_llm_impl(&api_key, &api_url, &model, &prompt, temperature, &combined);
+            let result = call_llm_impl(
+                &client,
+                &api_key,
+                &api_url,
+                &model,
+                &prompt,
+                temperature,
+                &combined,
+            );
 
             let (lock, cvar) = &*state;
             let mut st = lock.lock().unwrap();
@@ -277,6 +304,8 @@ impl TextPostProcessorSession for PreheatLlmSession {
     }
 
     fn finish(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        // Keep post-processing concatenation separator-free; the STT result is
+        // already a display-ready text stream before LLM cleanup.
         let combined = self.chunks.join("");
         if combined.is_empty() {
             return Ok(combined);
@@ -286,6 +315,7 @@ impl TextPostProcessorSession for PreheatLlmSession {
         // with non-empty text, but be safe), fire one now.
         if self.generation == 0 {
             return call_llm_impl(
+                &self.client,
                 &self.api_key,
                 &self.api_url,
                 &self.model,
@@ -316,6 +346,7 @@ impl TextPostProcessorSession for PreheatLlmSession {
                 info!(error = %e, "Preheat: last request failed, retrying with full text");
                 drop(st);
                 call_llm_impl(
+                    &self.client,
                     &self.api_key,
                     &self.api_url,
                     &self.model,
@@ -474,6 +505,10 @@ mod tests {
             "model".to_string(),
             "prompt".to_string(),
             0.0,
+            Client::builder()
+                .timeout(LLM_REQUEST_TIMEOUT)
+                .build()
+                .unwrap(),
         );
         assert_eq!(session.generation, 0);
         // push_stable_chunk fires a request and increments generation.


### PR DESCRIPTION
## Summary
- reuse a timeout-configured reqwest blocking client for LLM post-processing requests
- keep optional post-processing config failures on noop fallback, with explicit error-layering comments
- document separator-free post-process chunk concatenation
- remove the unused post_process_api_format config field and update docs/examples

## Validation
- cargo fmt --check
- cargo check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo check --release