### PR TITLE
fix(core): harden config and session orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ viberwhisper convert input.wav --output output.txt
 |------|------|--------|------|
 | `max_chunk_duration_secs` | 数字 | `30` | 每个分片最大秒数（0 = 不限） |
 | `max_chunk_size_bytes` | 数字 | `24117248` | 每个分片最大字节数（0 = 不限） |
-| `max_retries` | 数字 | `3` | 分片上传失败最大重试次数 |
-| `convergence_timeout_secs` | 数字 | `30` | 录音结束后等待所有分片转写完成的超时秒数 |
+| `max_retries` | 数字 | `3` | 分片上传失败最大重试次数（最大 16） |
+| `convergence_timeout_secs` | 数字 | `30` | 录音结束后等待所有分片转写完成的超时秒数（最大 3600） |
 
 ### LLM 后处理
 
@@ -161,7 +161,7 @@ viberwhisper convert input.wav --output output.txt
 | `post_process_prompt` | 字符串 | 内置默认 | 后处理系统提示词 |
 | `post_process_temperature` | 数字 | `0.0` | 后处理温度 |
 
-> **注意**：`config.json` 已在 `.gitignore` 中排除，避免误提交真实密钥。`api_key` 和 `post_process_api_key` 不会被程序写回磁盘。
+> **注意**：`config.json` 已在 `.gitignore` 中排除，避免误提交真实密钥。程序不会把环境变量中的密钥写入磁盘；手工写在 `config.json` 中的密钥会在更新其他配置项时原样保留。
 > 后处理当前固定使用 OpenAI-compatible chat completions 请求格式。
 
 ### 本地模式

--- a/changelog
+++ b/changelog
@@ -19,3 +19,4 @@
 2026-04-06: Add local Gemma service management: Python FastAPI server under server/, local install/start/stop/status CLI, runtime endpoint overrides, and local backend config fields
 2026-04-06: Move the local Gemma runtime to `server/` and complete local CLI/runtime wiring to the planned FastAPI service
 2026-07-05: Fix audio recorder recovery, bounded live-chunk memory, collision-safe temp files, and non-i16 WAV splitting
