### PR TITLE
feat(input): support named single-key hotkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,6 +2952,7 @@ dependencies = [
  "hound",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-graphics",
  "objc2-foundation",
  "png",
  "rdev",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tempfile = "3"
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSDate", "NSRunLoop"] }
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSEvent"] }
+objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGEventSource", "CGEventTypes", "CGRemoteOperation"] }
 
 [package.metadata.bundle]
 name = "ViberWhisper"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 功能特性
 
-- **全局热键录音**：按住 F8 开始录音，松开自动停止（Hold 模式）；按一下 F9 开始，再按一下停止（Toggle 模式）
+- **全局热键录音**：默认按住 F8 开始、松开停止（Hold 模式），按一下 F9 开始、再按一下停止（Toggle 模式）；两者均可改为具名单键，包括单独的右 Alt/Option
 - **AI 语音识别**：通过可配置的 HTTP 转写接口将语音转为文字（默认 Groq Whisper）
 - **长录音自动分片**：超过时长/大小限制的录音自动切分，后台并行转写，结果智能合并
 - **LLM 文本后处理**：可选的 LLM 后处理层，自动补标点、去语气词、清理中断与重复
@@ -139,9 +139,50 @@ CLI 只接受下表中的 canonical dotted key；`hotkey`、`model`、`local_mod
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `input.hold_hotkey` | 字符串 | `F8` | 按住录音热键；空字符串可禁用 |
-| `input.toggle_hotkey` | 字符串 | `F9` | 切换录音热键；空字符串可禁用 |
+| `input.hold_hotkey` | 字符串 | `F8` | 按住录音的具名单键；空字符串可禁用 |
+| `input.toggle_hotkey` | 字符串 | `F9` | 切换录音的具名单键；空字符串可禁用 |
 | `audio.mic_gain` | 数字 | `1.0` | 麦克风增益倍数 |
+
+#### 单键热键名称
+
+两个热键字段都接受大小写不敏感的物理单键名称。例如，将 Hold 热键设为右 Alt/Option：
+
+```bash
+viberwhisper config set input.hold_hotkey RIGHTALT
+viberwhisper config check
+```
+
+`config set` 保留输入的原始字符串；`config check` 和程序启动负责验证名称、平台支持情况以及 Hold/Toggle
+是否重复。运行时消息使用 canonical 名称，因此 `altgr`、`rightoption` 会显示为 `RIGHTALT`。
+
+| 分组 | Canonical 名称 |
+|------|----------------|
+| 功能键 | `F1`–`F12` |
+| 字母与数字 | `A`–`Z`、主键盘区 `0`–`9` |
+| 编辑与空白 | `BACKSPACE`、`DELETE`、`INSERT`、`ENTER`、`SPACE`、`TAB`、`ESCAPE` |
+| 导航 | `UP`、`DOWN`、`LEFT`、`RIGHT`、`HOME`、`END`、`PAGEUP`、`PAGEDOWN` |
+| 修饰键 | `LEFTALT`、`RIGHTALT`、`LEFTCTRL`、`RIGHTCTRL`、`LEFTSHIFT`、`RIGHTSHIFT`、`LEFTMETA`、`RIGHTMETA` |
+| 锁定与系统键 | `CAPSLOCK`、`NUMLOCK`、`SCROLLLOCK`、`PRINTSCREEN`、`PAUSE`、`FUNCTION` |
+| 标点 | `BACKQUOTE`、`MINUS`、`EQUAL`、`LEFTBRACKET`、`RIGHTBRACKET`、`SEMICOLON`、`QUOTE`、`BACKSLASH`、`INTLBACKSLASH`、`COMMA`、`DOT`、`SLASH` |
+| 数字键盘 | `NUMPAD0`–`NUMPAD9`、`NUMPADENTER`、`NUMPADMINUS`、`NUMPADPLUS`、`NUMPADMULTIPLY`、`NUMPADDIVIDE`、`NUMPADDELETE` |
+
+常用别名包括：`ALTGR`/`RIGHTOPTION` → `RIGHTALT`，`ALT`/`OPTION` → `LEFTALT`，
+`RETURN` → `ENTER`，`ESC` → `ESCAPE`，`COMMAND`/`WIN`/`SUPER` → `LEFTMETA`，箭头名称可追加
+`ARROW`，数字键盘名称可将 `NUMPAD` 缩写为 `KP`。
+
+名称对应 `rdev::Key` 的键位标识，而不是输入后产生的字符。macOS 后端按硬件键码映射；Windows 后端
+使用虚拟键值，因此字母和标点在非 QWERTY 布局上可能跟随活动布局，使用前应实际确认。监听只观察而不
+拦截按键，所以字母、数字、标点、编辑键和修饰键仍会传给当前应用或操作系统；程序会为这类绑定记录
+warning。Windows 的 AltGr 通常表现为左 Ctrl + 右 Alt，因此 `RIGHTALT` 能正常匹配，但单独配置的
+`LEFTCTRL` 也可能被 AltGr 触发；为避免一次按键产生两个录音动作，Windows 会拒绝同时配置
+`LEFTCTRL` 和 `RIGHTALT`。
+
+当前 `rdev 0.5.3` 后端还有以下明确限制，`config check` 会拒绝对应名称：
+
+- macOS：`CAPSLOCK`、`RIGHTCTRL`、`DELETE`、`INSERT`、`HOME`、`END`、`PAGEUP`、
+  `PAGEDOWN`、`NUMLOCK`、`SCROLLLOCK`、`PRINTSCREEN`、`PAUSE`、`INTLBACKSLASH` 和全部
+  `NUMPAD*` 名称。
+- Windows：`RIGHTMETA`、`FUNCTION`、`NUMPADENTER`；数字键盘的报告方式还会受到 Num Lock 影响。
 
 内部可靠性策略不作为用户配置：实时与离线音频统一按 30 秒或 23 MiB 的较小限制分片；每个 STT 请求
 最多等待 12 秒，网络错误或 HTTP 5xx 最多重试一次；停止录音后的 session 收敛窗口固定为 30 秒。

--- a/changelog
+++ b/changelog
@@ -36,3 +36,4 @@
 2026-08-03: Reduce main.rs to a thin library entry point and move CLI workflows plus listener orchestration into a lightweight application layer
 2026-08-10: Replace placeholder bundle artwork and generated tray dots with a shared five-bar V-shaped waveform icon, including native macOS template tinting and a red recording state
 2026-08-10: Harden API-mode macOS and Windows packaging with locked inputs, reviewed WiX authoring, pre-tag dry runs, validated portable/installable artifacts, checksums, provenance, and draft-first GitHub Release publication
+2026-08-10: Expand Hold and Toggle hotkeys from F1–F12 to named single keyboard keys, including standalone right Alt/Option, canonical aliases, platform-aware validation, and passthrough warnings

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Implementation plans and technical specs for each feature.
 | [10-objc2-overlay-migration.md](plan/10-objc2-overlay-migration.md) | Historical | Historical macOS overlay binding migration |
 | [11-packaging-and-ci.md](plan/11-packaging-and-ci.md) | Superseded | Original cross-platform CI and unexercised tag-release design; hardened by plan 27 |
 | [12-local-gemma-service.md](plan/12-local-gemma-service.md) | Done | Local Gemma inference service, lifecycle management, and CLI integration |
+| [13-full-hotkey-support.md](plan/13-full-hotkey-support.md) | Implemented | Expand Hold/Toggle configuration to named single keys, including standalone right Alt/Option |
 | [14-tray-recording-control.md](plan/14-tray-recording-control.md) | Done | Tray-only control, input-independent recording state, and strict SessionId routing |
 | [16-session-owned-chunk-results.md](plan/16-session-owned-chunk-results.md) | Done | Keep chunk state and transcription results owned by one session; workers return events instead of mutating shared chunk storage |
 | [17-shared-text-merge.md](plan/17-shared-text-merge.md) | Done | Centralize transcription text merging for offline chunks and session orchestration |

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -39,6 +39,14 @@ pub struct HotkeyManager {
 
 Spawns an `rdev::listen` thread that maps native events into an ordered channel. Per-binding key-down state suppresses operating-system key-repeat events so one physical toggle press produces one toggle action.
 
+**`HotkeyConfig`**
+
+The runtime boundary between persisted hotkey strings and native events. Validation resolves each
+enabled string to one `rdev::Key` plus a canonical display label, rejects duplicate or
+platform-unavailable bindings, and keeps empty strings disabled. Persisted strings are not
+canonicalized: `config get/list` return the user's input, while listener output and logs use the
+canonical runtime label.
+
 ### Recording Input Normalization
 
 Hotkey and tray source details stop at the listener integration boundary in `application::listener`. The integration reads the session machine's current state without mutating it and publishes only source-free core requests:
@@ -58,6 +66,10 @@ Because the core event carries no source, Hold release, Toggle, and tray input c
 
 - `HotkeyConfig::validate(&InputSection)` parses and validates both bindings before construction.
 - Empty strings disable a binding, including both bindings for tray-only control; duplicate non-empty bindings are rejected.
+- Non-function bindings log that `rdev::listen` observes rather than suppresses their native input.
+- On Windows, a `LEFTCTRL` binding logs an additional warning because AltGr is reported as left Ctrl
+  plus right Alt by layouts that use AltGr. Validation rejects a `LEFTCTRL`/`RIGHTALT` pair so one
+  physical AltGr press cannot enqueue both configured recording actions.
 - Spawns the listener thread without blocking application startup.
 
 **`check_event(&self) -> Option<HotkeyEvent>`**
@@ -66,7 +78,39 @@ Non-blockingly receives the oldest pending event. Called from the main loop on e
 
 **`parse_key(s: &str) -> Option<Key>`**
 
-Maps trimmed key name strings (`"F1"`–`"F12"`, case-insensitive) to `rdev::Key` variants.
+Maps trimmed, ASCII-case-insensitive named physical keys to `rdev::Key` variants. The fixed lookup
+covers `F1`–`F12`, letters, number-row keys, editing/whitespace, navigation, left/right modifiers,
+locks/system keys, punctuation, and numeric-keypad keys. Explicit aliases normalize platform terms:
+`ALTGR` and `RIGHTOPTION` map to canonical `RIGHTALT`/`Key::AltGr`; `ALT` and `OPTION` map to
+`LEFTALT`/`Key::Alt`.
+
+`parse_key` recognizes the shared vocabulary independently of platform. `HotkeyConfig::validate`
+then returns `hotkey.unsupported` when the current `rdev 0.5.3` backend cannot emit the named
+variant. On macOS this includes Caps Lock (a status change rather than a press/release pair), right
+Ctrl, forward Delete/Insert/navigation-cluster keys, several lock/system keys, international
+backslash, and numeric-keypad names. On Windows it includes right Meta, Function, and the numeric
+keypad Enter key that `rdev` cannot distinguish from Enter. Unknown names use `hotkey.invalid`, and
+aliases resolving to the same key use `hotkey.duplicate`. Windows additionally uses
+`hotkey.altgr_conflict` when the two bindings are `LEFTCTRL` and `RIGHTALT` in either order.
+
+Configuration persistence intentionally does not invoke this runtime validation. `config set`
+stores the string; `config check` and listener startup call the existing `runtime_config` resolution
+path and report hotkey issues together with other active-listener configuration issues.
+
+Key names identify `rdev::Key` values rather than produced characters. The macOS backend maps
+hardware key codes, while the Windows backend maps virtual-key values; letter and punctuation
+bindings can therefore follow the active Windows layout rather than a fixed physical QWERTY
+position. The listener is passive, so printable, editing, navigation, and modifier keys continue to
+affect the focused application or operating system. Windows AltGr also emits left Ctrl at the
+`rdev::Event` boundary, so a standalone `LEFTCTRL` binding may fire from AltGr; the retained event
+type does not contain enough native information to filter that event reliably.
+
+On macOS, `rdev 0.5.3` derives modifier press/release direction from aggregate modifier flags.
+That direction can be wrong when the listener starts while a modifier is held or when both sides
+of one modifier overlap. Before `EventMapper` sees a macOS modifier event, the listener therefore
+uses Core Graphics `CGEventSourceKeyState` with the physical modifier key code to normalize it to
+the current press/release state. Ordinary key events still flow directly through `rdev`, preserving
+their existing repeat suppression.
 
 ---
 

--- a/docs/plan/13-full-hotkey-support.md
+++ b/docs/plan/13-full-hotkey-support.md
@@ -1,0 +1,242 @@
+# 13 - Named Single-Key Hotkey Support
+
+## Status
+
+Implemented. Local macOS tests, formatting, strict Clippy, Windows-target check/Clippy, and GitHub
+macOS/Windows/Python CI pass. Hardware-level right-Alt smoke tests remain for the maintainer because
+this implementation environment cannot generate interactive physical keyboard input; the required
+macOS startup-held/overlap and Windows AltGr cases are listed below. The design and implementation
+were reviewed against the current `HotkeyConfig`, `EventMapper`, listener integration,
+configuration persistence, and `rdev 0.5.3` platform backends. It replaces the earlier, removed
+design for modifier combinations and raw platform key codes.
+
+## Goal
+
+Expand `input.hold_hotkey` and `input.toggle_hotkey` from `F1`–`F12` to the stable named keyboard
+keys exposed by `rdev 0.5.3`, while retaining the existing single-key recording semantics. The
+primary requested binding is a standalone right Alt key:
+
+```bash
+viberwhisper config set input.hold_hotkey RIGHTALT
+```
+
+On macOS, `RIGHTALT` means the physical right Option key. On Windows, it means the physical right
+Alt key, which the operating system may also use as AltGr for character input.
+
+## Scope
+
+This feature adds named **single keyboard keys** only. It does not expose modifier combinations,
+mouse-button bindings, media keys, configurable raw platform key codes, or interception of the configured key.
+The existing configuration fields, empty-string disabling, Hold/Toggle behavior, duplicate
+validation, defaults (`F8` and `F9`), and configuration schema version remain unchanged.
+
+The parser will support these canonical names:
+
+| Group | Canonical names |
+|---|---|
+| Function | `F1`–`F12` |
+| Letters | `A`–`Z` |
+| Number row | `0`–`9` |
+| Editing and whitespace | `BACKSPACE`, `DELETE`, `INSERT`, `ENTER`, `SPACE`, `TAB`, `ESCAPE` |
+| Navigation | `UP`, `DOWN`, `LEFT`, `RIGHT`, `HOME`, `END`, `PAGEUP`, `PAGEDOWN` |
+| Modifiers | `LEFTALT`, `RIGHTALT`, `LEFTCTRL`, `RIGHTCTRL`, `LEFTSHIFT`, `RIGHTSHIFT`, `LEFTMETA`, `RIGHTMETA` |
+| Locks and system | `CAPSLOCK`, `NUMLOCK`, `SCROLLLOCK`, `PRINTSCREEN`, `PAUSE`, `FUNCTION` |
+| Punctuation | `BACKQUOTE`, `MINUS`, `EQUAL`, `LEFTBRACKET`, `RIGHTBRACKET`, `SEMICOLON`, `QUOTE`, `BACKSLASH`, `INTLBACKSLASH`, `COMMA`, `DOT`, `SLASH` |
+| Numeric keypad | `NUMPAD0`–`NUMPAD9`, `NUMPADENTER`, `NUMPADMINUS`, `NUMPADPLUS`, `NUMPADMULTIPLY`, `NUMPADDIVIDE`, `NUMPADDELETE` |
+
+Names are ASCII case-insensitive and continue to ignore outer whitespace. A small alias set makes
+platform terminology discoverable without creating multiple behaviors:
+
+| Canonical name | Accepted aliases |
+|---|---|
+| `RIGHTALT` | `ALTGR`, `RIGHTOPTION` |
+| `LEFTALT` | `ALT`, `LEFTOPTION`, `OPTION` |
+| `ENTER` | `RETURN` |
+| `ESCAPE` | `ESC` |
+| `LEFTMETA` | `COMMAND`, `WIN`, `SUPER` |
+| `UP`, `DOWN`, `LEFT`, `RIGHT` | `UPARROW`, `DOWNARROW`, `LEFTARROW`, `RIGHTARROW` |
+| `NUMPAD*` | corresponding `KP*` spelling |
+
+`LEFTALT` maps to `rdev::Key::Alt`; `RIGHTALT` maps to `rdev::Key::AltGr`. Names identify
+`rdev::Key` values rather than produced characters. The macOS backend maps hardware key codes, but
+the Windows backend maps virtual-key values, so letter and punctuation bindings may follow the
+active Windows layout instead of fixed physical QWERTY positions. Number-row and numeric-keypad
+keys remain distinct where the backend exposes that distinction.
+
+## Platform Boundaries
+
+The supported vocabulary follows named `rdev::Key` variants rather than undocumented numeric key
+codes. A key is usable only when the operating system, keyboard, and `rdev` backend report that
+named variant. Inspection of the current `rdev 0.5.3` backend tables gives these explicit
+exceptions:
+
+| Platform | Names rejected because `rdev` does not emit a distinct named key |
+|---|---|
+| macOS | `CAPSLOCK`, `RIGHTCTRL`, `DELETE`, `INSERT`, `HOME`, `END`, `PAGEUP`, `PAGEDOWN`, `NUMLOCK`, `SCROLLLOCK`, `PRINTSCREEN`, `PAUSE`, `INTLBACKSLASH`, and all `NUMPAD*` names |
+| Windows | `RIGHTMETA`, `FUNCTION`, and `NUMPADENTER` |
+
+Those names stay in the shared canonical vocabulary for configurations moved between platforms,
+but validation rejects them on the affected platform with an actionable error. In particular:
+
+- `RIGHTALT` is first-class on both supported platforms (`AltGr` in `rdev`; right Option on macOS).
+- `rdev 0.5.3` can misclassify macOS modifier direction when the listener starts with a modifier
+  held or matching left/right modifiers overlap because it compares aggregate flags. The listener
+  normalizes modifier events from Core Graphics physical key state before `EventMapper`; ordinary
+  key repeat suppression is unchanged.
+- macOS reports Caps Lock as an on/off status change rather than one physical press followed by one
+  release. That cannot satisfy the existing Hold or Toggle repeat-suppression contract, so
+  `CAPSLOCK` is rejected on macOS rather than given mode-dependent behavior.
+- `FUNCTION` is macOS-only.
+- `NUMPADENTER` is not distinguishable from `ENTER` by the Windows backend.
+- Numeric-keypad reporting on Windows depends on Num Lock, as documented by `rdev`.
+- On Windows layouts with AltGr, the operating system exposes right Alt as left Ctrl plus right Alt.
+  `rdev::listen` keeps only the virtual-key identity and cannot identify the accompanying left-Ctrl
+  event as part of AltGr. A `RIGHTALT` binding still matches its `Key::AltGr` event correctly, but a
+  standalone `LEFTCTRL` binding can also fire when the user presses AltGr. Startup and user
+  documentation must warn about this limitation; no reliable filter can be added at the current
+  `rdev::Event` boundary. Validation rejects a configuration that assigns `LEFTCTRL` and
+  `RIGHTALT` to the two modes in either order, preventing one AltGr press from enqueuing both
+  actions.
+- Specialized, media, and extended function keys that arrive as `Key::Unknown` remain out of
+  scope. The feature does not hard-code platform scan codes.
+
+If implementation or CI discovers another named variant that the backend cannot emit on a
+supported platform, it must receive the same explicit validation and documentation treatment; it
+must not be silently accepted as a non-working binding.
+
+## Key-Passthrough Safety
+
+`rdev::listen` observes global input but does not consume it, so the configured key still reaches
+the focused application. This is especially important for bare letters, numbers, punctuation,
+editing keys, and Alt/Option:
+
+- Configuration accepts them because standalone keys are the requested capability.
+- Startup logs one warning for each enabled binding that is likely to type, edit, navigate, or
+  invoke an operating-system/application action.
+- User documentation recommends spare function/modifier keys such as `RIGHTALT` and explains that
+  Windows AltGr may participate in localized character entry.
+
+No key suppression is introduced; suppression would require a platform-specific input-grab design
+with materially different permissions and failure modes.
+
+## Technical Approach
+
+### `src/input/hotkey.rs`
+
+1. Keep `HotkeyConfig`, `HotkeyEvent`, `HotkeySource`, the listener thread, and `EventMapper`
+   single-key behavior intact.
+2. Preserve the public `parse_key(&str) -> Option<rdev::Key>` contract and replace only its
+   `F1`–`F12` match with an explicit, auditable name/alias lookup. Small private helpers provide the
+   canonical label, platform availability, and passthrough-risk classification; do not introduce a
+   generic registry or new module for a fixed key vocabulary.
+3. Store canonical runtime labels in `HotkeyConfig` rather than uppercasing the user's alias. The
+   listener's startup text, registration logs, and heartbeat therefore consistently show
+   `RIGHTALT`, including when the user entered `altgr` or `rightoption`. Persisted configuration and
+   `config get`/`config list` continue to show the exact user-entered string, matching the current
+   persistence contract.
+4. Validate platform-limited names in `HotkeyConfig::validate`, before the listener starts. Preserve
+   the existing aggregated `ValidationIssue` behavior: use `hotkey.invalid` for unknown names,
+   `hotkey.unsupported` for a known name unavailable on the current platform, and
+   `hotkey.duplicate` for aliases that resolve to the same `rdev::Key`. On Windows, use
+   `hotkey.altgr_conflict` to reject a `LEFTCTRL`/`RIGHTALT` pair.
+5. Emit passthrough and Windows `LEFTCTRL`/AltGr warnings during `HotkeyManager` construction, after
+   validation has produced a usable configuration.
+6. At the macOS event boundary, replace `rdev`'s modifier direction with the current physical state
+   reported by Core Graphics `CGEventSourceKeyState`. This handles both startup-held and overlapping
+   modifiers while leaving ordinary key-repeat suppression unchanged.
+
+No new module is needed. The macOS target adds a direct, narrow-feature
+`objc2-core-graphics` dependency for `CGEventSourceKeyState`; the implementation remains in the
+existing input module rather than adding an indirection that only forwards key lookup.
+
+### Configuration and Runtime Assembly
+
+`InputSection`, `ConfigKey`, `runtime_config`, and persistence continue to carry the two bindings as
+strings; no migration or schema bump is planned. `config set` currently persists string fields
+without resolving the whole listener configuration, and this feature preserves that behavior.
+Hotkey validity is checked by the existing `runtime_config::check` / `resolve_listener` path, so an
+unsupported value is reported by `viberwhisper config check` and listener startup rather than by
+`config set`. This avoids coupling field persistence to API credentials, profiles, or other runtime
+validation.
+
+## Test-First Implementation
+
+Tests are written before the parser and validation implementation:
+
+1. Table-driven parsing coverage for every canonical name, including all letters, digits,
+   punctuation, keypad keys, and the existing `F1`–`F12` compatibility set.
+2. Table-driven alias coverage, with explicit assertions that `RIGHTALT`, `ALTGR`, and
+   `RIGHTOPTION` all map to `Key::AltGr` while `LEFTALT` maps to `Key::Alt`.
+3. Case-insensitivity, outer-whitespace handling, empty disabling, invalid-name errors, and the
+   complete cfg-gated platform rejection matrix, including macOS `CAPSLOCK`.
+4. Duplicate-binding validation across canonical names and aliases, proving `RIGHTALT` conflicts
+   with `altgr`.
+5. Windows validation rejects `LEFTCTRL` and `RIGHTALT` as the two bindings in either order, while
+   retaining the warning for a standalone `LEFTCTRL` binding.
+6. Focused canonical runtime-label, passthrough-risk, and Windows `LEFTCTRL`/AltGr warning
+   classification tests where these protect behavior; avoid duplicating the exhaustive parser
+   table in separate tests.
+7. Retain the existing event-order and key-repeat test, adding one representative right-Alt Hold
+   press/release case to prove a modifier used alone follows ordinary single-key semantics.
+8. Add macOS normalization coverage proving physical key state corrects both misreported modifier
+   directions, including the startup-held release case, without querying ordinary keys.
+
+Manual smoke testing after implementation:
+
+1. macOS: bind Hold to `RIGHTALT`, press/release right Option, and verify exactly one recording
+   session without triggering from left Option. Repeat while left Option remains held and verify
+   releasing right Option still ends the session. Start the listener while right Option is held,
+   release it, and verify that release does not start recording.
+2. Windows: repeat with right Alt and verify left Alt does not trigger it; also check expected AltGr
+   interaction on a keyboard layout that uses AltGr when available. With `LEFTCTRL` configured by
+   itself, confirm/document whether the same AltGr press triggers it, matching the known backend
+   limitation; confirm a `LEFTCTRL`/`RIGHTALT` pair is rejected by `config check`.
+3. Configure a representative navigation key and a printable key, verifying Hold/Toggle behavior
+   and the documented passthrough warning.
+4. Confirm existing F8/F9 defaults behave unchanged.
+
+## Documentation Impact
+
+During implementation:
+
+- Update `README.md` with the supported single-key groups, the `RIGHTALT` example, key-identity and
+  passthrough warnings, Windows `LEFTCTRL`/AltGr behavior, the `config set` versus `config check`
+  boundary, and the platform-limited names.
+- Update `docs/architecture/input.md` so the parser contract, canonical-label behavior, validation,
+  and unchanged event mapping match the code.
+- Append a user-visible entry to `changelog`.
+- Keep `config.example.json` unchanged because its canonical F8/F9 defaults remain correct.
+- Update this plan's status and record any material platform deviations discovered during manual or
+  CI validation.
+
+This plan is indexed in `docs/README.md` during Planning. No current-truth documentation will claim
+the feature is available until the implementation is present.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test input::hotkey`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- GitHub macOS and Windows CI
+- Manual right-Alt smoke tests on both supported platforms when hardware/platform access is
+  available; otherwise the PR handoff must call out which manual checks remain for the maintainer.
+
+## Acceptance Criteria
+
+1. Both hotkey fields accept every documented, platform-available named single key while existing
+   F1–F12 values and empty-string disabling remain compatible.
+2. `RIGHTALT` works as an independent Hold or Toggle binding, maps to right Option on macOS and
+   right Alt/AltGr on Windows, and remains distinct from `LEFTALT`.
+3. Canonical names and aliases normalize consistently for runtime display and duplicate validation;
+   persisted configuration continues to preserve the user's input.
+4. Platform-unavailable bindings fail configuration validation with an actionable error instead of
+   silently never firing.
+5. Hold release, Toggle press-only behavior, event ordering, and ordinary-key repeat suppression are
+   unchanged for all added keys; startup-held and overlapping macOS modifier events use current
+   physical key state rather than the backend's ambiguous direction.
+6. Passthrough, platform/layout key-identity, and Windows `LEFTCTRL`/AltGr behavior is visible in
+   validation errors, startup warnings, and user documentation; Windows rejects assigning
+   `LEFTCTRL` and `RIGHTALT` to the two modes together.
+7. Automated validation and available cross-platform smoke tests pass, with any unavailable manual
+   verification explicitly recorded before the PR is marked ready.

--- a/src/input/hotkey.rs
+++ b/src/input/hotkey.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use rdev::{Event, EventType, Key, listen};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
+
+#[cfg(target_os = "macos")]
+use objc2_core_graphics::{CGEventSource, CGEventSourceStateID};
 
 use crate::core::config::{ConfigKey, InputSection, ValidationIssue};
 
@@ -15,25 +18,44 @@ pub struct HotkeyConfig {
     pub(crate) toggle_label: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NamedKey {
+    key: Key,
+    canonical: &'static str,
+}
+
 impl HotkeyConfig {
     pub(crate) fn validate(section: &InputSection) -> Result<Self, Vec<ValidationIssue>> {
         let mut issues = Vec::new();
-        let hold_key = validate_binding(
+        let hold_binding = validate_binding(
             ConfigKey::InputHoldHotkey,
             &section.hold_hotkey,
             &mut issues,
         );
-        let toggle_key = validate_binding(
+        let toggle_binding = validate_binding(
             ConfigKey::InputToggleHotkey,
             &section.toggle_hotkey,
             &mut issues,
         );
 
-        if hold_key.is_some() && hold_key == toggle_key {
+        if hold_binding.is_some()
+            && hold_binding.map(|binding| binding.key) == toggle_binding.map(|binding| binding.key)
+        {
             issues.push(ValidationIssue::new(
                 ConfigKey::InputToggleHotkey,
                 "hotkey.duplicate",
                 "hold and toggle hotkeys must use different keys",
+            ));
+        }
+        #[cfg(target_os = "windows")]
+        if has_windows_altgr_binding_conflict(
+            hold_binding.map(|binding| binding.key),
+            toggle_binding.map(|binding| binding.key),
+        ) {
+            issues.push(ValidationIssue::new(
+                ConfigKey::InputToggleHotkey,
+                "hotkey.altgr_conflict",
+                "LEFTCTRL and RIGHTALT cannot be used together because Windows AltGr emits both keys",
             ));
         }
 
@@ -41,52 +63,300 @@ impl HotkeyConfig {
             return Err(issues);
         }
         Ok(Self {
-            hold_key,
-            toggle_key,
-            hold_label: binding_label(&section.hold_hotkey),
-            toggle_label: binding_label(&section.toggle_hotkey),
+            hold_key: hold_binding.map(|binding| binding.key),
+            toggle_key: toggle_binding.map(|binding| binding.key),
+            hold_label: hold_binding.map(|binding| binding.canonical.to_string()),
+            toggle_label: toggle_binding.map(|binding| binding.canonical.to_string()),
         })
     }
 }
 
-fn validate_binding(key: ConfigKey, value: &str, issues: &mut Vec<ValidationIssue>) -> Option<Key> {
+fn validate_binding(
+    key: ConfigKey,
+    value: &str,
+    issues: &mut Vec<ValidationIssue>,
+) -> Option<NamedKey> {
     if value.trim().is_empty() {
         return None;
     }
-    match parse_key(value) {
-        Some(parsed) => Some(parsed),
-        None => {
-            issues.push(ValidationIssue::new(
-                key,
-                "hotkey.invalid",
-                format!("invalid hotkey `{value}`; expected F1 through F12"),
-            ));
-            None
+
+    let Some(parsed_key) = parse_key(value) else {
+        issues.push(ValidationIssue::new(
+            key,
+            "hotkey.invalid",
+            format!("invalid hotkey `{value}`; expected a named single key such as F8 or RIGHTALT"),
+        ));
+        return None;
+    };
+    let parsed = parse_named_key(value).expect("parse_key delegates to parse_named_key");
+    debug_assert_eq!(parsed.key, parsed_key);
+    if let Some(reason) = unsupported_reason(parsed.key) {
+        issues.push(ValidationIssue::new(
+            key,
+            "hotkey.unsupported",
+            format!("hotkey `{}` is unsupported: {reason}", parsed.canonical),
+        ));
+        return None;
+    }
+
+    Some(parsed)
+}
+
+#[cfg(target_os = "macos")]
+fn unsupported_reason(key: Key) -> Option<&'static str> {
+    match key {
+        Key::CapsLock => {
+            Some("macOS reports Caps Lock as a state change, not a physical press/release pair")
         }
+        Key::ControlRight
+        | Key::Delete
+        | Key::Insert
+        | Key::Home
+        | Key::End
+        | Key::PageUp
+        | Key::PageDown
+        | Key::NumLock
+        | Key::ScrollLock
+        | Key::PrintScreen
+        | Key::Pause
+        | Key::IntlBackslash
+        | Key::KpReturn
+        | Key::KpMinus
+        | Key::KpPlus
+        | Key::KpMultiply
+        | Key::KpDivide
+        | Key::Kp0
+        | Key::Kp1
+        | Key::Kp2
+        | Key::Kp3
+        | Key::Kp4
+        | Key::Kp5
+        | Key::Kp6
+        | Key::Kp7
+        | Key::Kp8
+        | Key::Kp9
+        | Key::KpDelete => Some("the current rdev macOS backend does not emit this named key"),
+        _ => None,
     }
 }
 
-fn binding_label(value: &str) -> Option<String> {
-    let value = value.trim();
-    (!value.is_empty()).then(|| value.to_ascii_uppercase())
+#[cfg(target_os = "windows")]
+fn unsupported_reason(key: Key) -> Option<&'static str> {
+    match key {
+        Key::MetaRight => Some("the current rdev Windows backend does not emit RIGHTMETA"),
+        Key::Function => Some("Windows does not expose the Fn key to rdev"),
+        Key::KpReturn => Some("the current rdev Windows backend cannot distinguish it from ENTER"),
+        _ => None,
+    }
 }
 
-/// Parse a configured function key. Empty strings disable a binding.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn unsupported_reason(_key: Key) -> Option<&'static str> {
+    None
+}
+
+/// Parse a configured, named physical key. Empty strings disable a binding.
 pub fn parse_key(value: &str) -> Option<Key> {
-    match value.trim().to_ascii_uppercase().as_str() {
-        "F1" => Some(Key::F1),
-        "F2" => Some(Key::F2),
-        "F3" => Some(Key::F3),
-        "F4" => Some(Key::F4),
-        "F5" => Some(Key::F5),
-        "F6" => Some(Key::F6),
-        "F7" => Some(Key::F7),
-        "F8" => Some(Key::F8),
-        "F9" => Some(Key::F9),
-        "F10" => Some(Key::F10),
-        "F11" => Some(Key::F11),
-        "F12" => Some(Key::F12),
+    parse_named_key(value).map(|named| named.key)
+}
+
+fn parse_named_key(value: &str) -> Option<NamedKey> {
+    let (key, canonical) = match value.trim().to_ascii_uppercase().as_str() {
+        "F1" => (Key::F1, "F1"),
+        "F2" => (Key::F2, "F2"),
+        "F3" => (Key::F3, "F3"),
+        "F4" => (Key::F4, "F4"),
+        "F5" => (Key::F5, "F5"),
+        "F6" => (Key::F6, "F6"),
+        "F7" => (Key::F7, "F7"),
+        "F8" => (Key::F8, "F8"),
+        "F9" => (Key::F9, "F9"),
+        "F10" => (Key::F10, "F10"),
+        "F11" => (Key::F11, "F11"),
+        "F12" => (Key::F12, "F12"),
+        "A" => (Key::KeyA, "A"),
+        "B" => (Key::KeyB, "B"),
+        "C" => (Key::KeyC, "C"),
+        "D" => (Key::KeyD, "D"),
+        "E" => (Key::KeyE, "E"),
+        "F" => (Key::KeyF, "F"),
+        "G" => (Key::KeyG, "G"),
+        "H" => (Key::KeyH, "H"),
+        "I" => (Key::KeyI, "I"),
+        "J" => (Key::KeyJ, "J"),
+        "K" => (Key::KeyK, "K"),
+        "L" => (Key::KeyL, "L"),
+        "M" => (Key::KeyM, "M"),
+        "N" => (Key::KeyN, "N"),
+        "O" => (Key::KeyO, "O"),
+        "P" => (Key::KeyP, "P"),
+        "Q" => (Key::KeyQ, "Q"),
+        "R" => (Key::KeyR, "R"),
+        "S" => (Key::KeyS, "S"),
+        "T" => (Key::KeyT, "T"),
+        "U" => (Key::KeyU, "U"),
+        "V" => (Key::KeyV, "V"),
+        "W" => (Key::KeyW, "W"),
+        "X" => (Key::KeyX, "X"),
+        "Y" => (Key::KeyY, "Y"),
+        "Z" => (Key::KeyZ, "Z"),
+        "0" => (Key::Num0, "0"),
+        "1" => (Key::Num1, "1"),
+        "2" => (Key::Num2, "2"),
+        "3" => (Key::Num3, "3"),
+        "4" => (Key::Num4, "4"),
+        "5" => (Key::Num5, "5"),
+        "6" => (Key::Num6, "6"),
+        "7" => (Key::Num7, "7"),
+        "8" => (Key::Num8, "8"),
+        "9" => (Key::Num9, "9"),
+        "BACKSPACE" => (Key::Backspace, "BACKSPACE"),
+        "DELETE" => (Key::Delete, "DELETE"),
+        "INSERT" => (Key::Insert, "INSERT"),
+        "ENTER" | "RETURN" => (Key::Return, "ENTER"),
+        "SPACE" => (Key::Space, "SPACE"),
+        "TAB" => (Key::Tab, "TAB"),
+        "ESCAPE" | "ESC" => (Key::Escape, "ESCAPE"),
+        "UP" | "UPARROW" => (Key::UpArrow, "UP"),
+        "DOWN" | "DOWNARROW" => (Key::DownArrow, "DOWN"),
+        "LEFT" | "LEFTARROW" => (Key::LeftArrow, "LEFT"),
+        "RIGHT" | "RIGHTARROW" => (Key::RightArrow, "RIGHT"),
+        "HOME" => (Key::Home, "HOME"),
+        "END" => (Key::End, "END"),
+        "PAGEUP" => (Key::PageUp, "PAGEUP"),
+        "PAGEDOWN" => (Key::PageDown, "PAGEDOWN"),
+        "LEFTALT" | "ALT" | "LEFTOPTION" | "OPTION" => (Key::Alt, "LEFTALT"),
+        "RIGHTALT" | "ALTGR" | "RIGHTOPTION" => (Key::AltGr, "RIGHTALT"),
+        "LEFTCTRL" => (Key::ControlLeft, "LEFTCTRL"),
+        "RIGHTCTRL" => (Key::ControlRight, "RIGHTCTRL"),
+        "LEFTSHIFT" => (Key::ShiftLeft, "LEFTSHIFT"),
+        "RIGHTSHIFT" => (Key::ShiftRight, "RIGHTSHIFT"),
+        "LEFTMETA" | "COMMAND" | "WIN" | "SUPER" => (Key::MetaLeft, "LEFTMETA"),
+        "RIGHTMETA" => (Key::MetaRight, "RIGHTMETA"),
+        "CAPSLOCK" => (Key::CapsLock, "CAPSLOCK"),
+        "NUMLOCK" => (Key::NumLock, "NUMLOCK"),
+        "SCROLLLOCK" => (Key::ScrollLock, "SCROLLLOCK"),
+        "PRINTSCREEN" => (Key::PrintScreen, "PRINTSCREEN"),
+        "PAUSE" => (Key::Pause, "PAUSE"),
+        "FUNCTION" => (Key::Function, "FUNCTION"),
+        "BACKQUOTE" => (Key::BackQuote, "BACKQUOTE"),
+        "MINUS" => (Key::Minus, "MINUS"),
+        "EQUAL" => (Key::Equal, "EQUAL"),
+        "LEFTBRACKET" => (Key::LeftBracket, "LEFTBRACKET"),
+        "RIGHTBRACKET" => (Key::RightBracket, "RIGHTBRACKET"),
+        "SEMICOLON" => (Key::SemiColon, "SEMICOLON"),
+        "QUOTE" => (Key::Quote, "QUOTE"),
+        "BACKSLASH" => (Key::BackSlash, "BACKSLASH"),
+        "INTLBACKSLASH" => (Key::IntlBackslash, "INTLBACKSLASH"),
+        "COMMA" => (Key::Comma, "COMMA"),
+        "DOT" => (Key::Dot, "DOT"),
+        "SLASH" => (Key::Slash, "SLASH"),
+        "NUMPAD0" | "KP0" => (Key::Kp0, "NUMPAD0"),
+        "NUMPAD1" | "KP1" => (Key::Kp1, "NUMPAD1"),
+        "NUMPAD2" | "KP2" => (Key::Kp2, "NUMPAD2"),
+        "NUMPAD3" | "KP3" => (Key::Kp3, "NUMPAD3"),
+        "NUMPAD4" | "KP4" => (Key::Kp4, "NUMPAD4"),
+        "NUMPAD5" | "KP5" => (Key::Kp5, "NUMPAD5"),
+        "NUMPAD6" | "KP6" => (Key::Kp6, "NUMPAD6"),
+        "NUMPAD7" | "KP7" => (Key::Kp7, "NUMPAD7"),
+        "NUMPAD8" | "KP8" => (Key::Kp8, "NUMPAD8"),
+        "NUMPAD9" | "KP9" => (Key::Kp9, "NUMPAD9"),
+        "NUMPADENTER" | "KPENTER" => (Key::KpReturn, "NUMPADENTER"),
+        "NUMPADMINUS" | "KPMINUS" => (Key::KpMinus, "NUMPADMINUS"),
+        "NUMPADPLUS" | "KPPLUS" => (Key::KpPlus, "NUMPADPLUS"),
+        "NUMPADMULTIPLY" | "KPMULTIPLY" => (Key::KpMultiply, "NUMPADMULTIPLY"),
+        "NUMPADDIVIDE" | "KPDIVIDE" => (Key::KpDivide, "NUMPADDIVIDE"),
+        "NUMPADDELETE" | "KPDELETE" => (Key::KpDelete, "NUMPADDELETE"),
+        _ => return None,
+    };
+    Some(NamedKey { key, canonical })
+}
+
+fn needs_passthrough_warning(key: Key) -> bool {
+    !matches!(
+        key,
+        Key::F1
+            | Key::F2
+            | Key::F3
+            | Key::F4
+            | Key::F5
+            | Key::F6
+            | Key::F7
+            | Key::F8
+            | Key::F9
+            | Key::F10
+            | Key::F11
+            | Key::F12
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn macos_modifier_keycode(key: Key) -> Option<u16> {
+    match key {
+        Key::MetaLeft => Some(55),
+        Key::ShiftLeft => Some(56),
+        Key::Alt => Some(58),
+        Key::ControlLeft => Some(59),
+        Key::ShiftRight => Some(60),
+        Key::AltGr => Some(61),
+        Key::ControlRight => Some(62),
+        Key::Function => Some(63),
+        Key::MetaRight => Some(54),
         _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn normalize_macos_modifier_event(
+    event_type: EventType,
+    key_is_pressed: impl FnOnce(u16) -> bool,
+) -> EventType {
+    let key = match &event_type {
+        EventType::KeyPress(key) | EventType::KeyRelease(key) => *key,
+        _ => return event_type,
+    };
+    let Some(keycode) = macos_modifier_keycode(key) else {
+        return event_type;
+    };
+
+    if key_is_pressed(keycode) {
+        EventType::KeyPress(key)
+    } else {
+        EventType::KeyRelease(key)
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn has_windows_altgr_alias_risk(key: Key) -> bool {
+    key == Key::ControlLeft
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn has_windows_altgr_binding_conflict(first: Option<Key>, second: Option<Key>) -> bool {
+    matches!(
+        (first, second),
+        (Some(Key::ControlLeft), Some(Key::AltGr)) | (Some(Key::AltGr), Some(Key::ControlLeft))
+    )
+}
+
+fn log_binding_warnings(mode: &'static str, key: Option<Key>, label: Option<&str>) {
+    let (Some(key), Some(label)) = (key, label) else {
+        return;
+    };
+    if needs_passthrough_warning(key) {
+        warn!(
+            mode,
+            hotkey = %label,
+            "hotkey input is observed but not suppressed and may also affect the focused application or operating system"
+        );
+    }
+    #[cfg(target_os = "windows")]
+    if has_windows_altgr_alias_risk(key) {
+        warn!(
+            mode,
+            hotkey = %label,
+            "LEFTCTRL may also be emitted when Windows handles RIGHTALT as AltGr"
+        );
     }
 }
 
@@ -154,6 +424,9 @@ impl HotkeyManager {
         let (sender, events) = mpsc::channel();
         spawn_listener(EventMapper::new(hold_key, toggle_key), sender);
 
+        log_binding_warnings("hold", hold_key, config.hold_label.as_deref());
+        log_binding_warnings("toggle", toggle_key, config.toggle_label.as_deref());
+
         if let Some(label) = config.hold_label.as_deref() {
             info!(hotkey = %label, "hold hotkey registered");
         }
@@ -175,9 +448,16 @@ fn spawn_listener(mapper: EventMapper, sender: Sender<HotkeyEvent>) {
         debug!("rdev listener thread started");
         let mapper = Arc::new(Mutex::new(mapper));
         let callback = move |event: Event| {
+            #[cfg(target_os = "macos")]
+            let event_type = normalize_macos_modifier_event(event.event_type, |keycode| {
+                CGEventSource::key_state(CGEventSourceStateID::HIDSystemState, keycode)
+            });
+            #[cfg(not(target_os = "macos"))]
+            let event_type = event.event_type;
+
             let mapped = match mapper.lock() {
-                Ok(mut mapper) => mapper.map(&event.event_type),
-                Err(poisoned) => poisoned.into_inner().map(&event.event_type),
+                Ok(mut mapper) => mapper.map(&event_type),
+                Err(poisoned) => poisoned.into_inner().map(&event_type),
             };
             if let Some(event) = mapped {
                 let _ = sender.send(event);
@@ -218,18 +498,255 @@ mod tests {
         assert_eq!(issues[0].key, ConfigKey::InputHoldHotkey);
 
         let duplicate = InputSection {
-            hold_hotkey: "F8".to_string(),
-            toggle_hotkey: "f8".to_string(),
+            hold_hotkey: "RIGHTALT".to_string(),
+            toggle_hotkey: "altgr".to_string(),
         };
-        assert!(HotkeyConfig::validate(&duplicate).is_err());
+        let issues = HotkeyConfig::validate(&duplicate).unwrap_err();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].code, "hotkey.duplicate");
     }
 
     #[test]
-    fn parses_keys_case_insensitively_and_ignores_outer_whitespace() {
-        assert_eq!(parse_key("F8"), Some(Key::F8));
-        assert_eq!(parse_key(" f9 "), Some(Key::F9));
-        assert_eq!(parse_key("F12"), Some(Key::F12));
+    fn parses_every_canonical_named_key() {
+        let cases = [
+            ("F1", Key::F1),
+            ("F2", Key::F2),
+            ("F3", Key::F3),
+            ("F4", Key::F4),
+            ("F5", Key::F5),
+            ("F6", Key::F6),
+            ("F7", Key::F7),
+            ("F8", Key::F8),
+            ("F9", Key::F9),
+            ("F10", Key::F10),
+            ("F11", Key::F11),
+            ("F12", Key::F12),
+            ("A", Key::KeyA),
+            ("B", Key::KeyB),
+            ("C", Key::KeyC),
+            ("D", Key::KeyD),
+            ("E", Key::KeyE),
+            ("F", Key::KeyF),
+            ("G", Key::KeyG),
+            ("H", Key::KeyH),
+            ("I", Key::KeyI),
+            ("J", Key::KeyJ),
+            ("K", Key::KeyK),
+            ("L", Key::KeyL),
+            ("M", Key::KeyM),
+            ("N", Key::KeyN),
+            ("O", Key::KeyO),
+            ("P", Key::KeyP),
+            ("Q", Key::KeyQ),
+            ("R", Key::KeyR),
+            ("S", Key::KeyS),
+            ("T", Key::KeyT),
+            ("U", Key::KeyU),
+            ("V", Key::KeyV),
+            ("W", Key::KeyW),
+            ("X", Key::KeyX),
+            ("Y", Key::KeyY),
+            ("Z", Key::KeyZ),
+            ("0", Key::Num0),
+            ("1", Key::Num1),
+            ("2", Key::Num2),
+            ("3", Key::Num3),
+            ("4", Key::Num4),
+            ("5", Key::Num5),
+            ("6", Key::Num6),
+            ("7", Key::Num7),
+            ("8", Key::Num8),
+            ("9", Key::Num9),
+            ("BACKSPACE", Key::Backspace),
+            ("DELETE", Key::Delete),
+            ("INSERT", Key::Insert),
+            ("ENTER", Key::Return),
+            ("SPACE", Key::Space),
+            ("TAB", Key::Tab),
+            ("ESCAPE", Key::Escape),
+            ("UP", Key::UpArrow),
+            ("DOWN", Key::DownArrow),
+            ("LEFT", Key::LeftArrow),
+            ("RIGHT", Key::RightArrow),
+            ("HOME", Key::Home),
+            ("END", Key::End),
+            ("PAGEUP", Key::PageUp),
+            ("PAGEDOWN", Key::PageDown),
+            ("LEFTALT", Key::Alt),
+            ("RIGHTALT", Key::AltGr),
+            ("LEFTCTRL", Key::ControlLeft),
+            ("RIGHTCTRL", Key::ControlRight),
+            ("LEFTSHIFT", Key::ShiftLeft),
+            ("RIGHTSHIFT", Key::ShiftRight),
+            ("LEFTMETA", Key::MetaLeft),
+            ("RIGHTMETA", Key::MetaRight),
+            ("CAPSLOCK", Key::CapsLock),
+            ("NUMLOCK", Key::NumLock),
+            ("SCROLLLOCK", Key::ScrollLock),
+            ("PRINTSCREEN", Key::PrintScreen),
+            ("PAUSE", Key::Pause),
+            ("FUNCTION", Key::Function),
+            ("BACKQUOTE", Key::BackQuote),
+            ("MINUS", Key::Minus),
+            ("EQUAL", Key::Equal),
+            ("LEFTBRACKET", Key::LeftBracket),
+            ("RIGHTBRACKET", Key::RightBracket),
+            ("SEMICOLON", Key::SemiColon),
+            ("QUOTE", Key::Quote),
+            ("BACKSLASH", Key::BackSlash),
+            ("INTLBACKSLASH", Key::IntlBackslash),
+            ("COMMA", Key::Comma),
+            ("DOT", Key::Dot),
+            ("SLASH", Key::Slash),
+            ("NUMPAD0", Key::Kp0),
+            ("NUMPAD1", Key::Kp1),
+            ("NUMPAD2", Key::Kp2),
+            ("NUMPAD3", Key::Kp3),
+            ("NUMPAD4", Key::Kp4),
+            ("NUMPAD5", Key::Kp5),
+            ("NUMPAD6", Key::Kp6),
+            ("NUMPAD7", Key::Kp7),
+            ("NUMPAD8", Key::Kp8),
+            ("NUMPAD9", Key::Kp9),
+            ("NUMPADENTER", Key::KpReturn),
+            ("NUMPADMINUS", Key::KpMinus),
+            ("NUMPADPLUS", Key::KpPlus),
+            ("NUMPADMULTIPLY", Key::KpMultiply),
+            ("NUMPADDIVIDE", Key::KpDivide),
+            ("NUMPADDELETE", Key::KpDelete),
+        ];
+
+        for (name, expected) in cases {
+            assert_eq!(parse_key(name), Some(expected), "name: {name}");
+        }
+    }
+
+    #[test]
+    fn parses_aliases_case_insensitively_and_canonicalizes_runtime_labels() {
+        let aliases = [
+            ("ALTGR", Key::AltGr),
+            ("RIGHTOPTION", Key::AltGr),
+            ("ALT", Key::Alt),
+            ("LEFTOPTION", Key::Alt),
+            ("OPTION", Key::Alt),
+            ("RETURN", Key::Return),
+            ("ESC", Key::Escape),
+            ("COMMAND", Key::MetaLeft),
+            ("WIN", Key::MetaLeft),
+            ("SUPER", Key::MetaLeft),
+            ("UPARROW", Key::UpArrow),
+            ("DOWNARROW", Key::DownArrow),
+            ("LEFTARROW", Key::LeftArrow),
+            ("RIGHTARROW", Key::RightArrow),
+            ("KP0", Key::Kp0),
+            ("KP9", Key::Kp9),
+            ("KPENTER", Key::KpReturn),
+            ("KPMINUS", Key::KpMinus),
+            ("KPPLUS", Key::KpPlus),
+            ("KPMULTIPLY", Key::KpMultiply),
+            ("KPDIVIDE", Key::KpDivide),
+            ("KPDELETE", Key::KpDelete),
+        ];
+
+        for (name, expected) in aliases {
+            assert_eq!(parse_key(name), Some(expected), "alias: {name}");
+        }
+
+        assert_eq!(parse_key(" rightoption "), Some(Key::AltGr));
         assert_eq!(parse_key("invalid"), None);
+
+        let config = HotkeyConfig::validate(&InputSection {
+            hold_hotkey: " rightoption ".to_string(),
+            toggle_hotkey: "f9".to_string(),
+        })
+        .unwrap();
+        assert_eq!(config.hold_label.as_deref(), Some("RIGHTALT"));
+        assert_eq!(config.toggle_label.as_deref(), Some("F9"));
+    }
+
+    #[test]
+    fn classifies_passthrough_and_windows_altgr_risks() {
+        assert!(!needs_passthrough_warning(Key::F8));
+        assert!(needs_passthrough_warning(Key::KeyA));
+        assert!(needs_passthrough_warning(Key::AltGr));
+        assert!(has_windows_altgr_alias_risk(Key::ControlLeft));
+        assert!(!has_windows_altgr_alias_risk(Key::AltGr));
+        assert!(has_windows_altgr_binding_conflict(
+            Some(Key::ControlLeft),
+            Some(Key::AltGr)
+        ));
+        assert!(has_windows_altgr_binding_conflict(
+            Some(Key::AltGr),
+            Some(Key::ControlLeft)
+        ));
+        assert!(!has_windows_altgr_binding_conflict(
+            Some(Key::Alt),
+            Some(Key::ControlLeft)
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn rejects_left_ctrl_and_right_alt_as_a_windows_binding_pair() {
+        let issues = HotkeyConfig::validate(&InputSection {
+            hold_hotkey: "LEFTCTRL".to_string(),
+            toggle_hotkey: "RIGHTALT".to_string(),
+        })
+        .unwrap_err();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].key, ConfigKey::InputToggleHotkey);
+        assert_eq!(issues[0].code, "hotkey.altgr_conflict");
+    }
+
+    #[test]
+    fn rejects_named_keys_the_current_platform_backend_cannot_emit() {
+        #[cfg(target_os = "macos")]
+        let unsupported = [
+            "CAPSLOCK",
+            "RIGHTCTRL",
+            "DELETE",
+            "INSERT",
+            "HOME",
+            "END",
+            "PAGEUP",
+            "PAGEDOWN",
+            "NUMLOCK",
+            "SCROLLLOCK",
+            "PRINTSCREEN",
+            "PAUSE",
+            "INTLBACKSLASH",
+            "NUMPAD0",
+            "NUMPAD1",
+            "NUMPAD2",
+            "NUMPAD3",
+            "NUMPAD4",
+            "NUMPAD5",
+            "NUMPAD6",
+            "NUMPAD7",
+            "NUMPAD8",
+            "NUMPAD9",
+            "NUMPADENTER",
+            "NUMPADMINUS",
+            "NUMPADPLUS",
+            "NUMPADMULTIPLY",
+            "NUMPADDIVIDE",
+            "NUMPADDELETE",
+        ];
+        #[cfg(target_os = "windows")]
+        let unsupported = ["RIGHTMETA", "FUNCTION", "NUMPADENTER"];
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        let unsupported: [&str; 0] = [];
+
+        for name in unsupported {
+            let issues = HotkeyConfig::validate(&InputSection {
+                hold_hotkey: name.to_string(),
+                toggle_hotkey: String::new(),
+            })
+            .unwrap_err();
+            assert_eq!(issues.len(), 1, "name: {name}");
+            assert_eq!(issues[0].code, "hotkey.unsupported", "name: {name}");
+        }
     }
 
     #[test]
@@ -254,6 +771,64 @@ mod tests {
         assert_eq!(
             mapper.map(&EventType::KeyPress(Key::F9)),
             Some(HotkeyEvent::Pressed(HotkeySource::Toggle))
+        );
+    }
+
+    #[test]
+    fn maps_standalone_right_alt_hold_press_and_release() {
+        let mut mapper = EventMapper::new(Some(Key::AltGr), Some(Key::F9));
+
+        assert_eq!(
+            mapper.map(&EventType::KeyPress(Key::AltGr)),
+            Some(HotkeyEvent::Pressed(HotkeySource::Hold))
+        );
+        assert_eq!(
+            mapper.map(&EventType::KeyRelease(Key::AltGr)),
+            Some(HotkeyEvent::Released(HotkeySource::Hold))
+        );
+        assert_eq!(mapper.map(&EventType::KeyPress(Key::Alt)), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn normalizes_macos_modifier_direction_from_physical_key_state() {
+        let keycodes = [
+            (Key::MetaRight, 54),
+            (Key::MetaLeft, 55),
+            (Key::ShiftLeft, 56),
+            (Key::Alt, 58),
+            (Key::ControlLeft, 59),
+            (Key::ShiftRight, 60),
+            (Key::AltGr, 61),
+            (Key::ControlRight, 62),
+            (Key::Function, 63),
+        ];
+        for (key, expected) in keycodes {
+            assert_eq!(macos_modifier_keycode(key), Some(expected));
+        }
+        assert_eq!(macos_modifier_keycode(Key::F8), None);
+
+        let mut mapper = EventMapper::new(Some(Key::AltGr), None);
+        let startup_release =
+            normalize_macos_modifier_event(EventType::KeyPress(Key::AltGr), |keycode| {
+                assert_eq!(keycode, 61);
+                false
+            });
+        assert_eq!(startup_release, EventType::KeyRelease(Key::AltGr));
+        assert_eq!(mapper.map(&startup_release), None);
+
+        assert_eq!(
+            mapper.map(&normalize_macos_modifier_event(
+                EventType::KeyRelease(Key::AltGr),
+                |_| true
+            )),
+            Some(HotkeyEvent::Pressed(HotkeySource::Hold))
+        );
+        assert_eq!(
+            normalize_macos_modifier_event(EventType::KeyPress(Key::F8), |_| {
+                panic!("ordinary keys do not require a physical-state query")
+            }),
+            EventType::KeyPress(Key::F8)
         );
     }
 }


### PR DESCRIPTION
## Summary
- expand Hold and Toggle configuration from F1–F12 to named single keyboard keys
- make standalone `RIGHTALT` first-class: right Option on macOS and right Alt/AltGr on Windows
- preserve defaults, empty-string disabling, public `parse_key`, config persistence, and existing Hold/Toggle behavior
- add canonical aliases, platform-aware validation, and passthrough warnings

## Platform behavior
- macOS corrects modifier event direction from Core Graphics physical key state, covering startup-held and overlapping left/right modifiers
- Windows rejects assigning `LEFTCTRL` and `RIGHTALT` to the two modes together because AltGr emits both; standalone `LEFTCTRL` retains a warning
- backend-specific named keys that cannot satisfy the event contract fail `config check` with `hotkey.unsupported`

## Documentation
- update README configuration reference and platform limitations
- update input architecture documentation and changelog
- add and index the implemented plan

## Validation
- `cargo fmt --check`
- `cargo test` (100 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --target x86_64-pc-windows-gnu --all-targets`
- `cargo clippy --target x86_64-pc-windows-gnu --all-targets -- -D warnings`
- `git diff --check`
- GitHub macOS, Windows, and Python CI: passed
- final independent Codex review: no findings

## Remaining manual verification
- smoke-test right Option/Alt on macOS and Windows hardware, including the macOS startup-held/overlapping-modifier cases and Windows AltGr behavior

Automated validation is complete and the unavailable hardware checks are explicitly assigned for maintainer verification.