### PR TITLE
fix/refactor: remaining codebase optimization items (#2, #4–#14, #16–#19)

### DIFF
--- a/changelog
+++ b/changelog
@@ -22,3 +22,6 @@
 2026-07-05: Harden core configuration persistence, validation, session shutdown, chunk cleanup, and transcription failure handling
 2026-07-05: Harden input hotkey ordering and validation, tray state updates, and overlay focus and Windows state ownership
 2026-07-07: Add STT upload timeout with a shared HTTP client, and replace error-string parsing with a structured TranscribeError across transcriber and orchestrator
+2026-07-08: Fix stop-time ChunksOnly reporting, reused local-service startup delay, preheat finish() unbounded wait, and cwd-dependent config/temp paths
+2026-07-08: Optimize audio pipeline: lock-free capture channel, 16 kHz upload downsampling, parallel chunk transcription workers, condvar-driven convergence wait
+2026-07-08: Deduplicate recording start/stop control, post-process fallback, merge_texts, server file lookup, and python launch command; table-driven config fields; restore macOS clipboard after paste-typing

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -10,11 +10,20 @@ pub use splitter::{TmpChunk, split_wav};
 
 static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
+/// Directory for transient recordings and chunk files.
+///
+/// Lives under the system temp directory rather than `./tmp` so the app also
+/// works when launched from Finder/Explorer, where the working directory is
+/// not the project directory (and may not even be writable).
+pub(crate) fn temp_dir() -> PathBuf {
+    std::env::temp_dir().join("viberwhisper")
+}
+
 fn unique_temp_wav_path(prefix: &str) -> Result<PathBuf, std::time::SystemTimeError> {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
     let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    Ok(PathBuf::from(format!(
-        "./tmp/{prefix}_{}_{}_{}.wav",
+    Ok(temp_dir().join(format!(
+        "{prefix}_{}_{}_{}.wav",
         std::process::id(),
         timestamp,
         sequence

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -297,13 +297,13 @@ impl AudioRecorder {
         }
     }
 
-    /// Write PCM samples to a WAV file under ./tmp/ and return the path.
+    /// Write PCM samples to a WAV file under the app temp dir and return the path.
     fn write_chunk(
         &mut self,
         samples: &[i16],
         chunk_index: usize,
     ) -> Result<String, Box<dyn std::error::Error>> {
-        std::fs::create_dir_all("./tmp")?;
+        std::fs::create_dir_all(super::temp_dir())?;
         let path = unique_temp_wav_path(&format!("chunk_live_{chunk_index:04}"))?;
 
         write_wav_to_path(&path, samples, self.sample_rate)?;
@@ -347,7 +347,7 @@ impl AudioRecorder {
             if wrote_live_chunks {
                 // All audio was already flushed to live chunks; there is no tail
                 // to write, but the session still has transcribable chunks.
-                self.cleanup_old_recordings("./tmp", 10);
+                self.cleanup_old_recordings(&super::temp_dir(), 10);
                 return Ok(StopResult::ChunksOnly);
             }
             return Err("No audio data recorded".into());
@@ -357,7 +357,7 @@ impl AudioRecorder {
         // writing every complete chunk before the final tail.
         if self.chunk_max_samples > 0 && tail_samples.len() >= self.chunk_max_samples {
             let paths = self.write_chunk_sequence(&tail_samples, chunk_index)?;
-            self.cleanup_old_recordings("./tmp", 10);
+            self.cleanup_old_recordings(&super::temp_dir(), 10);
             return Ok(StopResult::ChunkFiles(paths));
         }
 
@@ -369,7 +369,7 @@ impl AudioRecorder {
             self.write_chunk(&tail_samples, chunk_index)?
         };
 
-        self.cleanup_old_recordings("./tmp", 10);
+        self.cleanup_old_recordings(&super::temp_dir(), 10);
 
         if !wrote_live_chunks {
             Ok(StopResult::SingleFile(path))
@@ -395,7 +395,7 @@ impl AudioRecorder {
         &mut self,
         buffer: &[i16],
     ) -> Result<String, Box<dyn std::error::Error>> {
-        std::fs::create_dir_all("./tmp")?;
+        std::fs::create_dir_all(super::temp_dir())?;
         let path = unique_temp_wav_path("recording")?;
         let filename = path.to_string_lossy().to_string();
         debug!(path = %filename, "Saving recording");
@@ -407,7 +407,7 @@ impl AudioRecorder {
         Ok(filename)
     }
 
-    fn cleanup_old_recordings(&self, dir: &str, keep: usize) {
+    fn cleanup_old_recordings(&self, dir: &std::path::Path, keep: usize) {
         let current_files: HashSet<OsString> = self
             .current_session_files
             .iter()
@@ -573,7 +573,7 @@ mod tests {
 
         let mut recorder = recorder_for_buffer(Vec::new(), 10);
         recorder.current_session_files.push(current.clone());
-        recorder.cleanup_old_recordings(dir.to_str().unwrap(), 0);
+        recorder.cleanup_old_recordings(&dir, 0);
 
         assert!(current.exists());
         assert!(!old.exists());

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -66,6 +66,52 @@ fn push_mono_chunk(
     }
 }
 
+/// Sample rate used for WAV files written for STT upload.
+///
+/// Whisper-style backends operate on 16 kHz mono internally, so uploading
+/// device-rate audio (44.1/48 kHz) only inflates the transfer ~3x.
+const TARGET_UPLOAD_SAMPLE_RATE: u32 = 16_000;
+
+/// Downsample mono PCM with linear interpolation.
+///
+/// Linear interpolation is adequate for speech: the aliasing it admits sits
+/// above 8 kHz where speech carries little energy, and the STT model discards
+/// that band anyway.
+fn resample_linear(samples: &[i16], from_rate: u32, to_rate: u32) -> Vec<i16> {
+    if from_rate == to_rate || samples.is_empty() {
+        return samples.to_vec();
+    }
+    let ratio = from_rate as f64 / to_rate as f64;
+    let out_len = (samples.len() as f64 / ratio).floor() as usize;
+    let mut out = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let pos = i as f64 * ratio;
+        let idx = pos as usize;
+        let frac = pos - idx as f64;
+        let a = samples[idx] as f64;
+        let b = samples[(idx + 1).min(samples.len() - 1)] as f64;
+        out.push((a + (b - a) * frac).round() as i16);
+    }
+    out
+}
+
+/// Downsample to the upload rate when the device rate is higher; lower device
+/// rates are kept as-is (upsampling adds bytes without adding information).
+fn prepare_upload_samples(samples: &[i16], sample_rate: u32) -> (std::borrow::Cow<'_, [i16]>, u32) {
+    if sample_rate > TARGET_UPLOAD_SAMPLE_RATE {
+        (
+            std::borrow::Cow::Owned(resample_linear(
+                samples,
+                sample_rate,
+                TARGET_UPLOAD_SAMPLE_RATE,
+            )),
+            TARGET_UPLOAD_SAMPLE_RATE,
+        )
+    } else {
+        (std::borrow::Cow::Borrowed(samples), sample_rate)
+    }
+}
+
 /// Write `samples` as a 16-bit mono WAV file to `path`.
 fn write_wav_to_path(
     path: &PathBuf,
@@ -314,10 +360,11 @@ impl AudioRecorder {
         std::fs::create_dir_all(super::temp_dir())?;
         let path = unique_temp_wav_path(&format!("chunk_live_{chunk_index:04}"))?;
 
-        write_wav_to_path(&path, samples, self.sample_rate)?;
+        let (upload_samples, upload_rate) = prepare_upload_samples(samples, self.sample_rate);
+        write_wav_to_path(&path, &upload_samples, upload_rate)?;
 
         let path_str = path.to_string_lossy().to_string();
-        info!(path = %path_str, index = chunk_index, samples = samples.len(), "Live chunk written");
+        info!(path = %path_str, index = chunk_index, samples = upload_samples.len(), sample_rate = upload_rate, "Live chunk written");
         self.current_session_files.push(path);
         Ok(path_str)
     }
@@ -419,7 +466,8 @@ impl AudioRecorder {
         let filename = path.to_string_lossy().to_string();
         debug!(path = %filename, "Saving recording");
 
-        write_wav_to_path(&path, buffer, self.sample_rate)?;
+        let (upload_samples, upload_rate) = prepare_upload_samples(buffer, self.sample_rate);
+        write_wav_to_path(&path, &upload_samples, upload_rate)?;
 
         info!(path = %filename, "Recording saved");
         self.current_session_files.push(path);
@@ -562,6 +610,51 @@ mod tests {
             recorder.pending.is_empty(),
             "flushed samples should be released from memory"
         );
+
+        for path in recorder.current_session_files {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn test_resample_linear_scales_length() {
+        let samples: Vec<i16> = vec![0; 44_100];
+        let out = resample_linear(&samples, 44_100, 16_000);
+        assert_eq!(out.len(), 16_000);
+    }
+
+    #[test]
+    fn test_resample_linear_preserves_constant_signal() {
+        let samples: Vec<i16> = vec![1234; 4_410];
+        let out = resample_linear(&samples, 44_100, 16_000);
+        assert!(out.iter().all(|&s| s == 1234));
+    }
+
+    #[test]
+    fn test_resample_linear_same_rate_is_identity() {
+        let samples: Vec<i16> = (0..100).collect();
+        assert_eq!(resample_linear(&samples, 16_000, 16_000), samples);
+    }
+
+    #[test]
+    fn test_prepare_upload_samples_keeps_low_rates() {
+        let samples: Vec<i16> = (0..100).collect();
+        let (out, rate) = prepare_upload_samples(&samples, 8_000);
+        assert_eq!(rate, 8_000);
+        assert_eq!(out.as_ref(), samples.as_slice());
+    }
+
+    #[test]
+    fn test_write_chunk_downsamples_high_rate_audio() {
+        let mut recorder = recorder_for_buffer(Vec::new(), 0);
+        recorder.sample_rate = 44_100;
+
+        let samples: Vec<i16> = vec![0; 44_100]; // 1 second at device rate
+        let path = recorder.write_chunk(&samples, 0).unwrap();
+
+        let reader = hound::WavReader::open(&path).unwrap();
+        assert_eq!(reader.spec().sample_rate, 16_000);
+        assert_eq!(reader.len(), 16_000); // still ~1 second at the upload rate
 
         for path in recorder.current_session_files {
             let _ = std::fs::remove_file(path);

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::Duration;
 
@@ -14,7 +14,13 @@ use super::unique_temp_wav_path;
 
 pub struct AudioRecorder {
     recording: Arc<AtomicBool>,
-    buffer: Arc<Mutex<Vec<i16>>>,
+    /// Receives sample blocks from the audio callback. The callback only does a
+    /// non-blocking channel send, so it can never stall on the consumer holding
+    /// a lock during large chunk copies.
+    capture_rx: Option<mpsc::Receiver<Vec<i16>>>,
+    /// Samples drained from the channel that have not been flushed to disk yet.
+    /// Owned by the consumer side; no lock needed.
+    pending: Vec<i16>,
     stream: Option<cpal::Stream>,
     sample_count: Arc<AtomicUsize>,
     gain: f32,
@@ -33,18 +39,20 @@ pub struct AudioRecorder {
     max_chunk_size_bytes: u64,
 }
 
-/// Shared logic for both I16 and F32 audio callbacks: append mono samples to the
-/// buffer and signal a flush when the chunk threshold is crossed.
+/// Shared logic for both I16 and F32 audio callbacks: hand mono samples to the
+/// consumer via the channel and signal a flush when the chunk threshold is crossed.
 fn push_mono_chunk(
     mono: Vec<i16>,
-    buffer: &Mutex<Vec<i16>>,
+    capture_tx: &mpsc::Sender<Vec<i16>>,
     sample_count: &AtomicUsize,
     ready_chunk_count: &AtomicUsize,
     sample_rate: u32,
     chunk_max_samples: usize,
 ) {
     let len = mono.len();
-    buffer.lock().unwrap().extend_from_slice(&mono);
+    // A send only fails when the receiver is gone (recorder stopped/dropped);
+    // the samples are irrelevant then.
+    let _ = capture_tx.send(mono);
     let total = sample_count.fetch_add(len, Ordering::Relaxed) + len;
     if total % (sample_rate as usize / 2) < len {
         debug!(
@@ -116,7 +124,8 @@ impl AudioRecorder {
 
         Ok(AudioRecorder {
             recording: Arc::new(AtomicBool::new(false)),
-            buffer: Arc::new(Mutex::new(Vec::new())),
+            capture_rx: None,
+            pending: Vec::new(),
             stream: None,
             sample_count: Arc::new(AtomicUsize::new(0)),
             gain,
@@ -172,13 +181,14 @@ impl AudioRecorder {
         self.chunk_max_samples = max_by_duration.min(max_by_size);
 
         let recording = Arc::clone(&self.recording);
-        let buffer = Arc::clone(&self.buffer);
         let sample_count = Arc::clone(&self.sample_count);
         let ready_chunk_count = Arc::clone(&self.ready_chunk_count);
         let chunk_max_samples = self.chunk_max_samples;
         let gain = self.gain;
 
-        buffer.lock().unwrap().clear();
+        let (capture_tx, capture_rx) = mpsc::channel::<Vec<i16>>();
+        self.capture_rx = Some(capture_rx);
+        self.pending.clear();
         sample_count.store(0, Ordering::Relaxed);
 
         let stream = match sample_format {
@@ -196,7 +206,7 @@ impl AudioRecorder {
                             .collect();
                         push_mono_chunk(
                             mono,
-                            &buffer,
+                            &capture_tx,
                             &sample_count,
                             &ready_chunk_count,
                             sample_rate,
@@ -221,7 +231,7 @@ impl AudioRecorder {
                             .collect();
                         push_mono_chunk(
                             mono,
-                            &buffer,
+                            &capture_tx,
                             &sample_count,
                             &ready_chunk_count,
                             sample_rate,
@@ -268,25 +278,23 @@ impl AudioRecorder {
             return None;
         }
 
+        self.drain_captured_samples();
+
         let chunk_end = self.flushed_samples + self.chunk_max_samples;
         let chunk_index = flushed_chunk_count;
-        let chunk_samples = {
-            let buffer = self.buffer.lock().unwrap();
-            let total_samples = buffer.len();
-            if total_samples < self.chunk_max_samples {
-                debug!(
-                    total_samples = total_samples,
-                    chunk_size = self.chunk_max_samples,
-                    "Chunk count is ahead of buffered samples; retrying later"
-                );
-                return None;
-            }
-            buffer[..self.chunk_max_samples].to_vec()
-        };
+        if self.pending.len() < self.chunk_max_samples {
+            debug!(
+                total_samples = self.pending.len(),
+                chunk_size = self.chunk_max_samples,
+                "Chunk count is ahead of buffered samples; retrying later"
+            );
+            return None;
+        }
+        let chunk_samples = self.pending[..self.chunk_max_samples].to_vec();
 
         match self.write_chunk(&chunk_samples, chunk_index) {
             Ok(path) => {
-                self.buffer.lock().unwrap().drain(..self.chunk_max_samples);
+                self.pending.drain(..self.chunk_max_samples);
                 self.flushed_samples = chunk_end;
                 Some(path)
             }
@@ -330,18 +338,19 @@ impl AudioRecorder {
         drop(self.stream.take());
         debug!("Stream stopped");
 
-        let (tail_samples, chunk_index, wrote_live_chunks) = {
-            let buffer = self.buffer.lock().unwrap();
-            debug!(samples = buffer.len(), "Buffer size");
+        // Collect everything the callback produced; then close the channel so a
+        // late callback (should not happen after the stream drop) sends into void.
+        self.drain_captured_samples();
+        self.capture_rx = None;
 
-            let tail_samples = buffer.to_vec();
-            let chunk_index = if self.flushed_samples > 0 && self.chunk_max_samples > 0 {
-                self.flushed_samples / self.chunk_max_samples
-            } else {
-                0
-            };
-            (tail_samples, chunk_index, self.flushed_samples > 0)
+        let tail_samples = std::mem::take(&mut self.pending);
+        debug!(samples = tail_samples.len(), "Buffer size");
+        let chunk_index = if self.flushed_samples > 0 && self.chunk_max_samples > 0 {
+            self.flushed_samples / self.chunk_max_samples
+        } else {
+            0
         };
+        let wrote_live_chunks = self.flushed_samples > 0;
 
         if tail_samples.is_empty() {
             if wrote_live_chunks {
@@ -375,6 +384,16 @@ impl AudioRecorder {
             Ok(StopResult::SingleFile(path))
         } else {
             Ok(StopResult::TailChunk(path))
+        }
+    }
+
+    /// Move every sample block the audio callback has produced so far into the
+    /// local pending buffer. Non-blocking.
+    fn drain_captured_samples(&mut self) {
+        if let Some(rx) = &self.capture_rx {
+            while let Ok(block) = rx.try_recv() {
+                self.pending.extend_from_slice(&block);
+            }
         }
     }
 
@@ -507,7 +526,8 @@ mod tests {
     fn recorder_for_buffer(samples: Vec<i16>, chunk_max_samples: usize) -> AudioRecorder {
         AudioRecorder {
             recording: Arc::new(AtomicBool::new(true)),
-            buffer: Arc::new(Mutex::new(samples)),
+            capture_rx: None,
+            pending: samples,
             stream: None,
             sample_count: Arc::new(AtomicUsize::new(0)),
             gain: 1.0,
@@ -539,9 +559,37 @@ mod tests {
         assert_eq!(recorder.flushed_samples, 30);
         assert_eq!(recorder.current_session_files.len(), 3);
         assert!(
-            recorder.buffer.lock().unwrap().is_empty(),
+            recorder.pending.is_empty(),
             "flushed samples should be released from memory"
         );
+
+        for path in recorder.current_session_files {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn test_take_ready_chunk_drains_callback_channel() {
+        // Samples arrive through the channel exactly as the audio callback
+        // would deliver them, in several small blocks.
+        let mut recorder = recorder_for_buffer(Vec::new(), 10);
+        let (tx, rx) = mpsc::channel::<Vec<i16>>();
+        recorder.capture_rx = Some(rx);
+        for block in [
+            (0..4).collect::<Vec<i16>>(),
+            (4..10).collect(),
+            (10..12).collect(),
+        ] {
+            tx.send(block).unwrap();
+        }
+        recorder.ready_chunk_count.store(1, Ordering::Release);
+
+        let path = recorder.take_ready_chunk();
+
+        assert!(path.is_some());
+        assert_eq!(recorder.flushed_samples, 10);
+        // The partial second chunk stays pending.
+        assert_eq!(recorder.pending, vec![10, 11]);
 
         for path in recorder.current_session_files {
             let _ = std::fs::remove_file(path);

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -330,13 +330,9 @@ impl AudioRecorder {
         drop(self.stream.take());
         debug!("Stream stopped");
 
-        let (buffer_len, tail_samples, chunk_index, wrote_live_chunks) = {
+        let (tail_samples, chunk_index, wrote_live_chunks) = {
             let buffer = self.buffer.lock().unwrap();
             debug!(samples = buffer.len(), "Buffer size");
-
-            if buffer.is_empty() {
-                return Err("No audio data recorded".into());
-            }
 
             let tail_samples = buffer.to_vec();
             let chunk_index = if self.flushed_samples > 0 && self.chunk_max_samples > 0 {
@@ -344,26 +340,21 @@ impl AudioRecorder {
             } else {
                 0
             };
-            (
-                buffer.len(),
-                tail_samples,
-                chunk_index,
-                self.flushed_samples > 0,
-            )
+            (tail_samples, chunk_index, self.flushed_samples > 0)
         };
 
-        if buffer_len == 0 {
+        if tail_samples.is_empty() {
+            if wrote_live_chunks {
+                // All audio was already flushed to live chunks; there is no tail
+                // to write, but the session still has transcribable chunks.
+                self.cleanup_old_recordings("./tmp", 10);
+                return Ok(StopResult::ChunksOnly);
+            }
             return Err("No audio data recorded".into());
         }
 
         // If chunking is enabled and enough unflushed audio remains, catch up by
         // writing every complete chunk before the final tail.
-        if tail_samples.is_empty() {
-            // All audio was already flushed to chunks; nothing left.
-            self.cleanup_old_recordings("./tmp", 10);
-            return Ok(StopResult::ChunksOnly);
-        }
-
         if self.chunk_max_samples > 0 && tail_samples.len() >= self.chunk_max_samples {
             let paths = self.write_chunk_sequence(&tail_samples, chunk_index)?;
             self.cleanup_old_recordings("./tmp", 10);
@@ -609,6 +600,25 @@ mod tests {
         for path in recorder.current_session_files {
             let _ = std::fs::remove_file(path);
         }
+    }
+
+    #[test]
+    fn test_stop_recording_all_audio_flushed_returns_chunks_only() {
+        // Everything was already written as live chunks; the buffer is empty.
+        let mut recorder = recorder_for_buffer(Vec::new(), 10);
+        recorder.flushed_samples = 30;
+
+        let result = recorder.stop_recording().unwrap();
+
+        assert!(matches!(result, StopResult::ChunksOnly));
+    }
+
+    #[test]
+    fn test_stop_recording_no_audio_at_all_is_an_error() {
+        // Nothing was flushed and nothing is buffered — a genuinely empty recording.
+        let mut recorder = recorder_for_buffer(Vec::new(), 10);
+
+        assert!(recorder.stop_recording().is_err());
     }
 
     #[test]

--- a/src/audio/splitter.rs
+++ b/src/audio/splitter.rs
@@ -93,7 +93,7 @@ pub fn split_wav(
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("audio");
-    std::fs::create_dir_all("./tmp")?;
+    std::fs::create_dir_all(super::temp_dir())?;
 
     let chunk_spec = WavSpec {
         channels: spec.channels,

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -57,6 +57,255 @@ fn default_local_quantization() -> String {
     "int8".to_string()
 }
 
+/// One user-facing config field: its key plus string-based accessors.
+/// `get_field`, `set_field`, and the CLI `config list` all derive from this
+/// single table, so adding a field means adding exactly one entry here.
+struct FieldSpec {
+    key: &'static str,
+    get: fn(&AppConfig) -> Option<String>,
+    set: fn(&mut AppConfig, &str) -> Result<(), String>,
+}
+
+/// Map legacy aliases onto their canonical key.
+fn canonical_key(key: &str) -> &str {
+    if key == "groq_api_key" {
+        "api_key"
+    } else {
+        key
+    }
+}
+
+fn parse_bool(key: &str, value: &str) -> Result<bool, String> {
+    value
+        .parse::<bool>()
+        .map_err(|_| format!("{key} must be true/false, got: {value}"))
+}
+
+const FIELDS: &[FieldSpec] = &[
+    FieldSpec {
+        key: "api_key",
+        get: |c| c.api_key.as_ref().map(|_| "*** (set)".to_string()),
+        set: |_, _| {
+            Err("api_key cannot be saved by the config command; use the TRANSCRIPTION_API_KEY environment variable or edit config.json manually".to_string())
+        },
+    },
+    FieldSpec {
+        key: "transcription_api_url",
+        get: |c| Some(c.transcription_api_url.clone()),
+        set: |c, v| {
+            c.transcription_api_url = v.to_string();
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "provider",
+        get: |c| c.provider.clone(),
+        set: |c, v| {
+            c.provider = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "model",
+        get: |c| Some(c.model.clone()),
+        set: |c, v| {
+            c.model = v.to_string();
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "hold_hotkey",
+        get: |c| Some(c.hold_hotkey.clone()),
+        set: |c, v| {
+            c.hold_hotkey = v.to_string();
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "toggle_hotkey",
+        get: |c| Some(c.toggle_hotkey.clone()),
+        set: |c, v| {
+            c.toggle_hotkey = v.to_string();
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "language",
+        get: |c| c.language.clone(),
+        set: |c, v| {
+            c.language = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "prompt",
+        get: |c| c.prompt.clone(),
+        set: |c, v| {
+            c.prompt = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "temperature",
+        get: |c| Some(c.temperature.to_string()),
+        set: |c, v| {
+            c.temperature = parse_finite_f32("temperature", v)?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "mic_gain",
+        get: |c| Some(c.mic_gain.to_string()),
+        set: |c, v| {
+            c.mic_gain = parse_finite_f32("mic_gain", v)?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "max_chunk_duration_secs",
+        get: |c| Some(c.max_chunk_duration_secs.to_string()),
+        set: |c, v| {
+            c.max_chunk_duration_secs = v
+                .parse::<u32>()
+                .map_err(|_| format!("max_chunk_duration_secs must be a u32, got: {v}"))?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "max_chunk_size_bytes",
+        get: |c| Some(c.max_chunk_size_bytes.to_string()),
+        set: |c, v| {
+            c.max_chunk_size_bytes = v
+                .parse::<u64>()
+                .map_err(|_| format!("max_chunk_size_bytes must be a u64, got: {v}"))?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "max_retries",
+        get: |c| Some(c.max_retries.to_string()),
+        set: |c, v| {
+            let parsed = v
+                .parse::<u32>()
+                .map_err(|_| format!("max_retries must be a u32, got: {v}"))?;
+            if parsed > MAX_RETRIES {
+                return Err(format!("max_retries must be <= {MAX_RETRIES}, got: {v}"));
+            }
+            c.max_retries = parsed;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "convergence_timeout_secs",
+        get: |c| Some(c.convergence_timeout_secs.to_string()),
+        set: |c, v| {
+            let parsed = v
+                .parse::<u64>()
+                .map_err(|_| format!("convergence_timeout_secs must be a u64, got: {v}"))?;
+            if parsed > MAX_CONVERGENCE_TIMEOUT_SECS {
+                return Err(format!(
+                    "convergence_timeout_secs must be <= {MAX_CONVERGENCE_TIMEOUT_SECS}, got: {v}"
+                ));
+            }
+            c.convergence_timeout_secs = parsed;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "post_process_enabled",
+        get: |c| Some(c.post_process_enabled.to_string()),
+        set: |c, v| {
+            c.post_process_enabled = parse_bool("post_process_enabled", v)?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "post_process_streaming_enabled",
+        get: |c| Some(c.post_process_streaming_enabled.to_string()),
+        set: |c, v| {
+            c.post_process_streaming_enabled = parse_bool("post_process_streaming_enabled", v)?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "post_process_api_url",
+        get: |c| c.post_process_api_url.clone(),
+        set: |c, v| {
+            c.post_process_api_url = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "post_process_api_key",
+        get: |c| {
+            c.post_process_api_key
+                .as_ref()
+                .map(|_| "*** (set)".to_string())
+        },
+        set: |_, _| {
+            Err("post_process_api_key cannot be saved by the config command; use the POST_PROCESS_API_KEY environment variable or edit config.json manually".to_string())
+        },
+    },
+    FieldSpec {
+        key: "post_process_model",
+        get: |c| c.post_process_model.clone(),
+        set: |c, v| {
+            c.post_process_model = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "post_process_prompt",
+        get: |c| c.post_process_prompt.clone(),
+        set: |c, v| {
+            c.post_process_prompt = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "post_process_temperature",
+        get: |c| Some(c.post_process_temperature.to_string()),
+        set: |c, v| {
+            c.post_process_temperature = parse_finite_f32("post_process_temperature", v)?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "local_mode",
+        get: |c| Some(c.local_mode.to_string()),
+        set: |c, v| {
+            c.local_mode = parse_bool("local_mode", v)?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "local_data_dir",
+        get: |c| c.local_data_dir.clone(),
+        set: |c, v| {
+            c.local_data_dir = Some(v.to_string());
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "local_server_port",
+        get: |c| Some(c.local_server_port.to_string()),
+        set: |c, v| {
+            c.local_server_port = v
+                .parse::<u16>()
+                .map_err(|_| format!("local_server_port must be a u16, got: {v}"))?;
+            Ok(())
+        },
+    },
+    FieldSpec {
+        key: "local_quantization",
+        get: |c| Some(c.local_quantization.clone()),
+        set: |c, v| {
+            c.local_quantization = v.to_string();
+            Ok(())
+        },
+    },
+];
+
 fn parse_finite_f32(key: &str, value: &str) -> Result<f32, String> {
     let parsed = value
         .parse::<f32>()
@@ -259,185 +508,29 @@ impl AppConfig {
 
     /// Get the string value of a config field
     pub fn get_field(&self, key: &str) -> Option<String> {
-        match key {
-            "api_key" | "groq_api_key" => self.api_key.as_ref().map(|_| "*** (set)".to_string()),
-            "transcription_api_url" => Some(self.transcription_api_url.clone()),
-            "provider" => self.provider.clone(),
-            "model" => Some(self.model.clone()),
-            "hold_hotkey" => Some(self.hold_hotkey.clone()),
-            "toggle_hotkey" => Some(self.toggle_hotkey.clone()),
-            "temperature" => Some(self.temperature.to_string()),
-            "mic_gain" => Some(self.mic_gain.to_string()),
-            "language" => self.language.clone(),
-            "prompt" => self.prompt.clone(),
-            "max_chunk_duration_secs" => Some(self.max_chunk_duration_secs.to_string()),
-            "max_chunk_size_bytes" => Some(self.max_chunk_size_bytes.to_string()),
-            "max_retries" => Some(self.max_retries.to_string()),
-            "convergence_timeout_secs" => Some(self.convergence_timeout_secs.to_string()),
-            "post_process_enabled" => Some(self.post_process_enabled.to_string()),
-            "post_process_streaming_enabled" => {
-                Some(self.post_process_streaming_enabled.to_string())
-            }
-            "post_process_api_url" => self.post_process_api_url.clone(),
-            "post_process_api_key" => self
-                .post_process_api_key
-                .as_ref()
-                .map(|_| "*** (set)".to_string()),
-            "post_process_model" => self.post_process_model.clone(),
-            "post_process_prompt" => self.post_process_prompt.clone(),
-            "post_process_temperature" => Some(self.post_process_temperature.to_string()),
-            "local_mode" => Some(self.local_mode.to_string()),
-            "local_data_dir" => self.local_data_dir.clone(),
-            "local_server_port" => Some(self.local_server_port.to_string()),
-            "local_quantization" => Some(self.local_quantization.clone()),
-            _ => None,
-        }
+        let key = canonical_key(key);
+        FIELDS
+            .iter()
+            .find(|field| field.key == key)
+            .and_then(|field| (field.get)(self))
     }
 
     /// Set a config field value (accepts string, auto-converts types)
     pub fn set_field(&mut self, key: &str, value: &str) -> Result<(), String> {
-        match key {
-            "api_key" | "groq_api_key" => Err(
-                "api_key cannot be saved by the config command; use the TRANSCRIPTION_API_KEY environment variable or edit config.json manually"
-                    .to_string(),
-            ),
-            "transcription_api_url" => {
-                self.transcription_api_url = value.to_string();
-                Ok(())
-            }
-            "provider" => {
-                self.provider = Some(value.to_string());
-                Ok(())
-            }
-            "model" => {
-                self.model = value.to_string();
-                Ok(())
-            }
-            "hold_hotkey" => {
-                self.hold_hotkey = value.to_string();
-                Ok(())
-            }
-            "toggle_hotkey" => {
-                self.toggle_hotkey = value.to_string();
-                Ok(())
-            }
-            "language" => {
-                self.language = Some(value.to_string());
-                Ok(())
-            }
-            "prompt" => {
-                self.prompt = Some(value.to_string());
-                Ok(())
-            }
-            "temperature" => {
-                self.temperature = parse_finite_f32("temperature", value)?;
-                Ok(())
-            }
-            "mic_gain" => {
-                self.mic_gain = parse_finite_f32("mic_gain", value)?;
-                Ok(())
-            }
-            "max_chunk_duration_secs" => {
-                self.max_chunk_duration_secs = value.parse::<u32>().map_err(|_| {
-                    format!("max_chunk_duration_secs must be a u32, got: {}", value)
-                })?;
-                Ok(())
-            }
-            "max_chunk_size_bytes" => {
-                self.max_chunk_size_bytes = value
-                    .parse::<u64>()
-                    .map_err(|_| format!("max_chunk_size_bytes must be a u64, got: {}", value))?;
-                Ok(())
-            }
-            "max_retries" => {
-                let parsed = value
-                    .parse::<u32>()
-                    .map_err(|_| format!("max_retries must be a u32, got: {}", value))?;
-                if parsed > MAX_RETRIES {
-                    return Err(format!("max_retries must be <= {MAX_RETRIES}, got: {value}"));
-                }
-                self.max_retries = parsed;
-                Ok(())
-            }
-            "convergence_timeout_secs" => {
-                let parsed = value.parse::<u64>().map_err(|_| {
-                    format!("convergence_timeout_secs must be a u64, got: {}", value)
-                })?;
-                if parsed > MAX_CONVERGENCE_TIMEOUT_SECS {
-                    return Err(format!(
-                        "convergence_timeout_secs must be <= {MAX_CONVERGENCE_TIMEOUT_SECS}, got: {value}"
-                    ));
-                }
-                self.convergence_timeout_secs = parsed;
-                Ok(())
-            }
-            "post_process_enabled" => {
-                self.post_process_enabled = value.parse::<bool>().map_err(|_| {
-                    format!("post_process_enabled must be true/false, got: {}", value)
-                })?;
-                Ok(())
-            }
-            "post_process_streaming_enabled" => {
-                self.post_process_streaming_enabled = value.parse::<bool>().map_err(|_| {
-                    format!(
-                        "post_process_streaming_enabled must be true/false, got: {}",
-                        value
-                    )
-                })?;
-                Ok(())
-            }
-            "post_process_api_url" => {
-                self.post_process_api_url = Some(value.to_string());
-                Ok(())
-            }
-            "post_process_api_key" => Err(
-                "post_process_api_key cannot be saved by the config command; use the POST_PROCESS_API_KEY environment variable or edit config.json manually"
-                    .to_string(),
-            ),
-            "post_process_model" => {
-                self.post_process_model = Some(value.to_string());
-                Ok(())
-            }
-            "post_process_prompt" => {
-                self.post_process_prompt = Some(value.to_string());
-                Ok(())
-            }
-            "post_process_temperature" => {
-                self.post_process_temperature =
-                    parse_finite_f32("post_process_temperature", value)?;
-                Ok(())
-            }
-            "local_mode" => {
-                self.local_mode = value
-                    .parse::<bool>()
-                    .map_err(|_| format!("local_mode must be true/false, got: {}", value))?;
-                Ok(())
-            }
-            "local_data_dir" => {
-                self.local_data_dir = Some(value.to_string());
-                Ok(())
-            }
-            "local_server_port" => {
-                self.local_server_port = value
-                    .parse::<u16>()
-                    .map_err(|_| format!("local_server_port must be a u16, got: {}", value))?;
-                Ok(())
-            }
-            "local_quantization" => {
-                self.local_quantization = value.to_string();
-                Ok(())
-            }
-            _ => Err(format!(
-                "Unknown config key: {}. Available: api_key, transcription_api_url, model, \
-                 hold_hotkey, toggle_hotkey, language, prompt, temperature, mic_gain, \
-                 max_chunk_duration_secs, max_chunk_size_bytes, max_retries, \
-                 convergence_timeout_secs, post_process_enabled, post_process_streaming_enabled, \
-                 post_process_api_url, post_process_api_key, post_process_model, \
-                 post_process_prompt, post_process_temperature, \
-                 local_mode, local_data_dir, local_server_port, local_quantization",
-                key
+        let canonical = canonical_key(key);
+        match FIELDS.iter().find(|field| field.key == canonical) {
+            Some(field) => (field.set)(self, value),
+            None => Err(format!(
+                "Unknown config key: {}. Available: {}",
+                key,
+                Self::field_keys().collect::<Vec<_>>().join(", ")
             )),
         }
+    }
+
+    /// Ordered list of user-facing config keys (drives `config list`).
+    pub fn field_keys() -> impl Iterator<Item = &'static str> {
+        FIELDS.iter().map(|field| field.key)
     }
 
     fn apply_json(&mut self, json: &serde_json::Value) {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,8 +1,28 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::path::PathBuf;
 use tracing::{info, warn};
 
 const CONFIG_FILE: &str = "config.json";
+
+/// Resolve where the config file lives.
+///
+/// A `config.json` in the current working directory takes precedence so
+/// existing setups and `cargo run` keep working. Otherwise fall back to the
+/// per-user config directory, which is what a bundled app launched from
+/// Finder/Explorer needs (its cwd is not the project directory).
+fn config_file_path() -> PathBuf {
+    resolve_config_path(PathBuf::from(CONFIG_FILE), dirs::config_dir())
+}
+
+fn resolve_config_path(cwd_candidate: PathBuf, config_dir: Option<PathBuf>) -> PathBuf {
+    if cwd_candidate.exists() {
+        return cwd_candidate;
+    }
+    config_dir
+        .map(|dir| dir.join("viberwhisper").join(CONFIG_FILE))
+        .unwrap_or(cwd_candidate)
+}
 const MAX_RETRIES: u32 = 16;
 const MAX_CONVERGENCE_TIMEOUT_SECS: u64 = 60 * 60;
 
@@ -169,18 +189,19 @@ impl AppConfig {
     pub fn load() -> Self {
         let mut config = AppConfig::default();
 
-        if let Ok(content) = fs::read_to_string(CONFIG_FILE) {
+        let path = config_file_path();
+        if let Ok(content) = fs::read_to_string(&path) {
             match serde_json::from_str::<serde_json::Value>(&content) {
                 Ok(json) => {
                     config.apply_json(&json);
-                    info!(file = %CONFIG_FILE, "Config loaded successfully");
+                    info!(file = %path.display(), "Config loaded successfully");
                 }
                 Err(e) => {
-                    warn!(file = %CONFIG_FILE, error = %e, "Failed to parse config, using defaults")
+                    warn!(file = %path.display(), error = %e, "Failed to parse config, using defaults")
                 }
             }
         } else {
-            info!(file = %CONFIG_FILE, "Config file not found, using defaults");
+            info!(file = %path.display(), "Config file not found, using defaults");
         }
 
         // Env var override: GROQ_API_KEY for backward compat, api_key for new configs
@@ -201,12 +222,18 @@ impl AppConfig {
 
     /// Save config to config.json (excludes api_key — never persisted)
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let existing = fs::read_to_string(CONFIG_FILE)
+        let path = config_file_path();
+        let existing = fs::read_to_string(&path)
             .ok()
             .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok());
         let value = self.json_for_save(existing.as_ref())?;
         let json = serde_json::to_string_pretty(&value)?;
-        fs::write(CONFIG_FILE, json)?;
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, json)?;
         Ok(())
     }
 
@@ -534,6 +561,32 @@ impl AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_resolve_config_path_prefers_existing_cwd_file() {
+        let dir =
+            std::env::temp_dir().join(format!("viberwhisper-config-path-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cwd_file = dir.join(CONFIG_FILE);
+        std::fs::write(&cwd_file, "{}").unwrap();
+
+        let resolved = resolve_config_path(cwd_file.clone(), Some(PathBuf::from("/cfg")));
+        assert_eq!(resolved, cwd_file);
+
+        let _ = std::fs::remove_file(&cwd_file);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_resolve_config_path_falls_back_to_user_config_dir() {
+        let missing = PathBuf::from("/nonexistent-dir/config.json");
+        let resolved = resolve_config_path(missing.clone(), Some(PathBuf::from("/cfg")));
+        assert_eq!(resolved, PathBuf::from("/cfg/viberwhisper/config.json"));
+
+        // Without a config dir, keep the cwd candidate as a last resort.
+        let resolved = resolve_config_path(missing.clone(), None);
+        assert_eq!(resolved, missing);
+    }
 
     #[test]
     fn test_default_config() {

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 use tracing::{debug, error, info, warn};
 
-use crate::transcriber::Transcriber;
+use crate::transcriber::{Transcriber, merge_texts};
 // Re-exported so callers can keep using `core::orchestrator::TranscribeError`.
 pub use crate::transcriber::TranscribeError;
 
@@ -422,21 +422,6 @@ fn remove_chunk_file(path: &str, reason: &str) {
     }
 }
 
-/// Language-aware text merging (duplicated from `transcriber::api` to avoid
-/// cross-module coupling; kept intentionally minimal).
-fn merge_texts(texts: &[String], language: Option<&str>) -> String {
-    let sep = match language {
-        Some(lang) if lang.starts_with("zh") => "",
-        _ => " ",
-    };
-    texts
-        .iter()
-        .filter(|s| !s.is_empty())
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(sep)
-}
-
 fn collect_transcribed_texts(chunks: &[ChunkEntry]) -> Vec<String> {
     let mut ordered: Vec<&ChunkEntry> = chunks.iter().collect();
     ordered.sort_by_key(|e| e.index);
@@ -835,21 +820,4 @@ mod tests {
         assert!(!path.exists(), "panicking worker leaked chunk file");
     }
 
-    #[test]
-    fn test_merge_texts_zh() {
-        let texts = vec!["你好".to_string(), "世界".to_string()];
-        assert_eq!(merge_texts(&texts, Some("zh")), "你好世界");
-    }
-
-    #[test]
-    fn test_merge_texts_en() {
-        let texts = vec!["hello".to_string(), "world".to_string()];
-        assert_eq!(merge_texts(&texts, Some("en")), "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_empty_filtered() {
-        let texts = vec!["a".to_string(), "".to_string(), "b".to_string()];
-        assert_eq!(merge_texts(&texts, None), "a b");
-    }
 }

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -102,10 +102,15 @@ enum WorkerMsg {
     Chunk { index: usize, path: String },
 }
 
+/// Chunk store shared between the session and its workers. The condvar is
+/// signalled whenever a chunk reaches a terminal state so `stop_session` can
+/// wait for convergence without polling.
+type ChunkStore = Arc<(Mutex<Vec<ChunkEntry>>, Condvar)>;
+
 struct ActiveSessionInner {
     #[allow(dead_code)]
     mode: SessionMode,
-    chunks: Arc<Mutex<Vec<ChunkEntry>>>,
+    chunks: ChunkStore,
     chunk_tx: mpsc::SyncSender<WorkerMsg>,
     workers: Vec<thread::JoinHandle<()>>,
     next_index: usize,
@@ -153,7 +158,7 @@ impl SessionOrchestrator {
     /// worker will finish its current transcription and then exit cleanly when
     /// the channel is dropped).
     pub fn start_session(&self, mode: SessionMode) {
-        let chunks: Arc<Mutex<Vec<ChunkEntry>>> = Arc::new(Mutex::new(Vec::new()));
+        let chunks: ChunkStore = Arc::new((Mutex::new(Vec::new()), Condvar::new()));
         let (chunk_tx, chunk_rx) = mpsc::sync_channel::<WorkerMsg>(64);
 
         let shared_rx = Arc::new(Mutex::new(chunk_rx));
@@ -199,7 +204,7 @@ impl SessionOrchestrator {
         let index = session.next_index;
         session.next_index += 1;
 
-        session.chunks.lock().unwrap().push(ChunkEntry {
+        session.chunks.0.lock().unwrap().push(ChunkEntry {
             index,
             state: ChunkState::Flushed,
         });
@@ -213,10 +218,13 @@ impl SessionOrchestrator {
                 mpsc::TrySendError::Disconnected(_) => "worker channel closed",
             };
             error!(path = %path, error = message, "Failed to enqueue chunk; marking as failed");
-            let mut chunks = session.chunks.lock().unwrap();
-            if let Some(entry) = chunks.iter_mut().find(|e| e.index == index) {
-                entry.state = ChunkState::Failed(TranscribeError::Network(message.to_string()));
+            {
+                let mut chunks = session.chunks.0.lock().unwrap();
+                if let Some(entry) = chunks.iter_mut().find(|e| e.index == index) {
+                    entry.state = ChunkState::Failed(TranscribeError::Network(message.to_string()));
+                }
             }
+            session.chunks.1.notify_all();
             remove_chunk_file(&path, "rejected");
         } else {
             info!(index = index, path = %path, "Chunk enqueued for background transcription");
@@ -261,27 +269,33 @@ impl SessionOrchestrator {
         let deadline = Instant::now() + self.convergence_timeout;
         let mut timed_out = false;
 
-        loop {
-            let all_terminal = chunks.lock().unwrap().iter().all(|e| e.state.is_terminal());
-            if all_terminal {
-                break;
-            }
-            if Instant::now() >= deadline {
-                timed_out = true;
-                let mut locked = chunks.lock().unwrap();
-                let pending_count = locked.iter().filter(|e| !e.state.is_terminal()).count();
-                warn!(
-                    pending_count = pending_count,
-                    "Convergence timeout; marking pending chunks as Failed(Timeout)"
-                );
-                for entry in locked.iter_mut() {
-                    if !entry.state.is_terminal() {
-                        entry.state = ChunkState::Failed(TranscribeError::Timeout);
-                    }
+        {
+            let (lock, cvar) = &*chunks;
+            let mut locked = lock.lock().unwrap();
+            loop {
+                if locked.iter().all(|e| e.state.is_terminal()) {
+                    break;
                 }
-                break;
+                let now = Instant::now();
+                if now >= deadline {
+                    timed_out = true;
+                    let pending_count = locked.iter().filter(|e| !e.state.is_terminal()).count();
+                    warn!(
+                        pending_count = pending_count,
+                        "Convergence timeout; marking pending chunks as Failed(Timeout)"
+                    );
+                    for entry in locked.iter_mut() {
+                        if !entry.state.is_terminal() {
+                            entry.state = ChunkState::Failed(TranscribeError::Timeout);
+                        }
+                    }
+                    break;
+                }
+                // Woken by workers on every terminal state transition; the
+                // timeout bound also covers a worker dying without notifying.
+                let (guard, _) = cvar.wait_timeout(locked, deadline - now).unwrap();
+                locked = guard;
             }
-            thread::sleep(Duration::from_millis(100));
         }
 
         if !timed_out {
@@ -291,12 +305,12 @@ impl SessionOrchestrator {
             }
         } else {
             // Drop the handles without joining — workers may still be mid-request.
-            // They finish naturally; their Arc<Mutex<Vec<ChunkEntry>>> clones keep
-            // the data valid until each thread exits.
+            // They finish naturally; their ChunkStore clones keep the data valid
+            // until each thread exits.
             drop(session.workers);
         }
 
-        let locked = chunks.lock().unwrap();
+        let locked = chunks.0.lock().unwrap();
 
         if timed_out {
             let texts = collect_transcribed_texts(&locked);
@@ -318,7 +332,7 @@ impl SessionOrchestrator {
 
 fn worker_loop(
     rx: Arc<Mutex<mpsc::Receiver<WorkerMsg>>>,
-    chunks: Arc<Mutex<Vec<ChunkEntry>>>,
+    chunks: ChunkStore,
     transcriber: Arc<dyn Transcriber>,
 ) {
     loop {
@@ -330,7 +344,7 @@ fn worker_loop(
             Ok(WorkerMsg::Chunk { index, path }) => {
                 // Transition to Uploading.
                 {
-                    let mut locked = chunks.lock().unwrap();
+                    let mut locked = chunks.0.lock().unwrap();
                     if let Some(entry) = locked.iter_mut().find(|e| e.index == index)
                         && !begin_upload(entry)
                     {
@@ -351,11 +365,14 @@ fn worker_loop(
                 // Clean up the chunk file (ignore errors — file may already be gone).
                 remove_chunk_file(&path, "processed");
 
-                // Record outcome.
-                let mut locked = chunks.lock().unwrap();
-                if let Some(entry) = locked.iter_mut().find(|e| e.index == index) {
-                    record_worker_result(entry, result);
+                // Record outcome and wake the convergence waiter.
+                {
+                    let mut locked = chunks.0.lock().unwrap();
+                    if let Some(entry) = locked.iter_mut().find(|e| e.index == index) {
+                        record_worker_result(entry, result);
+                    }
                 }
+                chunks.1.notify_all();
             }
         }
     }
@@ -473,7 +490,6 @@ mod tests {
     use super::*;
     use crate::transcriber::MockTranscriber;
     use std::sync::Condvar;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn make_orchestrator_with_timeout(
         transcriber: Arc<dyn Transcriber>,
@@ -727,7 +743,7 @@ mod tests {
             "enqueueing blocked on a full worker queue"
         );
         let inner = orch.inner.lock().unwrap();
-        let chunks = inner.as_ref().unwrap().chunks.lock().unwrap();
+        let chunks = inner.as_ref().unwrap().chunks.0.lock().unwrap();
         assert!(chunks.iter().any(|entry| matches!(
             entry.state,
             ChunkState::Failed(TranscribeError::Network(ref message))

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -819,5 +819,4 @@ mod tests {
         assert!(matches!(result, Err(SessionError::PartialFailure { .. })));
         assert!(!path.exists(), "panicking worker leaked chunk file");
     }
-
 }

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -107,9 +107,15 @@ struct ActiveSessionInner {
     mode: SessionMode,
     chunks: Arc<Mutex<Vec<ChunkEntry>>>,
     chunk_tx: mpsc::SyncSender<WorkerMsg>,
-    worker: thread::JoinHandle<()>,
+    workers: Vec<thread::JoinHandle<()>>,
     next_index: usize,
 }
+
+/// Number of background transcription workers per session. Long recordings
+/// produce chunks faster than one upload round-trip completes; a few parallel
+/// uploads keep the convergence wait short while results are still merged in
+/// submission order via chunk indices.
+const WORKER_THREADS: usize = 3;
 
 // ─── SessionOrchestrator ──────────────────────────────────────────────────────
 
@@ -150,12 +156,15 @@ impl SessionOrchestrator {
         let chunks: Arc<Mutex<Vec<ChunkEntry>>> = Arc::new(Mutex::new(Vec::new()));
         let (chunk_tx, chunk_rx) = mpsc::sync_channel::<WorkerMsg>(64);
 
-        let worker_chunks = Arc::clone(&chunks);
-        let transcriber = Arc::clone(&self.transcriber);
-
-        let worker = thread::spawn(move || {
-            worker_loop(chunk_rx, worker_chunks, transcriber);
-        });
+        let shared_rx = Arc::new(Mutex::new(chunk_rx));
+        let workers = (0..WORKER_THREADS)
+            .map(|_| {
+                let rx = Arc::clone(&shared_rx);
+                let worker_chunks = Arc::clone(&chunks);
+                let transcriber = Arc::clone(&self.transcriber);
+                thread::spawn(move || worker_loop(rx, worker_chunks, transcriber))
+            })
+            .collect();
 
         let mut inner = self.inner.lock().unwrap();
         if inner.is_some() {
@@ -167,7 +176,7 @@ impl SessionOrchestrator {
             mode,
             chunks,
             chunk_tx,
-            worker,
+            workers,
             next_index: 0,
         });
 
@@ -235,9 +244,11 @@ impl SessionOrchestrator {
         };
 
         if session.next_index == 0 {
-            // Closing the channel lets the idle worker exit immediately.
+            // Closing the channel lets the idle workers exit immediately.
             drop(session.chunk_tx);
-            let _ = session.worker.join();
+            for worker in session.workers {
+                let _ = worker.join();
+            }
             return Err(SessionError::NoChunks);
         }
 
@@ -274,13 +285,15 @@ impl SessionOrchestrator {
         }
 
         if !timed_out {
-            // Worker should have processed Done and exited; join to clean up.
-            let _ = session.worker.join();
+            // Workers should have drained the queue and exited; join to clean up.
+            for worker in session.workers {
+                let _ = worker.join();
+            }
         } else {
-            // Drop the handle without joining — the worker may still be mid-request.
-            // It will finish naturally; its Arc<Mutex<Vec<ChunkEntry>>> clone keeps
-            // the data valid until the thread exits.
-            drop(session.worker);
+            // Drop the handles without joining — workers may still be mid-request.
+            // They finish naturally; their Arc<Mutex<Vec<ChunkEntry>>> clones keep
+            // the data valid until each thread exits.
+            drop(session.workers);
         }
 
         let locked = chunks.lock().unwrap();
@@ -304,13 +317,17 @@ impl SessionOrchestrator {
 // ─── Worker ───────────────────────────────────────────────────────────────────
 
 fn worker_loop(
-    rx: mpsc::Receiver<WorkerMsg>,
+    rx: Arc<Mutex<mpsc::Receiver<WorkerMsg>>>,
     chunks: Arc<Mutex<Vec<ChunkEntry>>>,
     transcriber: Arc<dyn Transcriber>,
 ) {
-    for msg in rx {
+    loop {
+        // Take the receiver lock only for the blocking recv itself; workers
+        // waiting on this mutex are exactly the idle ones.
+        let msg = rx.lock().unwrap().recv();
         match msg {
-            WorkerMsg::Chunk { index, path } => {
+            Err(_) => break,
+            Ok(WorkerMsg::Chunk { index, path }) => {
                 // Transition to Uploading.
                 {
                     let mut locked = chunks.lock().unwrap();
@@ -480,29 +497,30 @@ mod tests {
         }
     }
 
-    /// Returns pre-configured results in call order.
+    /// Returns pre-configured results keyed by chunk path. Path-keyed rather
+    /// than call-ordered because parallel workers pick up chunks in a
+    /// nondeterministic order.
     struct ScriptedTranscriber {
-        results: Vec<Result<String, TranscribeError>>,
-        call_count: AtomicUsize,
+        results: std::collections::HashMap<String, Result<String, TranscribeError>>,
     }
 
     impl ScriptedTranscriber {
-        fn new(results: Vec<Result<String, TranscribeError>>) -> Self {
+        fn new<const N: usize>(results: [(&str, Result<String, TranscribeError>); N]) -> Self {
             Self {
-                results,
-                call_count: AtomicUsize::new(0),
+                results: results
+                    .into_iter()
+                    .map(|(path, result)| (path.to_string(), result))
+                    .collect(),
             }
         }
     }
 
     impl Transcriber for ScriptedTranscriber {
-        fn transcribe(&self, _path: &str) -> Result<String, TranscribeError> {
-            let i = self.call_count.fetch_add(1, Ordering::SeqCst);
-            match self.results.get(i) {
-                Some(Ok(s)) => Ok(s.clone()),
-                Some(Err(e)) => Err(e.clone()),
-                None => Ok("extra".to_string()),
-            }
+        fn transcribe(&self, path: &str) -> Result<String, TranscribeError> {
+            self.results
+                .get(path)
+                .cloned()
+                .unwrap_or_else(|| Ok("extra".to_string()))
         }
     }
 
@@ -559,11 +577,10 @@ mod tests {
 
     #[test]
     fn test_multi_chunk_ordered_merge() {
-        // Three chunks whose transcriptions arrive in-order.
-        let t = Arc::new(ScriptedTranscriber::new(vec![
-            Ok("one".to_string()),
-            Ok("two".to_string()),
-            Ok("three".to_string()),
+        let t = Arc::new(ScriptedTranscriber::new([
+            ("c0.wav", Ok("one".to_string())),
+            ("c1.wav", Ok("two".to_string())),
+            ("c2.wav", Ok("three".to_string())),
         ]));
         let orch = default_orchestrator(t);
 
@@ -617,13 +634,16 @@ mod tests {
 
     #[test]
     fn test_partial_failure_returns_error_with_partial_text() {
-        let t = Arc::new(ScriptedTranscriber::new(vec![
-            Ok("good chunk".to_string()),
-            Err(TranscribeError::Api {
-                status: 500,
-                body: "server error".to_string(),
-            }),
-            Ok("another good".to_string()),
+        let t = Arc::new(ScriptedTranscriber::new([
+            ("c0.wav", Ok("good chunk".to_string())),
+            (
+                "c1.wav",
+                Err(TranscribeError::Api {
+                    status: 500,
+                    body: "server error".to_string(),
+                }),
+            ),
+            ("c2.wav", Ok("another good".to_string())),
         ]));
         let orch = default_orchestrator(t);
 

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -6,3 +6,4 @@ pub use installer::{
     install_requirements, model_weights_present, setup_venv, verify_install,
 };
 pub use service::LocalServiceManager;
+pub(crate) use service::find_server_file;

--- a/src/local/service.rs
+++ b/src/local/service.rs
@@ -65,11 +65,14 @@ impl LocalServiceManager {
     /// Spawns the local server process and waits for health.
     pub fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         self.cleanup_stale_pid_file();
+        // A server that is already running needs no spawn warm-up: probe it
+        // immediately and poll while it finishes loading. The 20s initial
+        // delay only makes sense for a freshly spawned process.
         if self.is_running()
             && health_check(
                 &self.base_url(),
                 HEALTH_TIMEOUT,
-                HEALTH_INITIAL_DELAY,
+                Duration::ZERO,
                 HEALTH_POLL_INTERVAL,
             )
             .is_ok()
@@ -611,6 +614,35 @@ mod tests {
                 "int8",
             ]
         );
+    }
+
+    #[test]
+    fn test_start_reuses_healthy_server_without_spawn_delay() {
+        let port = 18767;
+        spawn_health_stub(port, "HTTP/1.1 200 OK", "{\"status\":\"ok\"}");
+        let temp_dir =
+            std::env::temp_dir().join(format!("viberwhisper-local-reuse-{}", std::process::id()));
+        let model_dir = temp_dir.join("model");
+        fs::create_dir_all(&model_dir).unwrap();
+        // Point the pid file at this test process so is_running() is true.
+        fs::write(
+            temp_dir.join("local_server.pid"),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+
+        let mut manager = LocalServiceManager::new(port, model_dir, temp_dir.join("venv"));
+        let started = Instant::now();
+        let result = manager.start();
+
+        // The reuse path must succeed via the immediate health probe. If start()
+        // tried to spawn, it would fail (no venv python) — and the old code
+        // would have slept 20s before probing.
+        assert!(result.is_ok(), "{result:?}");
+        assert!(started.elapsed() < Duration::from_secs(5));
+
+        let _ = fs::remove_file(temp_dir.join("local_server.pid"));
+        let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/src/local/service.rs
+++ b/src/local/service.rs
@@ -105,14 +105,14 @@ impl LocalServiceManager {
         let child = match find_uv() {
             Some(uv) => {
                 let mut uv_command = Command::new(&uv);
-                uv_command.args(server_launch_args(
-                    &python,
-                    &script_path,
-                    &self.model_dir,
-                    self.port,
-                    &self.quantization,
-                ));
                 uv_command
+                    .args(server_launch_args(
+                        &python,
+                        &script_path,
+                        &self.model_dir,
+                        self.port,
+                        &self.quantization,
+                    ))
                     .stdin(Stdio::null())
                     .stdout(stdout_stdio)
                     .stderr(stderr_stdio);
@@ -121,43 +121,26 @@ impl LocalServiceManager {
                     Ok(child) => child,
                     Err(uv_error) => {
                         let (stdout, stderr) = self.log_stdio()?;
-                        let mut python_command = Command::new(&python);
-                        python_command
-                            .arg(&script_path)
-                            .arg("--model-dir")
-                            .arg(&self.model_dir)
-                            .arg("--port")
-                            .arg(self.port.to_string())
-                            .arg("--quantization")
-                            .arg(&self.quantization)
-                            .stdin(Stdio::null())
+                        self.python_launch_command(&python, &script_path)
                             .stdout(stdout)
-                            .stderr(stderr);
-                        python_command.spawn().map_err(|python_error| {
-                            format!(
-                                "failed to start local service with uv ({uv_error}) and direct python ({python_error})"
-                            )
-                        })?
+                            .stderr(stderr)
+                            .spawn()
+                            .map_err(|python_error| {
+                                format!(
+                                    "failed to start local service with uv ({uv_error}) and direct python ({python_error})"
+                                )
+                            })?
                     }
                 }
             }
-            None => {
-                let mut python_command = Command::new(&python);
-                python_command
-                    .arg(&script_path)
-                    .arg("--model-dir")
-                    .arg(&self.model_dir)
-                    .arg("--port")
-                    .arg(self.port.to_string())
-                    .arg("--quantization")
-                    .arg(&self.quantization)
-                    .stdin(Stdio::null())
-                    .stdout(stdout_stdio)
-                    .stderr(stderr_stdio);
-                python_command.spawn().map_err(|error| {
+            None => self
+                .python_launch_command(&python, &script_path)
+                .stdout(stdout_stdio)
+                .stderr(stderr_stdio)
+                .spawn()
+                .map_err(|error| {
                     format!("failed to start local service with direct python: {error}")
-                })?
-            }
+                })?,
         };
 
         fs::write(self.pid_file_path(), child.id().to_string()).map_err(|error| {
@@ -279,6 +262,21 @@ impl LocalServiceManager {
         find_server_file("server.py")
     }
 
+    /// Direct-python launch command, used when uv is unavailable or failed.
+    fn python_launch_command(&self, python: &Path, script_path: &Path) -> Command {
+        let mut command = Command::new(python);
+        command
+            .arg(script_path)
+            .arg("--model-dir")
+            .arg(&self.model_dir)
+            .arg("--port")
+            .arg(self.port.to_string())
+            .arg("--quantization")
+            .arg(&self.quantization)
+            .stdin(Stdio::null());
+        command
+    }
+
     fn read_pid(&self) -> Option<u32> {
         fs::read_to_string(self.pid_file_path())
             .ok()
@@ -328,7 +326,7 @@ impl LocalServiceManager {
 
 /// Locates a file inside the `server/` directory, trying the packaged location
 /// (next to the executable) first, then falling back to the development source tree.
-fn find_server_file(filename: &str) -> PathBuf {
+pub(crate) fn find_server_file(filename: &str) -> PathBuf {
     if let Ok(exe) = std::env::current_exe()
         && let Some(exe_dir) = exe.parent()
     {
@@ -605,6 +603,38 @@ mod tests {
                 "/tmp/venv/bin/python",
                 "--no-project",
                 "/tmp/venv/bin/python",
+                "/tmp/server.py",
+                "--model-dir",
+                "/tmp/model",
+                "--port",
+                "17265",
+                "--quantization",
+                "int8",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_python_launch_command_arguments() {
+        let manager = LocalServiceManager::with_quantization(
+            17265,
+            PathBuf::from("/tmp/model"),
+            PathBuf::from("/tmp/venv"),
+            "int8".to_string(),
+        );
+        let command = manager.python_launch_command(
+            Path::new("/tmp/venv/bin/python"),
+            Path::new("/tmp/server.py"),
+        );
+
+        assert_eq!(command.get_program(), "/tmp/venv/bin/python");
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
                 "/tmp/server.py",
                 "--model-dir",
                 "/tmp/model",

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,32 +487,7 @@ fn handle_config(action: ConfigAction) {
         ConfigAction::List => {
             println!("{:<25} Value", "Key");
             println!("{}", "-".repeat(60));
-            for key in &[
-                "api_key",
-                "transcription_api_url",
-                "model",
-                "hold_hotkey",
-                "toggle_hotkey",
-                "language",
-                "prompt",
-                "temperature",
-                "mic_gain",
-                "max_chunk_duration_secs",
-                "max_chunk_size_bytes",
-                "max_retries",
-                "convergence_timeout_secs",
-                "post_process_enabled",
-                "post_process_streaming_enabled",
-                "post_process_api_url",
-                "post_process_api_key",
-                "post_process_model",
-                "post_process_prompt",
-                "post_process_temperature",
-                "local_mode",
-                "local_data_dir",
-                "local_server_port",
-                "local_quantization",
-            ] {
+            for key in AppConfig::field_keys() {
                 let value = config
                     .get_field(key)
                     .unwrap_or_else(|| "(not set)".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,6 +236,25 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     run_listener_with_config(AppConfig::load())
 }
 
+/// Keep the raw STT text when post-processing yields nothing or fails —
+/// a cleanup step must never lose a successful transcription.
+fn resolve_post_processed_text(
+    result: Result<String, Box<dyn std::error::Error>>,
+    stt_text: String,
+) -> String {
+    match result {
+        Ok(processed) if !processed.is_empty() => processed,
+        Ok(_) => {
+            warn!("Post-processing returned empty text, using original STT text");
+            stt_text
+        }
+        Err(e) => {
+            warn!(error = %e, "Post-processing failed, using original STT text");
+            stt_text
+        }
+    }
+}
+
 fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     use audio::{AudioRecorder, StopResult};
     use core::orchestrator::{SessionError, SessionMode, SessionOrchestrator};
@@ -244,6 +263,7 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
     use input::tray::TrayManager;
     use input::typer::TextTyper;
     use postprocess::create_post_processor;
+    use std::cell::RefCell;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use transcriber::{Transcriber, create_transcriber};
@@ -295,10 +315,12 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let typer = input::typer::MockTyper;
 
-    let mut tray = TrayManager::new()?;
+    // RefCell so the start/stop closures below and the main loop can share
+    // the UI handles on this single thread.
+    let tray = RefCell::new(TrayManager::new()?);
     info!("System tray icon started");
 
-    let mut overlay = OverlayManager::new()?;
+    let overlay = RefCell::new(OverlayManager::new()?);
     info!("Floating overlay window started");
 
     println!(
@@ -338,19 +360,8 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
                 let text = {
                     let mut session = post_processor.start_session();
                     session.push_stable_chunk(&stt_text);
-                    match session.finish() {
-                        Ok(processed) if !processed.is_empty() => processed,
-                        Ok(_) => {
-                            // Empty post-process output is not useful; keep the STT text.
-                            warn!("Post-processing returned empty text, using original STT text");
-                            stt_text
-                        }
-                        Err(e) => {
-                            // Runtime LLM errors should not discard a successful STT result.
-                            warn!(error = %e, "Post-processing failed, using original STT text");
-                            stt_text
-                        }
-                    }
+                    let result = session.finish();
+                    resolve_post_processed_text(result, stt_text)
                 };
                 info!(text = %text, "Typing transcribed text");
                 if let Err(e) = typer.type_text(&text) {
@@ -391,66 +402,50 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
         }
     };
 
+    // Shared start/stop paths for the hold hotkey, toggle hotkey, and overlay
+    // click. UI state (tray + overlay) always tracks the recorder state.
+    let set_recording_ui = |on: bool| {
+        tray.borrow_mut().set_recording(on);
+        overlay.borrow_mut().set_recording(on);
+    };
+
+    let start_recording = |mode: SessionMode, trigger: &str| {
+        let mut rec = recorder.lock().unwrap();
+        match rec.start_recording() {
+            Ok(()) => {
+                orchestrator.start_session(mode);
+                info!(trigger = trigger, mode = ?mode, "Recording started");
+                set_recording_ui(true);
+            }
+            Err(e) => error!(error = %e, "Failed to start recording"),
+        }
+    };
+
+    let stop_recording = |trigger: &str| {
+        info!(trigger = trigger, "Stopping recording");
+        let stop_result = recorder.lock().unwrap().stop_recording();
+        set_recording_ui(false);
+        match stop_result {
+            Ok(result) => finalize(result),
+            Err(e) => error!(error = %e, "Failed to stop recording"),
+        }
+    };
+
     let mut counter = 0;
     loop {
         if let Some(event) = hotkey_manager.check_event() {
             match event {
                 HotkeyEvent::Pressed(HotkeySource::Hold) => {
-                    info!(hotkey = %config.hold_hotkey, "Hold key pressed, starting recording");
-                    let mut rec = recorder.lock().unwrap();
-                    match rec.start_recording() {
-                        Ok(()) => {
-                            orchestrator.start_session(SessionMode::Hold);
-                            info!("Recording started (hold mode)");
-                            tray.set_recording(true);
-                            overlay.set_recording(true);
-                        }
-                        Err(e) => error!(error = %e, "Failed to start recording"),
-                    }
+                    start_recording(SessionMode::Hold, "hold-press");
                 }
                 HotkeyEvent::Released(HotkeySource::Hold) => {
-                    info!(hotkey = %config.hold_hotkey, "Hold key released, stopping recording");
-                    let mut rec = recorder.lock().unwrap();
-                    match rec.stop_recording() {
-                        Ok(stop_result) => {
-                            tray.set_recording(false);
-                            overlay.set_recording(false);
-                            finalize(stop_result);
-                        }
-                        Err(e) => {
-                            error!(error = %e, "Failed to stop recording");
-                            tray.set_recording(false);
-                            overlay.set_recording(false);
-                        }
-                    }
+                    stop_recording("hold-release");
                 }
                 HotkeyEvent::Pressed(HotkeySource::Toggle) => {
-                    let mut rec = recorder.lock().unwrap();
-                    if rec.is_recording() {
-                        info!(hotkey = %config.toggle_hotkey, "Toggle key pressed, stopping recording");
-                        match rec.stop_recording() {
-                            Ok(stop_result) => {
-                                tray.set_recording(false);
-                                overlay.set_recording(false);
-                                finalize(stop_result);
-                            }
-                            Err(e) => {
-                                error!(error = %e, "Failed to stop recording");
-                                tray.set_recording(false);
-                                overlay.set_recording(false);
-                            }
-                        }
+                    if recorder.lock().unwrap().is_recording() {
+                        stop_recording("toggle-press");
                     } else {
-                        info!(hotkey = %config.toggle_hotkey, "Toggle key pressed, starting recording");
-                        match rec.start_recording() {
-                            Ok(()) => {
-                                orchestrator.start_session(SessionMode::Toggle);
-                                info!("Recording started (toggle mode)");
-                                tray.set_recording(true);
-                                overlay.set_recording(true);
-                            }
-                            Err(e) => error!(error = %e, "Failed to start recording"),
-                        }
+                        start_recording(SessionMode::Toggle, "toggle-press");
                     }
                 }
                 HotkeyEvent::Released(HotkeySource::Toggle) => {}
@@ -458,33 +453,11 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
         }
 
         // Check overlay click (acts like toggle hotkey)
-        if overlay.check_click() {
-            let mut rec = recorder.lock().unwrap();
-            if rec.is_recording() {
-                info!("Overlay clicked, stopping recording");
-                match rec.stop_recording() {
-                    Ok(stop_result) => {
-                        tray.set_recording(false);
-                        overlay.set_recording(false);
-                        finalize(stop_result);
-                    }
-                    Err(e) => {
-                        error!(error = %e, "Failed to stop recording");
-                        tray.set_recording(false);
-                        overlay.set_recording(false);
-                    }
-                }
+        if overlay.borrow_mut().check_click() {
+            if recorder.lock().unwrap().is_recording() {
+                stop_recording("overlay-click");
             } else {
-                info!("Overlay clicked, starting recording");
-                match rec.start_recording() {
-                    Ok(()) => {
-                        orchestrator.start_session(SessionMode::Toggle);
-                        info!("Recording started (overlay toggle)");
-                        tray.set_recording(true);
-                        overlay.set_recording(true);
-                    }
-                    Err(e) => error!(error = %e, "Failed to start recording"),
-                }
+                start_recording(SessionMode::Toggle, "overlay-click");
             }
         }
 
@@ -497,7 +470,7 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
             }
         }
 
-        if tray.check_exit() {
+        if tray.borrow().check_exit() {
             info!("User clicked exit from tray");
             break Ok(());
         }
@@ -517,7 +490,7 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
             );
         }
 
-        overlay.update();
+        overlay.borrow_mut().update();
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 }
@@ -614,19 +587,7 @@ fn handle_convert(input: &str, output: Option<&str>) {
 
     match transcriber.transcribe(input) {
         Ok(stt_text) => {
-            let text = match post_processor.process(&stt_text) {
-                Ok(processed) if !processed.is_empty() => processed,
-                Ok(_) => {
-                    // Empty post-process output is not useful; keep the STT text.
-                    warn!("Post-processing returned empty text, using original STT text");
-                    stt_text
-                }
-                Err(e) => {
-                    // Runtime LLM errors should not discard a successful STT result.
-                    warn!(error = %e, "Post-processing failed, using original STT text");
-                    stt_text
-                }
-            };
+            let text = resolve_post_processed_text(post_processor.process(&stt_text), stt_text);
             match output {
                 Some(path) => {
                     if let Err(e) = std::fs::write(path, &text) {
@@ -663,6 +624,24 @@ mod integration_tests {
     use crate::core::config::AppConfig;
     use audio::AudioRecorder;
     use transcriber::{MockTranscriber, Transcriber};
+
+    #[test]
+    fn test_resolve_post_processed_text_prefers_non_empty_result() {
+        let text = resolve_post_processed_text(Ok("cleaned".to_string()), "raw".to_string());
+        assert_eq!(text, "cleaned");
+    }
+
+    #[test]
+    fn test_resolve_post_processed_text_keeps_stt_on_empty_result() {
+        let text = resolve_post_processed_text(Ok(String::new()), "raw".to_string());
+        assert_eq!(text, "raw");
+    }
+
+    #[test]
+    fn test_resolve_post_processed_text_keeps_stt_on_error() {
+        let text = resolve_post_processed_text(Err("llm down".into()), "raw".to_string());
+        assert_eq!(text, "raw");
+    }
 
     #[test]
     fn test_audio_module_loads() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use core::cli::{Cli, Commands, ConfigAction, LocalCommand};
 use core::config::AppConfig;
 use local::{
     LocalServiceManager, PythonRuntime, dependencies_installed, detect_python_runtime,
-    download_model, install_requirements, model_weights_present, setup_venv, verify_install,
+    download_model, find_server_file, install_requirements, model_weights_present, setup_venv,
+    verify_install,
 };
 use std::path::PathBuf;
 use tracing::{debug, error, info, warn};
@@ -212,24 +213,6 @@ fn default_local_data_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
 
 fn local_requirements_path() -> PathBuf {
     find_server_file("requirements.txt")
-}
-
-/// Locates a file inside the `server/` directory, trying the packaged location
-/// (next to the executable) first, then falling back to the development source tree.
-fn find_server_file(filename: &str) -> PathBuf {
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(exe_dir) = exe.parent()
-    {
-        let candidate = exe_dir.join("server").join(filename);
-        if candidate.exists() {
-            return candidate;
-        }
-    }
-
-    // Fallback: compile-time source tree (works with `cargo run`).
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("server")
-        .join(filename)
 }
 
 fn run_listener() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,7 +1,35 @@
 use crate::input::typer::TextTyper;
-use tracing::info;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use tracing::{info, warn};
 
 pub struct MacTyper;
+
+/// Set the clipboard to `text` via `pbcopy` (no shell/AppleScript escaping needed).
+fn set_clipboard(text: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut child = Command::new("pbcopy").stdin(Stdio::piped()).spawn()?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or("pbcopy stdin unavailable")?
+        .write_all(text.as_bytes())?;
+    if !child.wait()?.success() {
+        return Err("pbcopy failed".into());
+    }
+    Ok(())
+}
+
+/// Read the current clipboard as text, best-effort. Returns `None` for an
+/// empty clipboard or non-text content (images etc. cannot be restored this
+/// way, so we deliberately do not touch them afterwards).
+fn read_clipboard_text() -> Option<String> {
+    let output = Command::new("pbpaste").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    if text.is_empty() { None } else { Some(text) }
+}
 
 impl TextTyper for MacTyper {
     fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -12,24 +40,42 @@ impl TextTyper for MacTyper {
         // Give the target window time to regain focus
         std::thread::sleep(std::time::Duration::from_millis(100));
 
-        // Use clipboard approach: set clipboard content then simulate Cmd+V paste
-        // This avoids keystroke length limits and special character issues
-        let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
-        let script = format!(
-            r#"set the clipboard to "{}"
-tell application "System Events" to keystroke "v" using command down"#,
-            escaped
-        );
+        // Clipboard-paste approach: avoids keystroke length limits and special
+        // character issues. The user's text clipboard is captured first and
+        // restored after the paste lands.
+        let previous_clipboard = read_clipboard_text();
+        set_clipboard(text)?;
 
-        let output = std::process::Command::new("osascript")
+        let output = Command::new("osascript")
             .arg("-e")
-            .arg(&script)
-            .output()?;
+            .arg(r#"tell application "System Events" to keystroke "v" using command down"#)
+            .output();
 
+        let restore = |reason: &str| {
+            if let Some(previous) = &previous_clipboard
+                && let Err(e) = set_clipboard(previous)
+            {
+                warn!(error = %e, reason, "Failed to restore previous clipboard");
+            }
+        };
+
+        let output = match output {
+            Ok(output) => output,
+            Err(e) => {
+                restore("paste command failed to run");
+                return Err(e.into());
+            }
+        };
         if !output.status.success() {
+            restore("paste command failed");
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(format!("osascript failed: {}", stderr).into());
         }
+
+        // Let the target app read the clipboard before putting the old
+        // content back.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        restore("after paste");
 
         info!(text = %text, "Text typed");
         Ok(())

--- a/src/postprocess/llm.rs
+++ b/src/postprocess/llm.rs
@@ -3,10 +3,16 @@ use crate::postprocess::{TextPostProcessor, TextPostProcessorSession};
 use reqwest::blocking::Client;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 const LLM_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Margin over the HTTP client timeout before `finish()` stops waiting for the
+/// background preheat thread and retries synchronously. The background request
+/// should always resolve within `LLM_REQUEST_TIMEOUT`; this bound protects
+/// against a panicked or wedged thread never signalling the condvar.
+const PREHEAT_WAIT_MARGIN: Duration = Duration::from_secs(10);
 
 const DEFAULT_PROMPT: &str = "请将下面的语音转写结果整理为适合直接发送的中文文本：\n\
     - 保留原意，不要扩写\n\
@@ -210,6 +216,7 @@ struct PreheatLlmSession {
     client: Client,
     chunks: Vec<String>,
     generation: u64,
+    finish_wait_timeout: Duration,
     state: Arc<(Mutex<PreheatState>, Condvar)>,
 }
 
@@ -231,6 +238,7 @@ impl PreheatLlmSession {
             client,
             chunks: Vec::new(),
             generation: 0,
+            finish_wait_timeout: LLM_REQUEST_TIMEOUT + PREHEAT_WAIT_MARGIN,
             state: Arc::new((
                 Mutex::new(PreheatState {
                     latest_generation: 0,
@@ -325,25 +333,48 @@ impl TextPostProcessorSession for PreheatLlmSession {
             );
         }
 
-        // Wait for the latest generation's result.
+        // Wait for the latest generation's result, but never forever: a wedged
+        // or panicked background thread must not hang the whole session.
         let (lock, cvar) = &*self.state;
         let mut st = lock.lock().unwrap();
+        let deadline = Instant::now() + self.finish_wait_timeout;
         while st.latest_result.is_none() {
-            st = cvar.wait(st).unwrap();
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            let (guard, _) = cvar.wait_timeout(st, deadline - now).unwrap();
+            st = guard;
         }
 
-        let result = st.latest_result.take().unwrap();
-        match result {
-            Ok(text) => {
+        match st.latest_result.take() {
+            Some(Ok(text)) => {
                 info!(
                     result_len = text.len(),
                     "Preheat: LLM post-processing complete"
                 );
                 Ok(text)
             }
-            Err(e) => {
+            Some(Err(e)) => {
                 // Preheat request failed — retry once with full text as fallback.
                 info!(error = %e, "Preheat: last request failed, retrying with full text");
+                drop(st);
+                call_llm_impl(
+                    &self.client,
+                    &self.api_key,
+                    &self.api_url,
+                    &self.model,
+                    &self.prompt,
+                    self.temperature,
+                    &combined,
+                )
+            }
+            None => {
+                // Timed out waiting for the background thread — fall back to a
+                // synchronous request with the full accumulated text.
+                info!(
+                    "Preheat: background request did not complete in time, retrying with full text"
+                );
                 drop(st);
                 call_llm_impl(
                     &self.client,
@@ -495,6 +526,36 @@ mod tests {
         let result = session.finish();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "");
+    }
+
+    #[test]
+    fn test_preheat_finish_does_not_hang_when_no_result_ever_arrives() {
+        // Simulate a fired request whose background thread never reports back
+        // (e.g. it panicked): generation > 0 but no thread will signal the
+        // condvar. finish() must give up after finish_wait_timeout and fall
+        // back to a synchronous call (which fails fast against localhost:1).
+        let mut session = PreheatLlmSession::new(
+            "key".to_string(),
+            "http://localhost:1/v1/chat/completions".to_string(),
+            "model".to_string(),
+            "prompt".to_string(),
+            0.0,
+            Client::builder()
+                .timeout(LLM_REQUEST_TIMEOUT)
+                .build()
+                .unwrap(),
+        );
+        session.chunks.push("hello".to_string());
+        session.generation = 1;
+        session.finish_wait_timeout = Duration::from_millis(100);
+
+        let started = Instant::now();
+        let result = session.finish();
+
+        // The synchronous fallback hits an unreachable port, so we expect Err,
+        // and crucially we expect to get here at all (no infinite wait).
+        assert!(result.is_err());
+        assert!(started.elapsed() < Duration::from_secs(10));
     }
 
     #[test]

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -1,6 +1,6 @@
 use crate::audio::split_wav;
 use crate::core::config::AppConfig;
-use crate::transcriber::TranscribeError;
+use crate::transcriber::{TranscribeError, merge_texts};
 use std::time::Duration;
 use tracing::{info, instrument, warn};
 
@@ -205,23 +205,6 @@ impl ApiTranscriber {
     }
 }
 
-/// Merge transcription results from multiple chunks.
-///
-/// Chinese text (zh, zh-CN, zh-TW) is concatenated without a separator.
-/// All other languages use a single space as separator.
-fn merge_texts(texts: &[String], language: Option<&str>) -> String {
-    let separator = match language {
-        Some(lang) if lang.starts_with("zh") => "",
-        _ => " ",
-    };
-    texts
-        .iter()
-        .filter(|t| !t.is_empty())
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(separator)
-}
-
 impl Transcriber for ApiTranscriber {
     #[instrument(name = "api_stt", skip(self), fields(path = %wav_path))]
     fn transcribe(&self, wav_path: &str) -> Result<String, TranscribeError> {
@@ -346,48 +329,6 @@ mod tests {
         assert_eq!(t.max_chunk_duration_secs, 60);
         assert_eq!(t.max_chunk_size_bytes, 10_000_000);
         assert_eq!(t.max_retries, 5);
-    }
-
-    #[test]
-    fn test_merge_texts_zh() {
-        let texts = vec!["你好".to_string(), "世界".to_string()];
-        let merged = merge_texts(&texts, Some("zh"));
-        assert_eq!(merged, "你好世界");
-    }
-
-    #[test]
-    fn test_merge_texts_zh_cn() {
-        let texts = vec!["你好".to_string(), "世界".to_string()];
-        let merged = merge_texts(&texts, Some("zh-CN"));
-        assert_eq!(merged, "你好世界");
-    }
-
-    #[test]
-    fn test_merge_texts_en() {
-        let texts = vec!["hello".to_string(), "world".to_string()];
-        let merged = merge_texts(&texts, Some("en"));
-        assert_eq!(merged, "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_no_language() {
-        let texts = vec!["hello".to_string(), "world".to_string()];
-        let merged = merge_texts(&texts, None);
-        assert_eq!(merged, "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_empty_segments_filtered() {
-        let texts = vec!["hello".to_string(), "".to_string(), "world".to_string()];
-        let merged = merge_texts(&texts, Some("en"));
-        assert_eq!(merged, "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_all_empty() {
-        let texts = vec!["".to_string(), "".to_string()];
-        let merged = merge_texts(&texts, Some("en"));
-        assert_eq!(merged, "");
     }
 
     #[test]

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -9,6 +9,9 @@ use tracing::{info, instrument, warn};
 /// the convergence timeout only stops the caller from waiting, not the worker.
 const STT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// Bounded concurrency for offline multi-chunk uploads (`convert` path).
+const PARALLEL_UPLOADS: usize = 3;
+
 pub trait Transcriber: Send + Sync {
     fn transcribe(&self, wav_path: &str) -> Result<String, TranscribeError>;
 }
@@ -241,10 +244,36 @@ impl Transcriber for ApiTranscriber {
         let total = chunks.len();
         info!(chunks = total, "Audio split into chunks for transcription");
 
+        // Upload chunks in parallel (bounded), then merge in chunk order.
+        let next = std::sync::atomic::AtomicUsize::new(0);
+        let results: Vec<std::sync::Mutex<Option<Result<String, TranscribeError>>>> =
+            (0..total).map(|_| std::sync::Mutex::new(None)).collect();
+
+        std::thread::scope(|scope| {
+            for _ in 0..PARALLEL_UPLOADS.min(total) {
+                scope.spawn(|| {
+                    loop {
+                        let i = next.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let Some(chunk) = chunks.get(i) else { break };
+                        let result =
+                            self.upload_file_with_retry(chunk.path_str(), chunk.index, total);
+                        *results[i].lock().unwrap() = Some(result);
+                    }
+                });
+            }
+        });
+
         let mut texts: Vec<String> = Vec::with_capacity(total);
-        for chunk in &chunks {
-            let text = self.upload_file_with_retry(chunk.path_str(), chunk.index, total)?;
-            texts.push(text);
+        for cell in results {
+            match cell.into_inner().unwrap() {
+                Some(Ok(text)) => texts.push(text),
+                Some(Err(e)) => return Err(e),
+                None => {
+                    return Err(TranscribeError::Network(
+                        "chunk upload did not complete".to_string(),
+                    ));
+                }
+            }
         }
 
         let result = merge_texts(&texts, self.language.as_deref());
@@ -477,6 +506,42 @@ mod tests {
         // Initial attempt + one retry.
         assert_eq!(requests.load(Ordering::SeqCst), 2);
         let _ = std::fs::remove_file(file);
+    }
+
+    #[test]
+    fn test_multi_chunk_transcription_uploads_all_chunks_and_merges_in_order() {
+        let (port, requests) = spawn_http_stub("HTTP/1.1 200 OK", "{\"text\":\"hi\"}");
+        let config = AppConfig {
+            api_key: Some("test_key".to_string()),
+            transcription_api_url: format!("http://127.0.0.1:{port}/v1/audio/transcriptions"),
+            max_chunk_duration_secs: 1,
+            language: None,
+            ..Default::default()
+        };
+        let t = ApiTranscriber::from_config(&config).unwrap();
+
+        // 3 seconds at 16 kHz split into 1-second chunks → 3 uploads.
+        let path = std::env::temp_dir().join(format!(
+            "viberwhisper-api-test-{}-multichunk.wav",
+            std::process::id()
+        ));
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).unwrap();
+        for i in 0..48_000 {
+            writer.write_sample((i % 100) as i16).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let result = t.transcribe(path.to_str().unwrap());
+
+        assert_eq!(result.unwrap(), "hi hi hi");
+        assert_eq!(requests.load(Ordering::SeqCst), 3);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src/transcriber/mod.rs
+++ b/src/transcriber/mod.rs
@@ -36,3 +36,48 @@ impl fmt::Display for TranscribeError {
 }
 
 impl std::error::Error for TranscribeError {}
+
+/// Merge transcription results from multiple chunks, in order.
+///
+/// Chinese text (zh, zh-CN, zh-TW) is concatenated without a separator.
+/// All other languages use a single space as separator. Empty fragments
+/// are dropped so a failed or silent chunk never produces double separators.
+pub fn merge_texts(texts: &[String], language: Option<&str>) -> String {
+    let separator = match language {
+        Some(lang) if lang.starts_with("zh") => "",
+        _ => " ",
+    };
+    texts
+        .iter()
+        .filter(|t| !t.is_empty())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_texts;
+
+    #[test]
+    fn test_merge_texts_zh_variants_concatenate_without_separator() {
+        let texts = vec!["你好".to_string(), "世界".to_string()];
+        assert_eq!(merge_texts(&texts, Some("zh")), "你好世界");
+        assert_eq!(merge_texts(&texts, Some("zh-CN")), "你好世界");
+        assert_eq!(merge_texts(&texts, Some("zh-TW")), "你好世界");
+    }
+
+    #[test]
+    fn test_merge_texts_other_languages_use_space() {
+        let texts = vec!["hello".to_string(), "world".to_string()];
+        assert_eq!(merge_texts(&texts, Some("en")), "hello world");
+        assert_eq!(merge_texts(&texts, None), "hello world");
+    }
+
+    #[test]
+    fn test_merge_texts_filters_empty_fragments() {
+        let texts = vec!["a".to_string(), String::new(), "b".to_string()];
+        assert_eq!(merge_texts(&texts, Some("en")), "a b");
+        assert_eq!(merge_texts(&[String::new(), String::new()], Some("en")), "");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining items from the codebase optimization review, one jj change per item. **Stacked on #68** (base branch is `fix/transcriber-timeout-and-errors`); merge #68 first, then retarget/merge this one.

### Correctness
- **ChunksOnly stop path** (`audio/recorder.rs`): when all audio was already flushed as live chunks, `stop_recording` returned `Err("No audio data recorded")`, so `finalize` never ran and the orchestrator session leaked with its results discarded. Now returns `StopResult::ChunksOnly`.
- **Local service reuse delay** (`local/service.rs`): reusing an already-running healthy server no longer sleeps the 20 s spawn warm-up before probing; the reuse path probes immediately.
- **Preheat `finish()` unbounded wait** (`postprocess/llm.rs`): condvar wait now has a deadline (client timeout + 10 s margin); on timeout it falls back to a synchronous full-text request instead of hanging forever if the background thread wedged.
- **cwd-independent paths**: config resolves to `./config.json` when present (dev/back-compat), otherwise `~/.config/viberwhisper/config.json` (`dirs::config_dir`); recordings/chunks moved from `./tmp` to the system temp dir. Apps launched from Finder/Explorer (cwd = `/`) now work.

### Performance
- **Lock-free audio capture** (`audio/recorder.rs`): the cpal callback now sends sample blocks over an mpsc channel instead of locking a shared `Mutex<Vec<i16>>` that the consumer held during multi-MB chunk copies.
- **16 kHz upload downsampling**: recordings are linearly resampled from device rate before writing upload WAVs (~3x smaller uploads; no-op when the device rate is ≤16 kHz).
- **Parallel transcription**: the orchestrator now runs 3 worker threads per session (results still merged by chunk index); the offline `convert` path uploads chunks with bounded (3) parallelism.
- **Condvar convergence wait**: `stop_session` waits on a condvar signalled at each terminal chunk transition instead of 100 ms polling. (The 10 ms main UI loop is intentionally kept — it drives overlay/tray on the main thread.)

### Deduplication / maintainability
- `main.rs`: recording start/stop extracted into shared closures (was copy-pasted 3×); post-process "empty/error → keep STT text" fallback extracted into `resolve_post_processed_text` and shared with `convert`.
- `merge_texts` unified in `transcriber/mod.rs`; `find_server_file` exported from `local` and reused by `main.rs`; the direct-python launch command in `local/service.rs` built in one place.
- `core/config.rs`: `get_field` / `set_field` / CLI `config list` now all derive from a single `FieldSpec` table — adding a config field is one table entry (plus `apply_json`, which keeps its lenient per-field load semantics). `config list` now also shows `provider`.
- **macOS clipboard restore** (`platform/macos.rs`): clipboard is set via `pbcopy` (no AppleScript escaping), and the user's previous text clipboard is captured and restored ~300 ms after the paste. Non-text clipboard content (images) can't be captured this way and is left untouched only in the sense that we skip restore; this remains best-effort.

Item #18 (HotkeyManager global state / dead code) needed no work — PR #66 already replaced the statics with a channel-based `EventMapper`; broader hotkey support stays with `docs/plan/13-full-hotkey-support.md`.

## Tests
- New tests: ChunksOnly/empty-recording stop paths, healthy-server fast reuse, preheat finish timeout, config path resolution, callback-channel drain, resampler properties + WAV spec check, multi-chunk parallel upload end-to-end (stub HTTP server), python launch command args, `resolve_post_processed_text`, shared `merge_texts`.
- `cargo test`: 158 passed. `cargo clippy --all-targets` clean, `cargo fmt` applied (hunks absorbed into their originating changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)