+2026-07-05: Harden core configuration persistence, validation, session shutdown, chunk cleanup, and transcription failure handling

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -29,8 +29,8 @@ pub struct AppConfig {
     pub mic_gain: f32,
     pub max_chunk_duration_secs: u32,         // max seconds per audio chunk (default: 30)
     pub max_chunk_size_bytes: u64,            // max bytes per chunk incl. WAV header (default: 23 MiB)
-    pub max_retries: u32,                     // max retry attempts per chunk upload (default: 3)
-    pub convergence_timeout_secs: u64,        // session convergence timeout (default: 30)
+    pub max_retries: u32,                     // max retry attempts (default: 3, max: 16)
+    pub convergence_timeout_secs: u64,        // timeout (default: 30s, max: 3600s)
 
     // --- LLM Post-processing ---
     pub post_process_enabled: bool,           // default: false
@@ -86,7 +86,7 @@ Loads config in priority order:
 
 **`save(&self) -> Result<()>`**
 
-Serializes to pretty-printed JSON. `api_key` and `post_process_api_key` are never written to disk.
+Serializes to pretty-printed JSON. Runtime/environment secrets are never introduced into the file. If `api_key`, legacy `groq_api_key`, or `post_process_api_key` already exists in `config.json`, it is preserved when other fields are updated.
 
 **`get_field(&self, key: &str) -> Option<String>`**
 
@@ -94,7 +94,7 @@ Returns a string representation of the named field. Supported keys: `api_key`, `
 
 **`set_field(&mut self, key: &str, value: &str) -> Result<(), String>`**
 
-Sets a field by name with auto type conversion (strings, floats, bools, integers). `groq_api_key` is accepted as an alias for `api_key`. Local runtime keys can also be mutated from CLI.
+Sets a field by name with type conversion and validation. Non-finite floats are rejected, `max_retries` is capped at 16, and `convergence_timeout_secs` is capped at 3600. Secret fields cannot be set through this command; use the documented environment variables or edit `config.json` directly. Local runtime keys can also be mutated from CLI.
 
 **`apply_json(&mut self, json: &Value)`** *(private)*
 
@@ -155,6 +155,8 @@ Parsed with `clap::Parser`. No subcommand runs the main recording loop.
 - **Chunk State Machine**: `Flushed → Uploading → Transcribed / Failed`
 - **Convergence Timeout**: Configurable via `convergence_timeout_secs`; chunks still pending at the deadline are marked `Failed(Timeout)`
 - **Partial Failure**: If some chunks succeed and others fail, returns partial text with an error
+- **Bounded Queue**: Chunk submission is non-blocking. A full queue marks the chunk failed and deletes its temporary file rather than stalling session shutdown.
+- **Cleanup Guarantee**: Processed, rejected, orphaned, timed-out queued, and panicking-transcriber chunk paths are cleaned up by the orchestrator.
 
 ### `SessionError` Enum
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -3,6 +3,8 @@ use std::fs;
 use tracing::{info, warn};
 
 const CONFIG_FILE: &str = "config.json";
+const MAX_RETRIES: u32 = 16;
+const MAX_CONVERGENCE_TIMEOUT_SECS: u64 = 60 * 60;
 
 /// Default transcription API URL (Groq Whisper endpoint).
 const DEFAULT_TRANSCRIPTION_API_URL: &str = "https://api.groq.com/openai/v1/audio/transcriptions";
@@ -33,6 +35,26 @@ fn default_local_server_port() -> u16 {
 
 fn default_local_quantization() -> String {
     "int8".to_string()
+}
+
+fn parse_finite_f32(key: &str, value: &str) -> Result<f32, String> {
+    let parsed = value
+        .parse::<f32>()
+        .map_err(|_| format!("{key} must be a float, got: {value}"))?;
+    if !parsed.is_finite() {
+        return Err(format!("{key} must be finite, got: {value}"));
+    }
+    Ok(parsed)
+}
+
+fn finite_f32_from_json(key: &str, value: f64) -> Option<f32> {
+    let narrowed = value as f32;
+    if narrowed.is_finite() {
+        Some(narrowed)
+    } else {
+        warn!(key, value, "Ignoring non-finite or out-of-range float");
+        None
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -179,9 +201,33 @@ impl AppConfig {
 
     /// Save config to config.json (excludes api_key — never persisted)
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let json = serde_json::to_string_pretty(self)?;
+        let existing = fs::read_to_string(CONFIG_FILE)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok());
+        let value = self.json_for_save(existing.as_ref())?;
+        let json = serde_json::to_string_pretty(&value)?;
         fs::write(CONFIG_FILE, json)?;
         Ok(())
+    }
+
+    /// Build the serialized config while retaining secrets that were already
+    /// present on disk. Runtime/env secrets are deliberately never introduced.
+    fn json_for_save(
+        &self,
+        existing: Option<&serde_json::Value>,
+    ) -> Result<serde_json::Value, serde_json::Error> {
+        let mut value = serde_json::to_value(self)?;
+        if let (Some(output), Some(existing)) = (value.as_object_mut(), existing) {
+            for key in ["api_key", "groq_api_key", "post_process_api_key"] {
+                if let Some(secret) = existing.get(key).and_then(serde_json::Value::as_str) {
+                    output.insert(
+                        key.to_string(),
+                        serde_json::Value::String(secret.to_string()),
+                    );
+                }
+            }
+        }
+        Ok(value)
     }
 
     /// Get the string value of a config field
@@ -224,10 +270,10 @@ impl AppConfig {
     /// Set a config field value (accepts string, auto-converts types)
     pub fn set_field(&mut self, key: &str, value: &str) -> Result<(), String> {
         match key {
-            "api_key" | "groq_api_key" => {
-                self.api_key = Some(value.to_string());
-                Ok(())
-            }
+            "api_key" | "groq_api_key" => Err(
+                "api_key cannot be saved by the config command; use the TRANSCRIPTION_API_KEY environment variable or edit config.json manually"
+                    .to_string(),
+            ),
             "transcription_api_url" => {
                 self.transcription_api_url = value.to_string();
                 Ok(())
@@ -257,15 +303,11 @@ impl AppConfig {
                 Ok(())
             }
             "temperature" => {
-                self.temperature = value
-                    .parse::<f32>()
-                    .map_err(|_| format!("temperature must be a float, got: {}", value))?;
+                self.temperature = parse_finite_f32("temperature", value)?;
                 Ok(())
             }
             "mic_gain" => {
-                self.mic_gain = value
-                    .parse::<f32>()
-                    .map_err(|_| format!("mic_gain must be a float, got: {}", value))?;
+                self.mic_gain = parse_finite_f32("mic_gain", value)?;
                 Ok(())
             }
             "max_chunk_duration_secs" => {
@@ -281,15 +323,25 @@ impl AppConfig {
                 Ok(())
             }
             "max_retries" => {
-                self.max_retries = value
+                let parsed = value
                     .parse::<u32>()
                     .map_err(|_| format!("max_retries must be a u32, got: {}", value))?;
+                if parsed > MAX_RETRIES {
+                    return Err(format!("max_retries must be <= {MAX_RETRIES}, got: {value}"));
+                }
+                self.max_retries = parsed;
                 Ok(())
             }
             "convergence_timeout_secs" => {
-                self.convergence_timeout_secs = value.parse::<u64>().map_err(|_| {
+                let parsed = value.parse::<u64>().map_err(|_| {
                     format!("convergence_timeout_secs must be a u64, got: {}", value)
                 })?;
+                if parsed > MAX_CONVERGENCE_TIMEOUT_SECS {
+                    return Err(format!(
+                        "convergence_timeout_secs must be <= {MAX_CONVERGENCE_TIMEOUT_SECS}, got: {value}"
+                    ));
+                }
+                self.convergence_timeout_secs = parsed;
                 Ok(())
             }
             "post_process_enabled" => {
@@ -311,10 +363,10 @@ impl AppConfig {
                 self.post_process_api_url = Some(value.to_string());
                 Ok(())
             }
-            "post_process_api_key" => {
-                self.post_process_api_key = Some(value.to_string());
-                Ok(())
-            }
+            "post_process_api_key" => Err(
+                "post_process_api_key cannot be saved by the config command; use the POST_PROCESS_API_KEY environment variable or edit config.json manually"
+                    .to_string(),
+            ),
             "post_process_model" => {
                 self.post_process_model = Some(value.to_string());
                 Ok(())
@@ -324,9 +376,8 @@ impl AppConfig {
                 Ok(())
             }
             "post_process_temperature" => {
-                self.post_process_temperature = value.parse::<f32>().map_err(|_| {
-                    format!("post_process_temperature must be a float, got: {}", value)
-                })?;
+                self.post_process_temperature =
+                    parse_finite_f32("post_process_temperature", value)?;
                 Ok(())
             }
             "local_mode" => {
@@ -385,8 +436,10 @@ impl AppConfig {
         if let Some(lang) = json["language"].as_str() {
             self.language = Some(lang.to_string());
         }
-        if let Some(temp) = json["temperature"].as_f64() {
-            self.temperature = temp as f32;
+        if let Some(temp) = json["temperature"].as_f64()
+            && let Some(value) = finite_f32_from_json("temperature", temp)
+        {
+            self.temperature = value;
         }
         // Backward compat: old hotkey field maps to hold_hotkey
         if let Some(hotkey) = json["hotkey"].as_str() {
@@ -398,23 +451,44 @@ impl AppConfig {
         if let Some(hotkey) = json["toggle_hotkey"].as_str() {
             self.toggle_hotkey = hotkey.to_string();
         }
-        if let Some(gain) = json["mic_gain"].as_f64() {
-            self.mic_gain = gain as f32;
+        if let Some(gain) = json["mic_gain"].as_f64()
+            && let Some(value) = finite_f32_from_json("mic_gain", gain)
+        {
+            self.mic_gain = value;
         }
         if let Some(prompt) = json["prompt"].as_str() {
             self.prompt = Some(prompt.to_string());
         }
         if let Some(v) = json["max_chunk_duration_secs"].as_u64() {
-            self.max_chunk_duration_secs = v as u32;
+            match u32::try_from(v) {
+                Ok(value) => self.max_chunk_duration_secs = value,
+                Err(_) => warn!(value = v, "Ignoring out-of-range max_chunk_duration_secs"),
+            }
         }
         if let Some(v) = json["max_chunk_size_bytes"].as_u64() {
             self.max_chunk_size_bytes = v;
         }
         if let Some(v) = json["max_retries"].as_u64() {
-            self.max_retries = v as u32;
+            match u32::try_from(v) {
+                Ok(value) if value <= MAX_RETRIES => self.max_retries = value,
+                Ok(value) => warn!(
+                    value,
+                    max = MAX_RETRIES,
+                    "Ignoring max_retries above supported limit"
+                ),
+                Err(_) => warn!(value = v, "Ignoring out-of-range max_retries"),
+            }
         }
         if let Some(v) = json["convergence_timeout_secs"].as_u64() {
-            self.convergence_timeout_secs = v;
+            if v <= MAX_CONVERGENCE_TIMEOUT_SECS {
+                self.convergence_timeout_secs = v;
+            } else {
+                warn!(
+                    value = v,
+                    max = MAX_CONVERGENCE_TIMEOUT_SECS,
+                    "Ignoring convergence_timeout_secs above supported limit"
+                );
+            }
         }
         if let Some(v) = json["post_process_enabled"].as_bool() {
             self.post_process_enabled = v;
@@ -434,8 +508,10 @@ impl AppConfig {
         if let Some(v) = json["post_process_prompt"].as_str() {
             self.post_process_prompt = Some(v.to_string());
         }
-        if let Some(v) = json["post_process_temperature"].as_f64() {
-            self.post_process_temperature = v as f32;
+        if let Some(v) = json["post_process_temperature"].as_f64()
+            && let Some(value) = finite_f32_from_json("post_process_temperature", v)
+        {
+            self.post_process_temperature = value;
         }
         if let Some(v) = json["local_mode"].as_bool() {
             self.local_mode = v;
@@ -444,7 +520,10 @@ impl AppConfig {
             self.local_data_dir = Some(v.to_string());
         }
         if let Some(v) = json["local_server_port"].as_u64() {
-            self.local_server_port = v as u16;
+            match u16::try_from(v) {
+                Ok(value) => self.local_server_port = value,
+                Err(_) => warn!(value = v, "Ignoring out-of-range local_server_port"),
+            }
         }
         if let Some(v) = json["local_quantization"].as_str() {
             self.local_quantization = v.to_string();
@@ -479,21 +558,18 @@ mod tests {
     fn test_api_key_get_set() {
         let mut config = AppConfig::default();
         assert_eq!(config.get_field("api_key"), None);
-        config.set_field("api_key", "mykey").unwrap();
-        assert_eq!(config.api_key.as_deref(), Some("mykey"));
-        assert_eq!(config.get_field("api_key"), Some("*** (set)".to_string()));
+        let error = config.set_field("api_key", "mykey").unwrap_err();
+        assert!(error.contains("environment variable"));
+        assert!(config.api_key.is_none());
     }
 
     #[test]
     fn test_groq_api_key_alias() {
-        // groq_api_key is an alias for api_key in get/set
+        // groq_api_key is an alias for api_key when reading, but secrets cannot
+        // be persisted through the config CLI.
         let mut config = AppConfig::default();
-        config.set_field("groq_api_key", "legacykey").unwrap();
-        assert_eq!(config.api_key.as_deref(), Some("legacykey"));
-        assert_eq!(
-            config.get_field("groq_api_key"),
-            Some("*** (set)".to_string())
-        );
+        assert!(config.set_field("groq_api_key", "legacykey").is_err());
+        assert!(config.api_key.is_none());
     }
 
     #[test]
@@ -615,6 +691,66 @@ mod tests {
     }
 
     #[test]
+    fn test_set_field_rejects_non_finite_floats() {
+        let mut config = AppConfig::default();
+
+        for (key, value) in [
+            ("temperature", "NaN"),
+            ("mic_gain", "inf"),
+            ("post_process_temperature", "-inf"),
+        ] {
+            assert!(
+                config.set_field(key, value).is_err(),
+                "accepted {key}={value}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_json_rejects_floats_that_overflow_f32() {
+        let mut config = AppConfig::default();
+        let json = serde_json::json!({
+            "temperature": 1e300,
+            "mic_gain": -1e300,
+            "post_process_temperature": 1e300
+        });
+
+        config.apply_json(&json);
+
+        assert_eq!(config.temperature, 0.0);
+        assert_eq!(config.mic_gain, 1.0);
+        assert_eq!(config.post_process_temperature, 0.0);
+    }
+
+    #[test]
+    fn test_retry_and_timeout_limits_are_enforced() {
+        let mut config = AppConfig::default();
+        assert!(
+            config
+                .set_field("max_retries", &(u64::from(MAX_RETRIES) + 1).to_string())
+                .is_err()
+        );
+        assert!(
+            config
+                .set_field(
+                    "convergence_timeout_secs",
+                    &(MAX_CONVERGENCE_TIMEOUT_SECS + 1).to_string(),
+                )
+                .is_err()
+        );
+
+        config.apply_json(&serde_json::json!({
+            "max_retries": u64::from(MAX_RETRIES) + 1,
+            "convergence_timeout_secs": MAX_CONVERGENCE_TIMEOUT_SECS + 1
+        }));
+        assert_eq!(config.max_retries, default_retries());
+        assert_eq!(
+            config.convergence_timeout_secs,
+            default_convergence_timeout()
+        );
+    }
+
+    #[test]
     fn test_set_field_unknown_key() {
         let mut config = AppConfig::default();
         let result = config.set_field("nonexistent", "value");
@@ -641,6 +777,22 @@ mod tests {
         assert_eq!(config.max_chunk_duration_secs, 60);
         assert_eq!(config.max_chunk_size_bytes, 10485760);
         assert_eq!(config.max_retries, 5);
+    }
+
+    #[test]
+    fn test_apply_json_rejects_out_of_range_narrow_integers() {
+        let mut config = AppConfig::default();
+        let json = serde_json::json!({
+            "max_chunk_duration_secs": u64::from(u32::MAX) + 1,
+            "max_retries": u64::from(u32::MAX) + 1,
+            "local_server_port": u64::from(u16::MAX) + 1
+        });
+
+        config.apply_json(&json);
+
+        assert_eq!(config.max_chunk_duration_secs, default_chunk_duration());
+        assert_eq!(config.max_retries, default_retries());
+        assert_eq!(config.local_server_port, default_local_server_port());
     }
 
     #[test]
@@ -778,12 +930,30 @@ mod tests {
     fn test_get_set_post_process_api_key_masked() {
         let mut config = AppConfig::default();
         assert_eq!(config.get_field("post_process_api_key"), None);
-        config.set_field("post_process_api_key", "secret").unwrap();
-        assert_eq!(config.post_process_api_key.as_deref(), Some("secret"));
-        assert_eq!(
-            config.get_field("post_process_api_key"),
-            Some("*** (set)".to_string())
-        );
+        let error = config
+            .set_field("post_process_api_key", "secret")
+            .unwrap_err();
+        assert!(error.contains("environment variable"));
+        assert!(config.post_process_api_key.is_none());
+    }
+
+    #[test]
+    fn test_save_json_preserves_existing_secret_fields() {
+        let config = AppConfig {
+            model: "updated-model".to_string(),
+            ..AppConfig::default()
+        };
+        let existing = serde_json::json!({
+            "api_key": "transcription-secret",
+            "post_process_api_key": "post-process-secret",
+            "model": "old-model"
+        });
+
+        let saved = config.json_for_save(Some(&existing)).unwrap();
+
+        assert_eq!(saved["api_key"], "transcription-secret");
+        assert_eq!(saved["post_process_api_key"], "post-process-secret");
+        assert_eq!(saved["model"], "updated-model");
     }
 
     #[test]

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -121,7 +121,6 @@ struct ChunkEntry {
 
 enum WorkerMsg {
     Chunk { index: usize, path: String },
-    Done,
 }
 
 struct ActiveSessionInner {
@@ -203,7 +202,11 @@ impl SessionOrchestrator {
     /// or `None` if no session is active.
     pub fn on_chunk_ready(&self, path: String) -> Option<usize> {
         let mut inner = self.inner.lock().unwrap();
-        let session = inner.as_mut()?;
+        let Some(session) = inner.as_mut() else {
+            warn!(path = %path, "Chunk arrived without an active session; deleting it");
+            remove_chunk_file(&path, "orphan");
+            return None;
+        };
 
         let index = session.next_index;
         session.next_index += 1;
@@ -213,17 +216,20 @@ impl SessionOrchestrator {
             state: ChunkState::Flushed,
         });
 
-        if let Err(e) = session.chunk_tx.send(WorkerMsg::Chunk {
+        if let Err(e) = session.chunk_tx.try_send(WorkerMsg::Chunk {
             index,
             path: path.clone(),
         }) {
-            error!(path = %path, error = %e, "Failed to enqueue chunk; marking as failed");
+            let message = match e {
+                mpsc::TrySendError::Full(_) => "worker queue full",
+                mpsc::TrySendError::Disconnected(_) => "worker channel closed",
+            };
+            error!(path = %path, error = message, "Failed to enqueue chunk; marking as failed");
             let mut chunks = session.chunks.lock().unwrap();
             if let Some(entry) = chunks.iter_mut().find(|e| e.index == index) {
-                entry.state = ChunkState::Failed(TranscribeError::Network(
-                    "worker channel closed".to_string(),
-                ));
+                entry.state = ChunkState::Failed(TranscribeError::Network(message.to_string()));
             }
+            remove_chunk_file(&path, "rejected");
         } else {
             info!(index = index, path = %path, "Chunk enqueued for background transcription");
         }
@@ -250,16 +256,16 @@ impl SessionOrchestrator {
         };
 
         if session.next_index == 0 {
-            // No chunks were ever submitted; signal worker to exit and return early.
-            let _ = session.chunk_tx.send(WorkerMsg::Done);
-            drop(session.worker); // let it clean up in background
+            // Closing the channel lets the idle worker exit immediately.
+            drop(session.chunk_tx);
+            let _ = session.worker.join();
             return Err(SessionError::NoChunks);
         }
 
-        // Signal the worker to stop after draining the current queue.
-        if let Err(e) = session.chunk_tx.send(WorkerMsg::Done) {
-            warn!(error = %e, "Failed to send Done to worker (already exited?)");
-        }
+        // Closing the sender is non-blocking. The receiver still drains every
+        // queued chunk before its iterator ends, so the convergence deadline
+        // covers the entire shutdown rather than starting after a blocking send.
+        drop(session.chunk_tx);
 
         let chunks = Arc::clone(&session.chunks);
         let deadline = Instant::now() + self.convergence_timeout;
@@ -325,45 +331,37 @@ fn worker_loop(
 ) {
     for msg in rx {
         match msg {
-            WorkerMsg::Done => {
-                debug!("Worker received Done signal, exiting");
-                break;
-            }
             WorkerMsg::Chunk { index, path } => {
                 // Transition to Uploading.
                 {
                     let mut locked = chunks.lock().unwrap();
-                    if let Some(entry) = locked.iter_mut().find(|e| e.index == index) {
-                        entry.state = ChunkState::Uploading { attempt: 1 };
+                    if let Some(entry) = locked.iter_mut().find(|e| e.index == index)
+                        && !begin_upload(entry)
+                    {
+                        drop(locked);
+                        remove_chunk_file(&path, "skipped");
+                        continue;
                     }
                 }
 
                 debug!(index = index, path = %path, "Worker transcribing chunk");
-                let result = transcriber.transcribe(&path);
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    transcriber.transcribe(&path)
+                }))
+                .unwrap_or_else(|_| Err("transcriber panicked".to_string().into()));
 
                 // Clean up the chunk file (ignore errors — file may already be gone).
-                if let Err(e) = std::fs::remove_file(&path) {
-                    debug!(path = %path, error = %e, "Could not delete chunk file");
-                }
+                remove_chunk_file(&path, "processed");
 
                 // Record outcome.
                 let mut locked = chunks.lock().unwrap();
                 if let Some(entry) = locked.iter_mut().find(|e| e.index == index) {
-                    entry.state = match result {
-                        Ok(text) => {
-                            info!(index = index, "Chunk transcribed successfully");
-                            ChunkState::Transcribed(text)
-                        }
-                        Err(e) => {
-                            let msg = e.to_string();
-                            error!(index = index, error = %msg, "Chunk transcription failed");
-                            ChunkState::Failed(classify_error(&msg))
-                        }
-                    };
+                    record_worker_result(entry, result);
                 }
             }
         }
     }
+    debug!("Worker channel closed, exiting");
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -380,13 +378,64 @@ fn classify_error(error_msg: &str) -> TranscribeError {
     }
 }
 
+fn record_worker_result(
+    entry: &mut ChunkEntry,
+    result: Result<String, Box<dyn std::error::Error>>,
+) {
+    // A convergence timeout is terminal from the caller's perspective. A late
+    // HTTP response must not rewrite the snapshot used for the timeout result.
+    if entry.state.is_terminal() {
+        debug!(
+            index = entry.index,
+            "Ignoring late result for terminal chunk"
+        );
+        return;
+    }
+
+    entry.state = match result {
+        Ok(text) => {
+            info!(index = entry.index, "Chunk transcribed successfully");
+            ChunkState::Transcribed(text)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            error!(index = entry.index, error = %msg, "Chunk transcription failed");
+            ChunkState::Failed(classify_error(&msg))
+        }
+    };
+}
+
+fn begin_upload(entry: &mut ChunkEntry) -> bool {
+    if !matches!(entry.state, ChunkState::Flushed) {
+        debug!(
+            index = entry.index,
+            "Skipping upload for chunk that is no longer flushed"
+        );
+        return false;
+    }
+    entry.state = ChunkState::Uploading { attempt: 1 };
+    true
+}
+
+fn remove_chunk_file(path: &str, reason: &str) {
+    if let Err(e) = std::fs::remove_file(path) {
+        debug!(path, reason, error = %e, "Could not delete chunk file");
+    }
+}
+
 /// Try to parse an HTTP status code out of an error message.
 fn extract_http_status(msg: &str) -> Option<u16> {
-    for token in msg.split_whitespace() {
-        if let Ok(n) = token.parse::<u16>()
-            && (100..=599).contains(&n)
-        {
-            return Some(n);
+    for marker in ["API error ", "HTTP ", "status "] {
+        if let Some(tail) = msg.split_once(marker).map(|(_, tail)| tail) {
+            let digits: String = tail
+                .chars()
+                .take_while(|character| character.is_ascii_digit())
+                .collect();
+            if let Ok(status) = digits.parse::<u16>()
+                && (100..=599).contains(&status)
+            {
+                return Some(status);
+            }
         }
     }
     None
@@ -459,6 +508,7 @@ fn collect_results(chunks: &[ChunkEntry], language: Option<&str>) -> Result<Stri
 mod tests {
     use super::*;
     use crate::transcriber::MockTranscriber;
+    use std::sync::Condvar;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn make_orchestrator_with_timeout(
@@ -512,6 +562,21 @@ mod tests {
     /// Sleeps for `delay` before returning.
     struct SlowTranscriber {
         delay: Duration,
+    }
+
+    struct GateTranscriber {
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl Transcriber for GateTranscriber {
+        fn transcribe(&self, _path: &str) -> Result<String, Box<dyn std::error::Error>> {
+            let (lock, condvar) = &*self.release;
+            let mut released = lock.lock().unwrap();
+            while !*released {
+                released = condvar.wait(released).unwrap();
+            }
+            Ok("released".to_string())
+        }
     }
 
     impl Transcriber for SlowTranscriber {
@@ -588,6 +653,22 @@ mod tests {
     }
 
     #[test]
+    fn test_chunk_without_active_session_is_deleted() {
+        let path = std::env::temp_dir().join(format!(
+            "viberwhisper-orphan-chunk-{}-{:?}.wav",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, b"orphan chunk").unwrap();
+        let orch = default_orchestrator(Arc::new(MockTranscriber));
+
+        let result = orch.on_chunk_ready(path.to_string_lossy().into_owned());
+
+        assert!(result.is_none());
+        assert!(!path.exists(), "orphan chunk file was not deleted");
+    }
+
+    #[test]
     fn test_partial_failure_returns_error_with_partial_text() {
         let t = Arc::new(ScriptedTranscriber::new(vec![
             Ok("good chunk".to_string()),
@@ -634,6 +715,56 @@ mod tests {
             }
             other => panic!("Expected ConvergenceTimeout, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_timed_out_chunk_cannot_be_overwritten_by_late_worker_result() {
+        let mut entry = ChunkEntry {
+            index: 0,
+            state: ChunkState::Failed(TranscribeError::Timeout),
+        };
+
+        assert!(!begin_upload(&mut entry));
+        record_worker_result(&mut entry, Ok("late result".to_string()));
+
+        assert!(matches!(
+            entry.state,
+            ChunkState::Failed(TranscribeError::Timeout)
+        ));
+    }
+
+    #[test]
+    fn test_full_worker_queue_marks_chunk_failed_without_blocking() {
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let t = Arc::new(GateTranscriber {
+            release: Arc::clone(&release),
+        });
+        let orch = default_orchestrator(t);
+        orch.start_session(SessionMode::Hold);
+
+        let started = Instant::now();
+        for index in 0..100 {
+            orch.on_chunk_ready(format!("queue-{index}.wav"));
+        }
+
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "enqueueing blocked on a full worker queue"
+        );
+        let inner = orch.inner.lock().unwrap();
+        let chunks = inner.as_ref().unwrap().chunks.lock().unwrap();
+        assert!(chunks.iter().any(|entry| matches!(
+            entry.state,
+            ChunkState::Failed(TranscribeError::Network(ref message))
+                if message == "worker queue full"
+        )));
+        drop(chunks);
+        drop(inner);
+
+        let (lock, condvar) = &*release;
+        *lock.lock().unwrap() = true;
+        condvar.notify_all();
+        let _ = orch.stop_session();
     }
 
     #[test]
@@ -695,6 +826,25 @@ mod tests {
     }
 
     #[test]
+    fn test_worker_panic_removes_chunk_file_and_reports_failure() {
+        let path = std::env::temp_dir().join(format!(
+            "viberwhisper-panic-chunk-{}-{:?}.wav",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, b"test chunk").unwrap();
+        let t = Arc::new(PanicTranscriber);
+        let orch = default_orchestrator(t);
+
+        orch.start_session(SessionMode::Hold);
+        orch.on_chunk_ready(path.to_string_lossy().into_owned());
+        let result = orch.stop_session();
+
+        assert!(matches!(result, Err(SessionError::PartialFailure { .. })));
+        assert!(!path.exists(), "panicking worker leaked chunk file");
+    }
+
+    #[test]
     fn test_merge_texts_zh() {
         let texts = vec!["你好".to_string(), "世界".to_string()];
         assert_eq!(merge_texts(&texts, Some("zh")), "你好世界");
@@ -716,6 +866,12 @@ mod tests {
     fn test_classify_error_api() {
         let e = classify_error("HTTP 400 bad request");
         assert!(matches!(e, TranscribeError::Api { status: 400, .. }));
+
+        let e = classify_error("API error 429: too many requests");
+        assert!(matches!(e, TranscribeError::Api { status: 429, .. }));
+
+        let e = classify_error("chunk 1/1 failed after 4 attempts: API error 500: unavailable");
+        assert!(matches!(e, TranscribeError::Api { status: 500, .. }));
     }
 
     #[test]
@@ -729,5 +885,10 @@ mod tests {
         assert_eq!(extract_http_status("status 500 internal"), Some(500));
         assert_eq!(extract_http_status("connection refused"), None);
         assert_eq!(extract_http_status("HTTP 429 too many requests"), Some(429));
+        assert_eq!(
+            extract_http_status("API error 400: invalid request"),
+            Some(400)
+        );
+        assert_eq!(extract_http_status("received 500 bytes"), None);
     }
 }


### PR DESCRIPTION
## Summary
- preserve existing config secrets while preventing CLI from pretending to persist runtime secrets
- validate finite floats, integer narrowing, retry limits, and convergence timeout limits
- make chunk submission and worker shutdown non-blocking while preserving partial failure reporting
- guarantee chunk cleanup across rejected, orphaned, timed-out, and panicking transcription paths
- classify real OpenAI-compatible API error strings correctly and sync core documentation

## Validation
- cargo test (145 passed)
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo check