### PR TITLE
fix(input): harden desktop input handling

### DIFF
--- a/changelog
+++ b/changelog
@@ -20,3 +20,4 @@
 2026-04-06: Move the local Gemma runtime to `server/` and complete local CLI/runtime wiring to the planned FastAPI service
 2026-07-05: Fix audio recorder recovery, bounded live-chunk memory, collision-safe temp files, and non-i16 WAV splitting
 2026-07-05: Harden core configuration persistence, validation, session shutdown, chunk cleanup, and transcription failure handling
+2026-07-05: Harden input hotkey ordering and validation, tray state updates, and overlay focus and Windows state ownership

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -33,27 +33,28 @@ Note: `Released` is only emitted for `Hold` source (toggle mode uses press-only 
 
 ```rust
 pub struct HotkeyManager {
-    running: Arc<AtomicBool>,
+    events: Receiver<HotkeyEvent>,
 }
 ```
 
-Spawns an `rdev::listen` thread that writes to three module-level `AtomicBool` flags (`HOLD_PRESSED`, `HOLD_RELEASED`, `TOGGLE_PRESSED`).
+Spawns an `rdev::listen` thread that maps native events into an ordered channel. Per-binding key-down state suppresses operating-system key-repeat events so one physical toggle press produces one toggle action.
 
 ### Key Methods
 
 **`HotkeyManager::new(hold_hotkey: &str, toggle_hotkey: &str) -> Result<Self>`**
 
 - Parses both hotkey strings via `parse_key()`.
-- Requires at least one valid key; returns an error if both are empty/invalid.
-- Spawns the listener thread and sleeps 100 ms to allow it to start.
+- Treats an empty string as a disabled binding and rejects any non-empty invalid binding.
+- Requires at least one enabled key and rejects assigning the same key to both modes.
+- Spawns the listener thread without blocking application startup.
 
 **`check_event(&self) -> Option<HotkeyEvent>`**
 
-Polls the atomic flags (swap-to-false). Priority order: `HoldPressed` → `HoldReleased` → `TogglePressed`. Called from the main loop on each iteration.
+Non-blockingly receives the oldest pending event. Called from the main loop on each iteration; later events remain queued in their original order.
 
 **`parse_key(s: &str) -> Option<Key>`**
 
-Maps key name strings (`"F1"`–`"F12"`, case-insensitive) to `rdev::Key` variants.
+Maps trimmed key name strings (`"F1"`–`"F12"`, case-insensitive) to `rdev::Key` variants.
 
 ---
 
@@ -84,6 +85,7 @@ pub struct TrayManager {
     tray_icon: TrayIcon,
     icon_idle: Icon,
     icon_recording: Icon,
+    status_item: MenuItem,
     exit_item_id: MenuId,
 }
 ```
@@ -105,7 +107,7 @@ Builds the tray icon with a menu containing: title item, status item, separator,
 
 **`set_recording(&mut self, recording: bool)`**
 
-Switches icon and tooltip based on recording state.
+Switches the icon, tooltip, and menu status text based on recording state. Native icon/tooltip update failures are logged rather than silently discarded.
 
 **`check_exit(&self) -> bool`**
 

--- a/src/input/hotkey.rs
+++ b/src/input/hotkey.rs
@@ -1,19 +1,13 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
 
 use rdev::{Event, EventType, Key, listen};
 use tracing::{debug, error, info};
 
-// Thread-safe state for tracking key states
-static HOLD_PRESSED: AtomicBool = AtomicBool::new(false);
-static HOLD_RELEASED: AtomicBool = AtomicBool::new(false);
-static TOGGLE_PRESSED: AtomicBool = AtomicBool::new(false);
-
-/// Parse a hotkey string into an rdev::Key
-pub fn parse_key(s: &str) -> Option<Key> {
-    match s.to_uppercase().as_str() {
+/// Parse a configured function key. Empty strings disable a binding.
+pub fn parse_key(value: &str) -> Option<Key> {
+    match value.trim().to_ascii_uppercase().as_str() {
         "F1" => Some(Key::F1),
         "F2" => Some(Key::F2),
         "F3" => Some(Key::F3),
@@ -30,100 +24,123 @@ pub fn parse_key(s: &str) -> Option<Key> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HotkeySource {
     Hold,
     Toggle,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HotkeyEvent {
     Pressed(HotkeySource),
     Released(HotkeySource),
 }
 
+#[derive(Debug)]
+struct EventMapper {
+    hold_key: Option<Key>,
+    toggle_key: Option<Key>,
+    hold_down: bool,
+    toggle_down: bool,
+}
+
+impl EventMapper {
+    fn new(hold_key: Option<Key>, toggle_key: Option<Key>) -> Self {
+        Self {
+            hold_key,
+            toggle_key,
+            hold_down: false,
+            toggle_down: false,
+        }
+    }
+
+    fn map(&mut self, event_type: &EventType) -> Option<HotkeyEvent> {
+        match event_type {
+            EventType::KeyPress(key) if Some(*key) == self.hold_key && !self.hold_down => {
+                self.hold_down = true;
+                Some(HotkeyEvent::Pressed(HotkeySource::Hold))
+            }
+            EventType::KeyRelease(key) if Some(*key) == self.hold_key && self.hold_down => {
+                self.hold_down = false;
+                Some(HotkeyEvent::Released(HotkeySource::Hold))
+            }
+            EventType::KeyPress(key) if Some(*key) == self.toggle_key && !self.toggle_down => {
+                self.toggle_down = true;
+                Some(HotkeyEvent::Pressed(HotkeySource::Toggle))
+            }
+            EventType::KeyRelease(key) if Some(*key) == self.toggle_key && self.toggle_down => {
+                self.toggle_down = false;
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
 pub struct HotkeyManager {
-    running: Arc<AtomicBool>,
+    events: Receiver<HotkeyEvent>,
 }
 
 impl HotkeyManager {
     pub fn new(hold_hotkey: &str, toggle_hotkey: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let hold_key = parse_key(hold_hotkey);
-        let toggle_key = parse_key(toggle_hotkey);
+        let hold_key = parse_binding("hold_hotkey", hold_hotkey)?;
+        let toggle_key = parse_binding("toggle_hotkey", toggle_hotkey)?;
 
         if hold_key.is_none() && toggle_key.is_none() {
-            return Err(
-                "At least one valid hotkey must be configured (hold_hotkey or toggle_hotkey)"
-                    .into(),
-            );
+            return Err("at least one hotkey must be configured".into());
+        }
+        if hold_key == toggle_key {
+            return Err("hold_hotkey and toggle_hotkey must use different keys".into());
         }
 
-        let running = Arc::new(AtomicBool::new(true));
-
-        thread::spawn(move || {
-            debug!("rdev listener thread started");
-
-            let callback = move |event: Event| match &event.event_type {
-                EventType::KeyPress(key) => {
-                    if let Some(hk) = hold_key
-                        && *key == hk
-                    {
-                        HOLD_PRESSED.store(true, Ordering::Relaxed);
-                    }
-                    if let Some(tk) = toggle_key
-                        && *key == tk
-                    {
-                        TOGGLE_PRESSED.store(true, Ordering::Relaxed);
-                    }
-                }
-                EventType::KeyRelease(key) => {
-                    if let Some(hk) = hold_key
-                        && *key == hk
-                    {
-                        HOLD_RELEASED.store(true, Ordering::Relaxed);
-                    }
-                }
-                _ => {}
-            };
-
-            if let Err(e) = listen(callback) {
-                error!(error = ?e, "rdev listen failed");
-            }
-
-            debug!("rdev listener thread exiting");
-        });
-
-        // Give the listener a moment to start
-        thread::sleep(Duration::from_millis(100));
+        let (sender, events) = mpsc::channel();
+        spawn_listener(EventMapper::new(hold_key, toggle_key), sender);
 
         if hold_key.is_some() {
-            info!(hotkey = %hold_hotkey, "hold hotkey registered");
+            info!(hotkey = %hold_hotkey.trim(), "hold hotkey registered");
         }
         if toggle_key.is_some() {
-            info!(hotkey = %toggle_hotkey, "toggle hotkey registered");
+            info!(hotkey = %toggle_hotkey.trim(), "toggle hotkey registered");
         }
 
-        Ok(HotkeyManager { running })
+        Ok(Self { events })
     }
 
+    /// Return the oldest pending event without losing later events.
     pub fn check_event(&self) -> Option<HotkeyEvent> {
-        if HOLD_PRESSED.swap(false, Ordering::Relaxed) {
-            return Some(HotkeyEvent::Pressed(HotkeySource::Hold));
-        }
-        if HOLD_RELEASED.swap(false, Ordering::Relaxed) {
-            return Some(HotkeyEvent::Released(HotkeySource::Hold));
-        }
-        if TOGGLE_PRESSED.swap(false, Ordering::Relaxed) {
-            return Some(HotkeyEvent::Pressed(HotkeySource::Toggle));
-        }
-        None
+        self.events.try_recv().ok()
     }
 }
 
-impl Drop for HotkeyManager {
-    fn drop(&mut self) {
-        debug!("HotkeyManager dropped");
-        self.running.store(false, Ordering::Relaxed);
+fn parse_binding(name: &str, value: &str) -> Result<Option<Key>, Box<dyn std::error::Error>> {
+    if value.trim().is_empty() {
+        return Ok(None);
     }
+
+    parse_key(value)
+        .map(Some)
+        .ok_or_else(|| format!("invalid {name} `{value}`; expected F1 through F12").into())
+}
+
+fn spawn_listener(mapper: EventMapper, sender: Sender<HotkeyEvent>) {
+    thread::spawn(move || {
+        debug!("rdev listener thread started");
+        let mapper = Arc::new(Mutex::new(mapper));
+        let callback = move |event: Event| {
+            let mapped = match mapper.lock() {
+                Ok(mut mapper) => mapper.map(&event.event_type),
+                Err(poisoned) => poisoned.into_inner().map(&event.event_type),
+            };
+            if let Some(event) = mapped {
+                let _ = sender.send(event);
+            }
+        };
+
+        if let Err(err) = listen(callback) {
+            error!(error = ?err, "rdev listen failed");
+        }
+        debug!("rdev listener thread exiting");
+    });
 }
 
 #[cfg(test)]
@@ -131,19 +148,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_key() {
+    fn parses_keys_case_insensitively_and_ignores_outer_whitespace() {
         assert_eq!(parse_key("F8"), Some(Key::F8));
-        assert_eq!(parse_key("f9"), Some(Key::F9));
+        assert_eq!(parse_key(" f9 "), Some(Key::F9));
         assert_eq!(parse_key("F12"), Some(Key::F12));
         assert_eq!(parse_key("invalid"), None);
     }
 
-    // This spins up the real global hotkey listener. Skip it on Windows CI to
-    // avoid native hook teardown crashes that happen after tests finish.
-    #[cfg(not(target_os = "windows"))]
     #[test]
-    fn test_hotkey_manager_creation() {
-        // Note: rdev listener requires appropriate permissions
-        let _ = HotkeyManager::new("F8", "F9");
+    fn rejects_invalid_and_ambiguous_bindings_before_starting_listener() {
+        assert!(HotkeyManager::new("F13", "F9").is_err());
+        assert!(HotkeyManager::new("", "invalid").is_err());
+        assert!(HotkeyManager::new("", "").is_err());
+        assert!(HotkeyManager::new("F8", "f8").is_err());
+    }
+
+    #[test]
+    fn maps_events_in_order_and_suppresses_key_repeat() {
+        let mut mapper = EventMapper::new(Some(Key::F8), Some(Key::F9));
+
+        assert_eq!(
+            mapper.map(&EventType::KeyPress(Key::F8)),
+            Some(HotkeyEvent::Pressed(HotkeySource::Hold))
+        );
+        assert_eq!(mapper.map(&EventType::KeyPress(Key::F8)), None);
+        assert_eq!(
+            mapper.map(&EventType::KeyRelease(Key::F8)),
+            Some(HotkeyEvent::Released(HotkeySource::Hold))
+        );
+        assert_eq!(
+            mapper.map(&EventType::KeyPress(Key::F9)),
+            Some(HotkeyEvent::Pressed(HotkeySource::Toggle))
+        );
+        assert_eq!(mapper.map(&EventType::KeyPress(Key::F9)), None);
+        assert_eq!(mapper.map(&EventType::KeyRelease(Key::F9)), None);
+        assert_eq!(
+            mapper.map(&EventType::KeyPress(Key::F9)),
+            Some(HotkeyEvent::Pressed(HotkeySource::Toggle))
+        );
     }
 }

--- a/src/input/overlay/macos.rs
+++ b/src/input/overlay/macos.rs
@@ -1,5 +1,4 @@
 use objc2::rc::{Allocated, Retained};
-use objc2::runtime::AnyObject;
 use objc2::{MainThreadMarker, MainThreadOnly, define_class, extern_methods};
 use objc2_app_kit::{
     NSApp, NSAppearance, NSAppearanceNameAccessibilityHighContrastDarkAqua,
@@ -63,8 +62,9 @@ impl OverlayManager {
 
         let content_view = create_overlay_view(window_rect.size, mtm);
         window.setContentView(Some(&content_view));
-        window.makeKeyAndOrderFront(None::<&AnyObject>);
-        window.resignKeyWindow();
+        // Show the overlay without making it the key window or stealing focus
+        // from the application that will receive transcribed text.
+        window.orderFrontRegardless();
 
         Ok(Self {
             window,

--- a/src/input/overlay/windows_impl.rs
+++ b/src/input/overlay/windows_impl.rs
@@ -22,13 +22,10 @@ impl OverlayManager {
         register_window_class()?;
 
         let (x, y) = overlay_origin()?;
-        let state = Box::new(WindowState::default());
-        let state_ptr = Box::into_raw(state);
-
         let hwnd = unsafe {
             // SAFETY: The class has been registered, the title/class pointers are
             // valid NUL-terminated UTF-16 buffers for the duration of the call,
-            // and the lpParam carries ownership of a Box<WindowState>.
+            // and this call does not transfer any application-owned pointer.
             ffi::CreateWindowExW(
                 ffi::WS_EX_TOOLWINDOW
                     | ffi::WS_EX_TOPMOST
@@ -44,21 +41,18 @@ impl OverlayManager {
                 ptr::null_mut(),
                 ptr::null_mut(),
                 ffi::GetModuleHandleW(ptr::null()),
-                state_ptr.cast(),
+                ptr::null_mut(),
             )
         };
 
         if hwnd.is_null() {
-            unsafe {
-                // SAFETY: state_ptr came from Box::into_raw above and window
-                // creation failed, so ownership needs to be reclaimed here.
-                drop(Box::from_raw(state_ptr));
-            }
             return Err(last_os_error("CreateWindowExW failed").into());
         }
 
         unsafe {
             // SAFETY: hwnd is a valid layered popup window we just created.
+            let state_ptr = Box::into_raw(Box::new(WindowState::default()));
+            ffi::SetWindowLongPtrW(hwnd, ffi::GWLP_USERDATA, state_ptr as isize);
             ffi::SetLayeredWindowAttributes(hwnd, 0, WINDOW_ALPHA, ffi::LWA_ALPHA);
             ffi::ShowWindow(hwnd, ffi::SW_SHOWNOACTIVATE);
             ffi::UpdateWindow(hwnd);
@@ -193,30 +187,21 @@ unsafe extern "system" fn window_proc(
 ) -> ffi::LRESULT {
     match msg {
         ffi::WM_NCCREATE => {
-            let create_struct = lparam as *const ffi::CREATESTRUCTW;
-            if !create_struct.is_null() {
-                let state_ptr = unsafe { (*create_struct).lpCreateParams as *mut WindowState };
+            let region = unsafe {
+                // SAFETY: Creates a valid rounded region for the fixed overlay size.
+                ffi::CreateRoundRectRgn(
+                    0,
+                    0,
+                    OVERLAY_SIZE + 1,
+                    OVERLAY_SIZE + 1,
+                    CORNER_RADIUS,
+                    CORNER_RADIUS,
+                )
+            };
+            if !region.is_null() {
                 unsafe {
-                    // SAFETY: During WM_NCCREATE the lpCreateParams is our Box pointer.
-                    ffi::SetWindowLongPtrW(hwnd, ffi::GWLP_USERDATA, state_ptr as isize);
-                }
-
-                let region = unsafe {
-                    // SAFETY: Creates a valid rounded region for the fixed overlay size.
-                    ffi::CreateRoundRectRgn(
-                        0,
-                        0,
-                        OVERLAY_SIZE + 1,
-                        OVERLAY_SIZE + 1,
-                        CORNER_RADIUS,
-                        CORNER_RADIUS,
-                    )
-                };
-                if !region.is_null() {
-                    unsafe {
-                        // SAFETY: The OS takes ownership of the region on success.
-                        ffi::SetWindowRgn(hwnd, region, 1);
-                    }
+                    // SAFETY: The OS takes ownership of the region on success.
+                    ffi::SetWindowRgn(hwnd, region, 1);
                 }
             }
             1
@@ -435,9 +420,9 @@ fn read_apps_use_light_theme() -> Option<bool> {
 }
 
 fn perceived_luminance(color: u32) -> u8 {
-    let r = (color & 0xFF) as u32;
-    let g = ((color >> 8) & 0xFF) as u32;
-    let b = ((color >> 16) & 0xFF) as u32;
+    let r = color & 0xFF;
+    let g = (color >> 8) & 0xFF;
+    let b = (color >> 16) & 0xFF;
     ((r * 299 + g * 587 + b * 114) / 1000) as u8
 }
 
@@ -623,22 +608,6 @@ mod ffi {
         pub rgbReserved: [u8; 32],
     }
 
-    #[repr(C)]
-    pub struct CreateStructW {
-        pub lpCreateParams: *mut c_void,
-        pub hInstance: HINSTANCE,
-        pub hMenu: HMENU,
-        pub hwndParent: HWND,
-        pub cy: i32,
-        pub cx: i32,
-        pub y: i32,
-        pub x: i32,
-        pub style: i32,
-        pub lpszName: LPCWSTR,
-        pub lpszClass: LPCWSTR,
-        pub dwExStyle: DWORD,
-    }
-
     pub type Wndproc = Option<unsafe extern "system" fn(HWND, UINT, WPARAM, LPARAM) -> LRESULT>;
 
     #[repr(C)]
@@ -655,7 +624,6 @@ mod ffi {
         pub lpszClassName: LPCWSTR,
     }
 
-    pub use CreateStructW as CREATESTRUCTW;
     pub use Msg as MSG;
     pub use PaintStruct as PAINTSTRUCT;
     pub use Point as POINT;

--- a/src/input/tray.rs
+++ b/src/input/tray.rs
@@ -1,4 +1,6 @@
 #[cfg(not(test))]
+use tracing::warn;
+#[cfg(not(test))]
 use tray_icon::menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem};
 #[cfg(not(test))]
 use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
@@ -8,6 +10,7 @@ pub struct TrayManager {
     tray_icon: TrayIcon,
     icon_idle: Icon,
     icon_recording: Icon,
+    status_item: MenuItem,
     exit_item_id: tray_icon::menu::MenuId,
 }
 
@@ -20,8 +23,8 @@ pub struct TrayManager;
 #[cfg(not(test))]
 impl TrayManager {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        let icon_idle = create_icon(128, 128, 128, 255);
-        let icon_recording = create_icon(220, 50, 50, 255);
+        let icon_idle = create_icon(128, 128, 128, 255)?;
+        let icon_recording = create_icon(220, 50, 50, 255)?;
 
         let menu = Menu::new();
         let title_item = MenuItem::new("ViberWhisper", false, None);
@@ -45,6 +48,7 @@ impl TrayManager {
             tray_icon,
             icon_idle,
             icon_recording,
+            status_item,
             exit_item_id: exit_id,
         })
     }
@@ -61,8 +65,17 @@ impl TrayManager {
             "ViberWhisper - 空闲"
         };
 
-        let _ = self.tray_icon.set_icon(Some(icon.clone()));
-        let _ = self.tray_icon.set_tooltip(Some(tooltip));
+        self.status_item.set_text(if recording {
+            "状态：录音中"
+        } else {
+            "状态：空闲"
+        });
+        if let Err(err) = self.tray_icon.set_icon(Some(icon.clone())) {
+            warn!(error = ?err, "failed to update tray icon");
+        }
+        if let Err(err) = self.tray_icon.set_tooltip(Some(tooltip)) {
+            warn!(error = ?err, "failed to update tray tooltip");
+        }
     }
 
     pub fn check_exit(&self) -> bool {
@@ -116,9 +129,9 @@ fn build_icon_rgba(r: u8, g: u8, b: u8, a: u8) -> (Vec<u8>, u32) {
 }
 
 #[cfg(not(test))]
-fn create_icon(r: u8, g: u8, b: u8, a: u8) -> Icon {
+fn create_icon(r: u8, g: u8, b: u8, a: u8) -> Result<Icon, tray_icon::BadIcon> {
     let (rgba, size) = build_icon_rgba(r, g, b, a);
-    Icon::from_rgba(rgba, size, size).expect("Failed to create tray icon")
+    Icon::from_rgba(rgba, size, size)
 }
 
 #[cfg(test)]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -36,6 +36,7 @@ impl TextTyper for WindowsTyper {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 mod ffi {
     use std::mem::ManuallyDrop;
 


### PR DESCRIPTION
## Summary
- preserve hotkey event order with a channel and suppress key-repeat toggle events
- reject invalid, disabled-all, and conflicting hotkey configurations
- keep tray status text synchronized and surface native update failures
- show the macOS overlay without stealing focus
- avoid double-free risk in Windows overlay creation failure paths
- update input architecture documentation and changelog

## Validation
- `cargo fmt --check`
- `cargo test` (146 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings`