### PR TITLE
fix(audio): harden recording and WAV chunk handling

### DIFF
--- a/changelog
+++ b/changelog
@@ -18,3 +18,4 @@
 2026-04-06: Add native Windows floating overlay with click-to-toggle, dragging, always-on-top behavior, and recording-state rendering
 2026-04-06: Add local Gemma service management: Python FastAPI server under server/, local install/start/stop/status CLI, runtime endpoint overrides, and local backend config fields
 2026-04-06: Move the local Gemma runtime to `server/` and complete local CLI/runtime wiring to the planned FastAPI service
+2026-07-05: Fix audio recorder recovery, bounded live-chunk memory, collision-safe temp files, and non-i16 WAV splitting

--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -71,7 +71,7 @@ Creates a recorder with explicit chunk-splitting config. The chunk threshold is 
 
 Polls for a completed chunk during recording. Returns `Some(path)` when a chunk has been flushed to disk. Should be called periodically from the main event loop.
 
-The audio callback updates `ready_chunk_count` as chunk boundaries are crossed. This method compares that count with `flushed_samples`, copies the next complete chunk out of the shared buffer, releases the buffer lock, writes the chunk to `./tmp/chunk_live_NNNN_TIMESTAMP.wav`, advances `flushed_samples`, and returns the path. Repeated calls drain multiple ready chunks without losing boundaries.
+The audio callback updates `ready_chunk_count` as chunk boundaries are crossed. This method compares that count with `flushed_samples`, copies the next complete chunk out of the shared buffer, releases the buffer lock, writes the chunk to a collision-safe temporary WAV path, removes the flushed samples from memory, advances `flushed_samples`, and returns the path. Repeated calls drain multiple ready chunks without losing boundaries or retaining the full recording in memory.
 
 ### `stop_recording(&mut self) -> Result<StopResult>`
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,5 +1,22 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 pub mod recorder;
 pub mod splitter;
 pub use recorder::{AudioRecorder, StopResult};
 #[allow(unused_imports)]
 pub use splitter::{TmpChunk, split_wav};
+
+static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_wav_path(prefix: &str) -> Result<PathBuf, std::time::SystemTimeError> {
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    Ok(PathBuf::from(format!(
+        "./tmp/{prefix}_{}_{}_{}.wav",
+        std::process::id(),
+        timestamp,
+        sequence
+    )))
+}

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -4,11 +4,13 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use hound::{WavSpec, WavWriter};
 use tracing::{debug, error, info, instrument, warn};
+
+use super::unique_temp_wav_path;
 
 pub struct AudioRecorder {
     recording: Arc<AtomicBool>,
@@ -179,9 +181,6 @@ impl AudioRecorder {
         buffer.lock().unwrap().clear();
         sample_count.store(0, Ordering::Relaxed);
 
-        // Set to true before starting stream to avoid dropping initial frames
-        self.recording.store(true, Ordering::Relaxed);
-
         let stream = match sample_format {
             cpal::SampleFormat::I16 => device.build_input_stream(
                 &config.into(),
@@ -207,7 +206,7 @@ impl AudioRecorder {
                 },
                 move |err| error!(error = %err, "Stream error"),
                 None,
-            )?,
+            ),
             cpal::SampleFormat::F32 => device.build_input_stream(
                 &config.into(),
                 move |data: &[f32], _: &cpal::InputCallbackInfo| {
@@ -232,14 +231,20 @@ impl AudioRecorder {
                 },
                 move |err| error!(error = %err, "Stream error"),
                 None,
-            )?,
+            ),
             _ => {
                 self.recording.store(false, Ordering::Relaxed);
                 return Err("Unsupported sample format".into());
             }
-        };
+        }?;
 
-        stream.play()?;
+        // Enable callbacks immediately before playback. Roll back the state if
+        // the backend rejects playback so the next start request can retry.
+        self.recording.store(true, Ordering::Relaxed);
+        if let Err(error) = stream.play() {
+            self.recording.store(false, Ordering::Relaxed);
+            return Err(error.into());
+        }
         self.stream = Some(stream);
 
         info!("Recording started");
