### PR TITLE
fix(transcriber): STT request timeout + structured TranscribeError

### DIFF
--- a/changelog
+++ b/changelog
@@ -21,3 +21,4 @@
 2026-07-05: Fix audio recorder recovery, bounded live-chunk memory, collision-safe temp files, and non-i16 WAV splitting
 2026-07-05: Harden core configuration persistence, validation, session shutdown, chunk cleanup, and transcription failure handling
 2026-07-05: Harden input hotkey ordering and validation, tray state updates, and overlay focus and Windows state ownership
+2026-07-07: Add STT upload timeout with a shared HTTP client, and replace error-string parsing with a structured TranscribeError across transcriber and orchestrator

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -12,6 +12,8 @@ use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use crate::transcriber::Transcriber;
+// Re-exported so callers can keep using `core::orchestrator::TranscribeError`.
+pub use crate::transcriber::TranscribeError;
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -20,29 +22,6 @@ use crate::transcriber::Transcriber;
 pub enum SessionMode {
     Hold,
     Toggle,
-}
-
-/// Reason a single chunk transcription failed.
-#[derive(Debug, Clone)]
-pub enum TranscribeError {
-    /// The API returned an HTTP error (4xx or 5xx).
-    Api { status: u16, body: String },
-    /// A network or I/O error occurred (retriable errors exhausted).
-    Network(String),
-    /// The chunk did not reach a terminal state before convergence timeout.
-    Timeout,
-}
-
-impl fmt::Display for TranscribeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TranscribeError::Api { status, body } => {
-                write!(f, "API error {}: {}", status, body)
-            }
-            TranscribeError::Network(msg) => write!(f, "Network error: {}", msg),
-            TranscribeError::Timeout => write!(f, "Convergence timeout"),
-        }
-    }
 }
 
 /// Error returned by `SessionOrchestrator::stop_session`.
@@ -348,7 +327,9 @@ fn worker_loop(
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     transcriber.transcribe(&path)
                 }))
-                .unwrap_or_else(|_| Err("transcriber panicked".to_string().into()));
+                .unwrap_or_else(|_| {
+                    Err(TranscribeError::Network("transcriber panicked".to_string()))
+                });
 
                 // Clean up the chunk file (ignore errors — file may already be gone).
                 remove_chunk_file(&path, "processed");
@@ -366,22 +347,7 @@ fn worker_loop(
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/// Classify a transcription error string into a `TranscribeError` variant.
-fn classify_error(error_msg: &str) -> TranscribeError {
-    if let Some(status) = extract_http_status(error_msg) {
-        TranscribeError::Api {
-            status,
-            body: error_msg.to_string(),
-        }
-    } else {
-        TranscribeError::Network(error_msg.to_string())
-    }
-}
-
-fn record_worker_result(
-    entry: &mut ChunkEntry,
-    result: Result<String, Box<dyn std::error::Error>>,
-) {
+fn record_worker_result(entry: &mut ChunkEntry, result: Result<String, TranscribeError>) {
     // A convergence timeout is terminal from the caller's perspective. A late
     // HTTP response must not rewrite the snapshot used for the timeout result.
     if entry.state.is_terminal() {
@@ -398,9 +364,8 @@ fn record_worker_result(
             ChunkState::Transcribed(text)
         }
         Err(e) => {
-            let msg = e.to_string();
-            error!(index = entry.index, error = %msg, "Chunk transcription failed");
-            ChunkState::Failed(classify_error(&msg))
+            error!(index = entry.index, error = %e, "Chunk transcription failed");
+            ChunkState::Failed(e)
         }
     };
 }
@@ -421,24 +386,6 @@ fn remove_chunk_file(path: &str, reason: &str) {
     if let Err(e) = std::fs::remove_file(path) {
         debug!(path, reason, error = %e, "Could not delete chunk file");
     }
-}
-
-/// Try to parse an HTTP status code out of an error message.
-fn extract_http_status(msg: &str) -> Option<u16> {
-    for marker in ["API error ", "HTTP ", "status "] {
-        if let Some(tail) = msg.split_once(marker).map(|(_, tail)| tail) {
-            let digits: String = tail
-                .chars()
-                .take_while(|character| character.is_ascii_digit())
-                .collect();
-            if let Ok(status) = digits.parse::<u16>()
-                && (100..=599).contains(&status)
-            {
-                return Some(status);
-            }
-        }
-    }
-    None
 }
 
 /// Language-aware text merging (duplicated from `transcriber::api` to avoid
@@ -528,19 +475,19 @@ mod tests {
     struct FixedTranscriber(String);
 
     impl Transcriber for FixedTranscriber {
-        fn transcribe(&self, _path: &str) -> Result<String, Box<dyn std::error::Error>> {
+        fn transcribe(&self, _path: &str) -> Result<String, TranscribeError> {
             Ok(self.0.clone())
         }
     }
 
     /// Returns pre-configured results in call order.
     struct ScriptedTranscriber {
-        results: Vec<Result<String, String>>,
+        results: Vec<Result<String, TranscribeError>>,
         call_count: AtomicUsize,
     }
 
     impl ScriptedTranscriber {
-        fn new(results: Vec<Result<String, String>>) -> Self {
+        fn new(results: Vec<Result<String, TranscribeError>>) -> Self {
             Self {
                 results,
                 call_count: AtomicUsize::new(0),
@@ -549,11 +496,11 @@ mod tests {
     }
 
     impl Transcriber for ScriptedTranscriber {
-        fn transcribe(&self, _path: &str) -> Result<String, Box<dyn std::error::Error>> {
+        fn transcribe(&self, _path: &str) -> Result<String, TranscribeError> {
             let i = self.call_count.fetch_add(1, Ordering::SeqCst);
             match self.results.get(i) {
                 Some(Ok(s)) => Ok(s.clone()),
-                Some(Err(e)) => Err(e.clone().into()),
+                Some(Err(e)) => Err(e.clone()),
                 None => Ok("extra".to_string()),
             }
         }
@@ -569,7 +516,7 @@ mod tests {
     }
 
     impl Transcriber for GateTranscriber {
-        fn transcribe(&self, _path: &str) -> Result<String, Box<dyn std::error::Error>> {
+        fn transcribe(&self, _path: &str) -> Result<String, TranscribeError> {
             let (lock, condvar) = &*self.release;
             let mut released = lock.lock().unwrap();
             while !*released {
@@ -580,7 +527,7 @@ mod tests {
     }
 
     impl Transcriber for SlowTranscriber {
-        fn transcribe(&self, _path: &str) -> Result<String, Box<dyn std::error::Error>> {
+        fn transcribe(&self, _path: &str) -> Result<String, TranscribeError> {
             thread::sleep(self.delay);
             Ok("slow".to_string())
         }
@@ -590,7 +537,7 @@ mod tests {
     struct PanicTranscriber;
 
     impl Transcriber for PanicTranscriber {
-        fn transcribe(&self, _path: &str) -> Result<String, Box<dyn std::error::Error>> {
+        fn transcribe(&self, _path: &str) -> Result<String, TranscribeError> {
             panic!("intentional transcriber panic for testing");
         }
     }
@@ -672,7 +619,10 @@ mod tests {
     fn test_partial_failure_returns_error_with_partial_text() {
         let t = Arc::new(ScriptedTranscriber::new(vec![
             Ok("good chunk".to_string()),
-            Err("HTTP 500 server error".to_string()),
+            Err(TranscribeError::Api {
+                status: 500,
+                body: "server error".to_string(),
+            }),
             Ok("another good".to_string()),
         ]));
         let orch = default_orchestrator(t);
@@ -690,6 +640,11 @@ mod tests {
             }) => {
                 assert_eq!(errors.len(), 1);
                 assert_eq!(errors[0].0, 1); // chunk index 1 failed
+                // The structured error variant survives end-to-end (no string parsing).
+                assert!(matches!(
+                    errors[0].1,
+                    TranscribeError::Api { status: 500, .. }
+                ));
                 // partial_text contains only the successful chunks in order.
                 assert_eq!(partial_text, "good chunk another good");
             }
@@ -860,35 +815,5 @@ mod tests {
     fn test_merge_texts_empty_filtered() {
         let texts = vec!["a".to_string(), "".to_string(), "b".to_string()];
         assert_eq!(merge_texts(&texts, None), "a b");
-    }
-
-    #[test]
-    fn test_classify_error_api() {
-        let e = classify_error("HTTP 400 bad request");
-        assert!(matches!(e, TranscribeError::Api { status: 400, .. }));
-
-        let e = classify_error("API error 429: too many requests");
-        assert!(matches!(e, TranscribeError::Api { status: 429, .. }));
-
-        let e = classify_error("chunk 1/1 failed after 4 attempts: API error 500: unavailable");
-        assert!(matches!(e, TranscribeError::Api { status: 500, .. }));
-    }
-
-    #[test]
-    fn test_classify_error_network() {
-        let e = classify_error("connection refused");
-        assert!(matches!(e, TranscribeError::Network(_)));
-    }
-
-    #[test]
-    fn test_extract_http_status() {
-        assert_eq!(extract_http_status("status 500 internal"), Some(500));
-        assert_eq!(extract_http_status("connection refused"), None);
-        assert_eq!(extract_http_status("HTTP 429 too many requests"), Some(429));
-        assert_eq!(
-            extract_http_status("API error 400: invalid request"),
-            Some(400)
-        );
-        assert_eq!(extract_http_status("received 500 bytes"), None);
     }
 }

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -1,5 +1,6 @@
 use crate::audio::split_wav;
 use crate::core::config::AppConfig;
+use crate::transcriber::TranscribeError;
 use std::time::Duration;
 use tracing::{info, instrument, warn};
 
@@ -9,14 +10,14 @@ use tracing::{info, instrument, warn};
 const STT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub trait Transcriber: Send + Sync {
-    fn transcribe(&self, wav_path: &str) -> Result<String, Box<dyn std::error::Error>>;
+    fn transcribe(&self, wav_path: &str) -> Result<String, TranscribeError>;
 }
 
 pub struct MockTranscriber;
 
 impl Transcriber for MockTranscriber {
     #[instrument(name = "mock_stt", skip(self), fields(path = %wav_path))]
-    fn transcribe(&self, wav_path: &str) -> Result<String, Box<dyn std::error::Error>> {
+    fn transcribe(&self, wav_path: &str) -> Result<String, TranscribeError> {
         info!("Starting transcription");
         let text = "This is mock transcribed text".to_string();
         info!(result = %text, "Transcription complete");
@@ -72,8 +73,9 @@ impl ApiTranscriber {
     }
 
     /// Upload a single WAV file and return its transcription text.
-    fn upload_file(&self, wav_path: &str) -> Result<String, Box<dyn std::error::Error>> {
-        let file_bytes = std::fs::read(wav_path)?;
+    fn upload_file(&self, wav_path: &str) -> Result<String, TranscribeError> {
+        let file_bytes = std::fs::read(wav_path)
+            .map_err(|e| TranscribeError::Network(format!("failed to read {wav_path}: {e}")))?;
         let file_name = std::path::Path::new(wav_path)
             .file_name()
             .and_then(|n| n.to_str())
@@ -82,7 +84,8 @@ impl ApiTranscriber {
 
         let part = reqwest::blocking::multipart::Part::bytes(file_bytes)
             .file_name(file_name)
-            .mime_str("audio/wav")?;
+            .mime_str("audio/wav")
+            .map_err(|e| TranscribeError::Network(e.to_string()))?;
 
         let mut form = reqwest::blocking::multipart::Form::new()
             .text("model", self.model.clone())
@@ -102,19 +105,28 @@ impl ApiTranscriber {
             .post(&self.api_url)
             .header("Authorization", format!("Bearer {}", self.api_key))
             .multipart(form)
-            .send()?;
+            .send()
+            .map_err(|e| TranscribeError::Network(e.to_string()))?;
 
         let status = response.status();
-        let body = response.text()?;
+        let body = response
+            .text()
+            .map_err(|e| TranscribeError::Network(e.to_string()))?;
 
         if !status.is_success() {
-            return Err(format!("API error {}: {}", status, body).into());
+            return Err(TranscribeError::Api {
+                status: status.as_u16(),
+                body,
+            });
         }
 
-        let json: serde_json::Value = serde_json::from_str(&body)?;
+        let json: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|e| TranscribeError::Network(format!("invalid JSON response: {e}")))?;
         let text = json["text"]
             .as_str()
-            .ok_or("text field not found in response")?
+            .ok_or_else(|| {
+                TranscribeError::Network("text field not found in response".to_string())
+            })?
             .trim()
             .to_string();
 
@@ -135,8 +147,8 @@ impl ApiTranscriber {
         wav_path: &str,
         chunk_index: usize,
         total_chunks: usize,
-    ) -> Result<String, Box<dyn std::error::Error>> {
-        let mut last_error: Box<dyn std::error::Error> = "upload not attempted".to_string().into();
+    ) -> Result<String, TranscribeError> {
+        let mut last_error = TranscribeError::Network("upload not attempted".to_string());
 
         for attempt in 0..=self.max_retries {
             if attempt > 0 {
@@ -158,21 +170,15 @@ impl ApiTranscriber {
                 "Uploading chunk"
             );
 
-            // We need to distinguish 4xx from 5xx / network errors.
-            // Read file and do the request manually so we can inspect the status.
-            match self.try_upload(wav_path) {
+            match self.upload_file(wav_path) {
                 Ok(text) => return Ok(text),
+                // Client errors (4xx) are not transient — retrying is futile.
+                Err(e @ TranscribeError::Api { status, .. })
+                    if !Self::is_retryable_status(status) =>
+                {
+                    return Err(e);
+                }
                 Err(e) => {
-                    // Extract HTTP status from error message if present.
-                    let msg = e.to_string();
-                    // Parse "API error 4XX: ..." — do not retry 4xx.
-                    if let Some(status_str) = msg.strip_prefix("API error ")
-                        && let Some(code_str) = status_str.split(':').next()
-                        && let Ok(code) = code_str.trim().parse::<u16>()
-                        && !Self::is_retryable_status(code)
-                    {
-                        return Err(e);
-                    }
                     warn!(
                         chunk = chunk_index + 1,
                         total = total_chunks,
@@ -185,19 +191,14 @@ impl ApiTranscriber {
             }
         }
 
-        Err(format!(
-            "chunk {}/{} failed after {} attempts: {}",
-            chunk_index + 1,
-            total_chunks,
-            self.max_retries + 1,
-            last_error
-        )
-        .into())
-    }
-
-    /// Low-level upload attempt (one shot, no retry).
-    fn try_upload(&self, wav_path: &str) -> Result<String, Box<dyn std::error::Error>> {
-        self.upload_file(wav_path)
+        warn!(
+            chunk = chunk_index + 1,
+            total = total_chunks,
+            attempts = self.max_retries + 1,
+            error = %last_error,
+            "Chunk upload failed after all retries"
+        );
+        Err(last_error)
     }
 }
 
@@ -220,14 +221,15 @@ fn merge_texts(texts: &[String], language: Option<&str>) -> String {
 
 impl Transcriber for ApiTranscriber {
     #[instrument(name = "api_stt", skip(self), fields(path = %wav_path))]
-    fn transcribe(&self, wav_path: &str) -> Result<String, Box<dyn std::error::Error>> {
+    fn transcribe(&self, wav_path: &str) -> Result<String, TranscribeError> {
         info!("Starting transcription");
 
         let chunks = split_wav(
             wav_path,
             self.max_chunk_duration_secs,
             self.max_chunk_size_bytes,
-        )?;
+        )
+        .map_err(|e| TranscribeError::Network(format!("failed to split {wav_path}: {e}")))?;
 
         if chunks.is_empty() {
             // File fits within limits — use single-shot upload path (no splitting overhead).
@@ -366,5 +368,124 @@ mod tests {
         assert!(!ApiTranscriber::is_retryable_status(400));
         assert!(!ApiTranscriber::is_retryable_status(404));
         assert!(!ApiTranscriber::is_retryable_status(429));
+    }
+
+    // --- structured error tests against a local HTTP stub ---
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Minimal HTTP server that answers every connection with a fixed response
+    /// and counts how many requests it served.
+    fn spawn_http_stub(status_line: &'static str, body: &'static str) -> (u16, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&requests);
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                counter.fetch_add(1, Ordering::SeqCst);
+                let mut stream = stream;
+                // Drain the request (multipart body arrives in several reads);
+                // a short read timeout marks the end of the client's send.
+                let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(100)));
+                let mut buf = [0u8; 16384];
+                loop {
+                    match stream.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {}
+                    }
+                }
+                let response = format!(
+                    "{status_line}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        (port, requests)
+    }
+
+    fn transcriber_for_port(port: u16, max_retries: u32) -> ApiTranscriber {
+        let config = AppConfig {
+            api_key: Some("test_key".to_string()),
+            transcription_api_url: format!("http://127.0.0.1:{port}/v1/audio/transcriptions"),
+            max_retries,
+            ..Default::default()
+        };
+        ApiTranscriber::from_config(&config).unwrap()
+    }
+
+    fn temp_upload_file(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "viberwhisper-api-test-{}-{name}.wav",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"fake wav bytes").unwrap();
+        path
+    }
+
+    #[test]
+    fn test_upload_success_returns_trimmed_text() {
+        let (port, _requests) = spawn_http_stub("HTTP/1.1 200 OK", "{\"text\": \" hello \"}");
+        let t = transcriber_for_port(port, 3);
+        let file = temp_upload_file("ok");
+
+        let result = t.upload_file_with_retry(file.to_str().unwrap(), 0, 1);
+
+        assert_eq!(result.unwrap(), "hello");
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_client_error_is_structured_and_not_retried() {
+        let (port, requests) =
+            spawn_http_stub("HTTP/1.1 400 Bad Request", "{\"error\":\"bad model\"}");
+        let t = transcriber_for_port(port, 3);
+        let file = temp_upload_file("bad-request");
+
+        let started = std::time::Instant::now();
+        let result = t.upload_file_with_retry(file.to_str().unwrap(), 0, 1);
+
+        match result {
+            Err(TranscribeError::Api { status: 400, body }) => {
+                assert!(body.contains("bad model"));
+            }
+            other => panic!("expected structured 400 error, got {:?}", other),
+        }
+        // No retry: a single request, no exponential-backoff sleeps.
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_server_error_is_retried_and_kept_structured() {
+        let (port, requests) =
+            spawn_http_stub("HTTP/1.1 503 Service Unavailable", "{\"error\":\"busy\"}");
+        let t = transcriber_for_port(port, 1);
+        let file = temp_upload_file("server-error");
+
+        let result = t.upload_file_with_retry(file.to_str().unwrap(), 0, 1);
+
+        assert!(matches!(
+            result,
+            Err(TranscribeError::Api { status: 503, .. })
+        ));
+        // Initial attempt + one retry.
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_missing_file_is_network_error() {
+        let (port, _requests) = spawn_http_stub("HTTP/1.1 200 OK", "{\"text\":\"x\"}");
+        let t = transcriber_for_port(port, 0);
+
+        let result = t.upload_file_with_retry("/nonexistent/viberwhisper.wav", 0, 1);
+
+        assert!(matches!(result, Err(TranscribeError::Network(_))));
     }
 }

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -1,6 +1,12 @@
 use crate::audio::split_wav;
 use crate::core::config::AppConfig;
+use std::time::Duration;
 use tracing::{info, instrument, warn};
+
+/// Total per-request timeout for one chunk upload (connect + send + response).
+/// Without it, a hung request would pin the orchestrator worker thread forever;
+/// the convergence timeout only stops the caller from waiting, not the worker.
+const STT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub trait Transcriber: Send + Sync {
     fn transcribe(&self, wav_path: &str) -> Result<String, Box<dyn std::error::Error>>;
@@ -39,6 +45,8 @@ pub struct ApiTranscriber {
     max_chunk_size_bytes: u64,
     /// Maximum retry attempts per chunk on transient errors (5xx / network).
     max_retries: u32,
+    /// Shared HTTP client (connection reuse + request timeout).
+    client: reqwest::blocking::Client,
 }
 
 impl ApiTranscriber {
@@ -57,6 +65,9 @@ impl ApiTranscriber {
             max_chunk_duration_secs: config.max_chunk_duration_secs,
             max_chunk_size_bytes: config.max_chunk_size_bytes,
             max_retries: config.max_retries,
+            client: reqwest::blocking::Client::builder()
+                .timeout(STT_REQUEST_TIMEOUT)
+                .build()?,
         })
     }
 
@@ -86,8 +97,8 @@ impl ApiTranscriber {
             form = form.text("prompt", prompt.clone());
         }
 
-        let client = reqwest::blocking::Client::new();
-        let response = client
+        let response = self
+            .client
             .post(&self.api_url)
             .header("Authorization", format!("Bearer {}", self.api_key))
             .multipart(form)

--- a/src/transcriber/mod.rs
+++ b/src/transcriber/mod.rs
@@ -4,3 +4,35 @@ pub mod factory;
 pub use api::MockTranscriber;
 pub use api::Transcriber;
 pub use factory::create_transcriber;
+
+use std::fmt;
+
+/// Structured failure for a single transcription request.
+///
+/// Producers construct the variant directly instead of encoding the failure in
+/// an error string, so downstream layers (retry logic, the session orchestrator)
+/// can match on it without parsing messages.
+#[derive(Debug, Clone)]
+pub enum TranscribeError {
+    /// The API returned an HTTP error response (4xx or 5xx).
+    Api { status: u16, body: String },
+    /// A network, I/O, or response-parsing error.
+    Network(String),
+    /// The chunk did not reach a terminal state before the convergence timeout.
+    /// Produced by the session orchestrator, never by a transcriber itself.
+    Timeout,
+}
+
+impl fmt::Display for TranscribeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TranscribeError::Api { status, body } => {
+                write!(f, "API error {}: {}", status, body)
+            }
+            TranscribeError::Network(msg) => write!(f, "Network error: {}", msg),
+            TranscribeError::Timeout => write!(f, "Convergence timeout"),
+        }
+    }
+}
+
+impl std::error::Error for TranscribeError {}


### PR DESCRIPTION
## Summary

Fixes items 1 and 3 from the codebase optimization review.

### 1. Shared HTTP client with request timeout (`src/transcriber/api.rs`)
- `ApiTranscriber` previously created a fresh `reqwest::blocking::Client` on every upload with **no timeout** — a hung request would pin the orchestrator worker thread forever (the convergence timeout only stops the caller from waiting, not the worker).
- Now builds one client in `from_config` with a 120 s per-request timeout, also gaining connection reuse across chunk uploads. This mirrors what `LlmPostProcessor` already did.

### 2. Structured `TranscribeError` instead of error-string parsing
- `Transcriber::transcribe` now returns `Result<String, TranscribeError>` (`Api { status, body }` / `Network` / `Timeout`), defined once in `transcriber/mod.rs`.
- `ApiTranscriber` constructs the variant at the failure site; the retry loop matches on `Api { status }` directly instead of `strip_prefix("API error ")`.
- The orchestrator stores the worker's error as-is; deleted `classify_error` and `extract_http_status` (string sniffing) along with their tests. `core::orchestrator::TranscribeError` is re-exported so caller paths keep working.
- Removed the pointless `try_upload` wrapper touched by the same lines.

## Tests
- New stub-HTTP-server tests: 200 parses trimmed text; 400 returns structured `Api { status: 400 }` with **no retry** (request count = 1); 503 is retried and stays structured; missing file maps to `Network`.
- `test_partial_failure` now asserts the 500 status survives end-to-end structurally.
- `cargo test`: 147 passed. `cargo clippy --all-targets` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)