@@ -268,19 +273,20 @@ impl AudioRecorder {
         let chunk_samples = {
             let buffer = self.buffer.lock().unwrap();
             let total_samples = buffer.len();
-            if total_samples < chunk_end {
+            if total_samples < self.chunk_max_samples {
                 debug!(
                     total_samples = total_samples,
-                    chunk_end = chunk_end,
+                    chunk_size = self.chunk_max_samples,
                     "Chunk count is ahead of buffered samples; retrying later"
                 );
                 return None;
             }
-            buffer[self.flushed_samples..chunk_end].to_vec()
+            buffer[..self.chunk_max_samples].to_vec()
         };
 
         match self.write_chunk(&chunk_samples, chunk_index) {
             Ok(path) => {
+                self.buffer.lock().unwrap().drain(..self.chunk_max_samples);
                 self.flushed_samples = chunk_end;
                 Some(path)
             }
@@ -298,11 +304,7 @@ impl AudioRecorder {
         chunk_index: usize,
     ) -> Result<String, Box<dyn std::error::Error>> {
         std::fs::create_dir_all("./tmp")?;
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-        let path = PathBuf::from(format!(
-            "./tmp/chunk_live_{:04}_{}.wav",
-            chunk_index, timestamp
-        ));
+        let path = unique_temp_wav_path(&format!("chunk_live_{chunk_index:04}"))?;
 
         write_wav_to_path(&path, samples, self.sample_rate)?;
 
@@ -336,7 +338,7 @@ impl AudioRecorder {
                 return Err("No audio data recorded".into());
             }
 
-            let tail_samples = buffer[self.flushed_samples..].to_vec();
+            let tail_samples = buffer.to_vec();
             let chunk_index = if self.flushed_samples > 0 && self.chunk_max_samples > 0 {
                 self.flushed_samples / self.chunk_max_samples
             } else {
@@ -403,8 +405,7 @@ impl AudioRecorder {
         buffer: &[i16],
     ) -> Result<String, Box<dyn std::error::Error>> {
         std::fs::create_dir_all("./tmp")?;
-        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-        let path = PathBuf::from(format!("./tmp/recording_{}.wav", timestamp));
+        let path = unique_temp_wav_path("recording")?;
         let filename = path.to_string_lossy().to_string();
         debug!(path = %filename, "Saving recording");
 
@@ -546,6 +547,23 @@ mod tests {
         assert!(fourth.is_none());
         assert_eq!(recorder.flushed_samples, 30);
         assert_eq!(recorder.current_session_files.len(), 3);
+        assert!(
+            recorder.buffer.lock().unwrap().is_empty(),
+            "flushed samples should be released from memory"
+        );
+
+        for path in recorder.current_session_files {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn test_chunk_paths_are_unique() {
+        let mut recorder = recorder_for_buffer(Vec::new(), 10);
+        let first = recorder.write_chunk(&[1, 2, 3], 0).unwrap();
+        let second = recorder.write_chunk(&[4, 5, 6], 0).unwrap();
+
+        assert_ne!(first, second);
 
         for path in recorder.current_session_files {
             let _ = std::fs::remove_file(path);

--- a/src/audio/splitter.rs
+++ b/src/audio/splitter.rs
@@ -1,8 +1,10 @@
+use std::io::Read;
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use hound::{WavReader, WavSpec, WavWriter};
+use hound::{Sample, WavReader, WavSpec, WavWriter};
 use tracing::{debug, info, warn};
+
+use super::unique_temp_wav_path;
 
 /// A temporary WAV chunk file that deletes itself when dropped.
 pub struct TmpChunk {
@@ -49,7 +51,13 @@ pub fn split_wav(
     let spec = reader.spec();
 
     const WAV_HEADER_BYTES: u64 = 44;
-    let bytes_per_sample = (spec.bits_per_sample / 8) as u64;
+    if max_chunk_size_bytes > 0 && max_chunk_size_bytes <= WAV_HEADER_BYTES {
+        return Err(format!(
+            "max_chunk_size_bytes must be greater than the {WAV_HEADER_BYTES}-byte WAV header"
+        )
+        .into());
+    }
+    let bytes_per_sample = spec.bits_per_sample.div_ceil(8) as u64;
     let channels = spec.channels as u64;
     let sample_rate = spec.sample_rate as u64;
 
@@ -85,8 +93,6 @@ pub fn split_wav(
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("audio");
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-
     std::fs::create_dir_all("./tmp")?;
 
     let chunk_spec = WavSpec {
@@ -96,15 +102,32 @@ pub fn split_wav(
         sample_format: spec.sample_format,
     };
 
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            split_samples::<_, f32>(&mut reader, chunk_spec, chunk_max_samples, source)
+        }
+        hound::SampleFormat::Int => {
+            split_samples::<_, i32>(&mut reader, chunk_spec, chunk_max_samples, source)
+        }
+    }
+}
+
+fn split_samples<R, S>(
+    reader: &mut WavReader<R>,
+    chunk_spec: WavSpec,
+    chunk_max_samples: u64,
+    source: &str,
+) -> Result<Vec<TmpChunk>, Box<dyn std::error::Error>>
+where
+    R: Read,
+    S: Sample,
+{
     let mut chunks: Vec<TmpChunk> = Vec::new();
-    let mut samples_iter = reader.samples::<i16>();
+    let mut samples_iter = reader.samples::<S>();
     let mut chunk_index: usize = 0;
 
     loop {
-        let chunk_path = PathBuf::from(format!(
-            "./tmp/chunk_{}_{}_{}.wav",
-            source, chunk_index, timestamp
-        ));
+        let chunk_path = unique_temp_wav_path(&format!("chunk_{source}_{chunk_index}"))?;
 
         let mut writer = WavWriter::create(&chunk_path, chunk_spec)?;
         let mut samples_written: u64 = 0;
@@ -175,6 +198,21 @@ mod tests {
         let mut writer = WavWriter::create(path, spec).unwrap();
         for i in 0..num_samples {
             writer.write_sample(i as i16).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn write_float_test_wav(path: &str, sample_rate: u32, num_samples: u32) {
+        std::fs::create_dir_all("./tmp").unwrap();
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate,
+            bits_per_sample: 32,
+            sample_format: hound::SampleFormat::Float,
+        };
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        for i in 0..num_samples {
+            writer.write_sample(i as f32 / num_samples as f32).unwrap();
         }
         writer.finalize().unwrap();
     }
@@ -272,6 +310,48 @@ mod tests {
             2,
             "10 000 samples split into 5 000-sample chunks should give 2 chunks"
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_split_float_wav_preserves_format() {
+        let path = "./tmp/test_split_float.wav";
+        write_float_test_wav(path, 16_000, 32_000);
+
+        let chunks = split_wav(path, 1, 0).unwrap();
+
+        assert_eq!(chunks.len(), 2);
+        for chunk in &chunks {
+            let reader = WavReader::open(&chunk.path).unwrap();
+            assert_eq!(reader.spec().sample_format, hound::SampleFormat::Float);
+            assert_eq!(reader.spec().bits_per_sample, 32);
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_too_small_chunk_size_is_rejected() {
+        let path = "./tmp/test_invalid_chunk_size.wav";
+        write_test_wav(path, 16_000, 100);
+
+        let error = match split_wav(path, 0, 44) {
+            Ok(_) => panic!("expected invalid chunk size to fail"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains("max_chunk_size_bytes"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_concurrent_splits_use_unique_paths() {
+        let path = "./tmp/test_unique_split.wav";
+        write_test_wav(path, 16_000, 32_000);
+
+        let first = split_wav(path, 1, 0).unwrap();
+        let second = split_wav(path, 1, 0).unwrap();
+
+        assert_ne!(first[0].path, second[0].path);
         let _ = std::fs::remove_file(path);
     }
 }


### PR DESCRIPTION
## Summary

- recover recorder state when audio stream startup fails
- release flushed live audio samples to bound long-recording memory usage
- generate collision-safe temporary WAV paths
- preserve float and high-bit-depth integer WAV formats while splitting
- reject invalid chunk-size limits that cannot contain a WAV header

## Validation

- cargo test (136 passed)
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check