### PR TITLE
feat(postprocess): wire streaming preheat feed end-to-end

### DIFF
--- a/changelog
+++ b/changelog
@@ -25,3 +25,4 @@
 2026-07-08: Fix stop-time ChunksOnly reporting, reused local-service startup delay, preheat finish() unbounded wait, and cwd-dependent config/temp paths
 2026-07-08: Optimize audio pipeline: lock-free capture channel, 16 kHz upload downsampling, parallel chunk transcription workers, condvar-driven convergence wait
 2026-07-08: Deduplicate recording start/stop control, post-process fallback, merge_texts, server file lookup, and python launch command; table-driven config fields; restore macOS clipboard after paste-typing
+2026-07-08: Wire streaming post-process end-to-end: orchestrator take_stable_texts + SessionOutput remainder, main-loop PostFeed, preheat compatibility notes for the non-streaming chat API

--- a/docs/plan/08-llm-post-processing.md
+++ b/docs/plan/08-llm-post-processing.md
@@ -439,3 +439,11 @@ match LlmPostProcessor::from_config(config) {
    - 再补 README / `config.example.json` / architecture 文档
 
 这样 review 边界清楚，也避免再把“音频识别后端”和“文本后处理层”混成一锅。
+
+## 实现状态（2026-07-08 更新）
+
+Phase 1–3 已落地。此前 `run_listener` 是在 `stop_session()` 之后才创建后处理 session 并一次性推入全文，preheat 模式实际等价于 conservative 模式；现已补全"录音进行中增量接入"：
+
+- `SessionOrchestrator::take_stable_texts()`：按提交序交付已到达终态的稳定前缀文本，每段只交付一次；`stop_session` 返回 `SessionOutput { full_text, unconsumed_text }`，session 只需补齐未消费的余量。
+- `main.rs` 的 `PostFeed`：录音开始即创建后处理 session，主循环每个 tick 把新稳定的 chunk 文本（带语言相关分隔符）推给 session；结束时推余量并 `finish()`。
+- **流式调用的兼容性实现**：当前 chat-completions API 没有增量输入通道，`PreheatLlmSession` 的"流式"是每个稳定 chunk 到达时携带全部累计文本重新发起一次非流式请求，最新一代获胜、旧结果丢弃（见 `src/postprocess/llm.rs` 的 Compatibility note）。将来后端提供真正的增量接口时，只需替换该 session 实现，`TextPostProcessorSession` 契约与主循环喂料方式不变。

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -24,6 +24,18 @@ pub enum SessionMode {
     Toggle,
 }
 
+/// Successful result of `SessionOrchestrator::stop_session`.
+#[derive(Debug)]
+pub struct SessionOutput {
+    /// Language-aware merge of every transcribed chunk in the session.
+    pub full_text: String,
+    /// Merge of only the chunks that were never handed out through
+    /// `take_stable_texts`. Equals `full_text` when streaming consumption was
+    /// not used. An incremental post-process session that already received
+    /// the consumed prefix only needs this remainder before `finish()`.
+    pub unconsumed_text: String,
+}
+
 /// Error returned by `SessionOrchestrator::stop_session`.
 #[derive(Debug)]
 pub enum SessionError {
@@ -114,6 +126,8 @@ struct ActiveSessionInner {
     chunk_tx: mpsc::SyncSender<WorkerMsg>,
     workers: Vec<thread::JoinHandle<()>>,
     next_index: usize,
+    /// Index of the first chunk not yet handed out via `take_stable_texts`.
+    stable_consumed: usize,
 }
 
 /// Number of background transcription workers per session. Long recordings
@@ -183,6 +197,7 @@ impl SessionOrchestrator {
             chunk_tx,
             workers,
             next_index: 0,
+            stable_consumed: 0,
         });
 
         info!(mode = ?mode, "Session started");
@@ -233,15 +248,54 @@ impl SessionOrchestrator {
         Some(index)
     }
 
+    /// Hand out the texts of chunks that became "stable" since the last call:
+    /// the maximal prefix (in submission order) whose chunks have all reached
+    /// a terminal state. Each text is returned exactly once. Failed chunks
+    /// contribute no text but still advance the prefix, matching how
+    /// `stop_session` merges results.
+    ///
+    /// The main loop calls this while recording to feed the LLM post-process
+    /// preheat session (see `postprocess::llm` for the compatibility notes on
+    /// the non-streaming chat API). Returns an empty vec when no session is
+    /// active or nothing new is stable yet.
+    pub fn take_stable_texts(&self) -> Vec<String> {
+        let mut inner = self.inner.lock().unwrap();
+        let Some(session) = inner.as_mut() else {
+            return Vec::new();
+        };
+
+        let chunks = session.chunks.0.lock().unwrap();
+        let mut texts = Vec::new();
+        loop {
+            let next_index = session.stable_consumed;
+            let Some(entry) = chunks.iter().find(|e| e.index == next_index) else {
+                break;
+            };
+            match &entry.state {
+                ChunkState::Transcribed(text) => {
+                    if !text.is_empty() {
+                        texts.push(text.clone());
+                    }
+                }
+                ChunkState::Failed(_) => {}
+                // Prefix is not stable yet — stop here and retry next poll.
+                _ => break,
+            }
+            session.stable_consumed += 1;
+        }
+        texts
+    }
+
     /// Stop the current session and block until all chunks reach a terminal state
     /// (or `convergence_timeout` elapses).
     ///
     /// Returns:
-    /// - `Ok(text)` — all chunks succeeded; `text` is the language-aware merge.
+    /// - `Ok(SessionOutput)` — all chunks succeeded; carries the full merge and
+    ///   the not-yet-consumed remainder (see `SessionOutput`).
     /// - `Err(SessionError::NoChunks)` — recording produced no chunks.
     /// - `Err(SessionError::PartialFailure { … })` — some chunks failed; partial text included.
     /// - `Err(SessionError::ConvergenceTimeout { … })` — timeout hit; partial text included.
-    pub fn stop_session(&self) -> Result<String, SessionError> {
+    pub fn stop_session(&self) -> Result<SessionOutput, SessionError> {
         let active = {
             let mut inner = self.inner.lock().unwrap();
             inner.take()
@@ -266,6 +320,7 @@ impl SessionOrchestrator {
         drop(session.chunk_tx);
 
         let chunks = Arc::clone(&session.chunks);
+        let stable_consumed = session.stable_consumed;
         let deadline = Instant::now() + self.convergence_timeout;
         let mut timed_out = false;
 
@@ -324,7 +379,7 @@ impl SessionOrchestrator {
             });
         }
 
-        collect_results(&locked, self.language.as_deref())
+        collect_results(&locked, stable_consumed, self.language.as_deref())
     }
 }
 
@@ -437,16 +492,26 @@ fn collect_transcribed_texts(chunks: &[ChunkEntry]) -> Vec<String> {
         .collect()
 }
 
-fn collect_results(chunks: &[ChunkEntry], language: Option<&str>) -> Result<String, SessionError> {
+fn collect_results(
+    chunks: &[ChunkEntry],
+    stable_consumed: usize,
+    language: Option<&str>,
+) -> Result<SessionOutput, SessionError> {
     let mut ordered: Vec<&ChunkEntry> = chunks.iter().collect();
     ordered.sort_by_key(|e| e.index);
 
     let mut texts: Vec<String> = Vec::new();
+    let mut unconsumed: Vec<String> = Vec::new();
     let mut errors: Vec<(usize, TranscribeError)> = Vec::new();
 
     for entry in ordered {
         match &entry.state {
-            ChunkState::Transcribed(t) => texts.push(t.clone()),
+            ChunkState::Transcribed(t) => {
+                texts.push(t.clone());
+                if entry.index >= stable_consumed {
+                    unconsumed.push(t.clone());
+                }
+            }
             ChunkState::Failed(e) => errors.push((entry.index, e.clone())),
             _ => {
                 // Should not happen after convergence completes.
@@ -459,7 +524,10 @@ fn collect_results(chunks: &[ChunkEntry], language: Option<&str>) -> Result<Stri
     }
 
     if errors.is_empty() {
-        Ok(merge_texts(&texts, language))
+        Ok(SessionOutput {
+            full_text: merge_texts(&texts, language),
+            unconsumed_text: merge_texts(&unconsumed, language),
+        })
     } else {
         Err(SessionError::PartialFailure {
             errors,
@@ -573,7 +641,7 @@ mod tests {
         let result = orch.stop_session();
 
         assert!(result.is_ok(), "Expected Ok, got {:?}", result);
-        assert_eq!(result.unwrap(), "hello world");
+        assert_eq!(result.unwrap().full_text, "hello world");
     }
 
     #[test]
@@ -593,7 +661,92 @@ mod tests {
 
         assert!(result.is_ok());
         // Chunks must be joined in submission order, not completion order.
-        assert_eq!(result.unwrap(), "one two three");
+        let output = result.unwrap();
+        assert_eq!(output.full_text, "one two three");
+        // take_stable_texts was never called, so nothing was consumed.
+        assert_eq!(output.unconsumed_text, "one two three");
+    }
+
+    #[test]
+    fn test_take_stable_texts_streams_prefix_in_order_once() {
+        let t = Arc::new(ScriptedTranscriber::new([
+            ("c0.wav", Ok("one".to_string())),
+            ("c1.wav", Ok("two".to_string())),
+        ]));
+        let orch = default_orchestrator(t);
+
+        orch.start_session(SessionMode::Hold);
+        orch.on_chunk_ready("c0.wav".to_string());
+        orch.on_chunk_ready("c1.wav".to_string());
+
+        // Workers run in the background; poll until both chunks are stable.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut collected: Vec<String> = Vec::new();
+        while collected.len() < 2 && Instant::now() < deadline {
+            collected.extend(orch.take_stable_texts());
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert_eq!(collected, vec!["one".to_string(), "two".to_string()]);
+        // Consumed texts are handed out exactly once.
+        assert!(orch.take_stable_texts().is_empty());
+
+        let output = orch.stop_session().unwrap();
+        assert_eq!(output.full_text, "one two");
+        assert_eq!(output.unconsumed_text, "");
+    }
+
+    #[test]
+    fn test_take_stable_texts_waits_for_prefix_completion() {
+        // c0 is gated; c1 completes immediately. Nothing may be handed out
+        // until c0 lands, because the merge order must match submission order.
+        struct PrefixGateTranscriber {
+            release: Arc<(Mutex<bool>, Condvar)>,
+        }
+        impl Transcriber for PrefixGateTranscriber {
+            fn transcribe(&self, path: &str) -> Result<String, TranscribeError> {
+                if path == "c0.wav" {
+                    let (lock, condvar) = &*self.release;
+                    let mut released = lock.lock().unwrap();
+                    while !*released {
+                        released = condvar.wait(released).unwrap();
+                    }
+                    Ok("first".to_string())
+                } else {
+                    Ok("second".to_string())
+                }
+            }
+        }
+
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let t = Arc::new(PrefixGateTranscriber {
+            release: Arc::clone(&release),
+        });
+        let orch = default_orchestrator(t);
+
+        orch.start_session(SessionMode::Hold);
+        orch.on_chunk_ready("c0.wav".to_string());
+        orch.on_chunk_ready("c1.wav".to_string());
+
+        // Give c1 time to finish; the prefix is still blocked on c0.
+        thread::sleep(Duration::from_millis(200));
+        assert!(orch.take_stable_texts().is_empty());
+
+        let (lock, condvar) = &*release;
+        *lock.lock().unwrap() = true;
+        condvar.notify_all();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut collected: Vec<String> = Vec::new();
+        while collected.len() < 2 && Instant::now() < deadline {
+            collected.extend(orch.take_stable_texts());
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        assert_eq!(collected, vec!["first".to_string(), "second".to_string()]);
+        let output = orch.stop_session().unwrap();
+        assert_eq!(output.full_text, "first second");
+        assert_eq!(output.unconsumed_text, "");
     }
 
     #[test]
@@ -755,7 +908,7 @@ mod tests {
             let result = orch.stop_session();
 
             assert!(result.is_ok(), "Mode {:?} failed: {:?}", mode, result);
-            assert_eq!(result.unwrap(), "text");
+            assert_eq!(result.unwrap().full_text, "text");
         }
     }
 
@@ -776,7 +929,7 @@ mod tests {
 
         // Only the new session's chunk should appear.
         assert!(result.is_ok(), "{:?}", result);
-        assert_eq!(result.unwrap(), "new session");
+        assert_eq!(result.unwrap().full_text, "new session");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,49 @@ fn resolve_post_processed_text(
     }
 }
 
+/// Feeds stable STT text fragments to a post-process session.
+///
+/// Sessions concatenate pushed fragments verbatim, so this feeder owns the
+/// language-appropriate separator and prepends it to every fragment after the
+/// first. Opened when recording starts; while the recording continues, stable
+/// chunk texts are pushed as they arrive so a preheat LLM session already has
+/// the cleanup request in flight by the time the user stops.
+struct PostFeed {
+    session: Box<dyn postprocess::TextPostProcessorSession>,
+    separator: &'static str,
+    pushed_any: bool,
+}
+
+impl PostFeed {
+    fn new(
+        session: Box<dyn postprocess::TextPostProcessorSession>,
+        separator: &'static str,
+    ) -> Self {
+        Self {
+            session,
+            separator,
+            pushed_any: false,
+        }
+    }
+
+    fn push(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if self.pushed_any && !self.separator.is_empty() {
+            self.session
+                .push_stable_chunk(&format!("{}{}", self.separator, text));
+        } else {
+            self.session.push_stable_chunk(text);
+        }
+        self.pushed_any = true;
+    }
+
+    fn finish(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        self.session.finish()
+    }
+}
+
 fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error::Error>> {
     use audio::{AudioRecorder, StopResult};
     use core::orchestrator::{SessionError, SessionMode, SessionOrchestrator};
@@ -317,6 +360,14 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
     println!("Press Ctrl+C to exit.");
     println!();
 
+    // Streaming post-process feed: opened at recording start, fed stable
+    // chunk texts while recording, and finished in `finalize`. With the
+    // preheat session this keeps the cleanup request warm during recording;
+    // with the conservative/noop sessions it simply accumulates.
+    let stream_separator = transcriber::merge_separator(config.language.as_deref());
+    let post_feed: RefCell<Option<PostFeed>> = RefCell::new(None);
+    let new_post_feed = || PostFeed::new(post_processor.start_session(), stream_separator);
+
     // Finalize a stopped recording: submit the tail chunk (if any) to the orchestrator,
     // then wait for convergence and type (or log) the result.
     let finalize = |stop_result: StopResult| {
@@ -334,18 +385,20 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
             }
         }
 
+        // The feed (if any) already received the stable prefix during
+        // recording; on success only the unconsumed remainder is pushed.
+        // On failure it is discarded — the raw partial text is typed as-is.
+        let feed = post_feed.borrow_mut().take();
+
         match orchestrator.stop_session() {
-            Ok(stt_text) => {
-                if stt_text.is_empty() {
+            Ok(output) => {
+                if output.full_text.is_empty() {
                     info!("Transcription returned empty text");
                     return;
                 }
-                let text = {
-                    let mut session = post_processor.start_session();
-                    session.push_stable_chunk(&stt_text);
-                    let result = session.finish();
-                    resolve_post_processed_text(result, stt_text)
-                };
+                let mut feed = feed.unwrap_or_else(&new_post_feed);
+                feed.push(&output.unconsumed_text);
+                let text = resolve_post_processed_text(feed.finish(), output.full_text);
                 info!(text = %text, "Typing transcribed text");
                 if let Err(e) = typer.type_text(&text) {
                     error!(error = %e, "Failed to type text");
@@ -397,6 +450,7 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
         match rec.start_recording() {
             Ok(()) => {
                 orchestrator.start_session(mode);
+                *post_feed.borrow_mut() = Some(new_post_feed());
                 info!(trigger = trigger, mode = ?mode, "Recording started");
                 set_recording_ui(true);
             }
@@ -450,6 +504,23 @@ fn run_listener_with_config(config: AppConfig) -> Result<(), Box<dyn std::error:
             if let Some(path) = chunk_path {
                 info!(path = %path, "Ready chunk detected, forwarding to orchestrator");
                 orchestrator.on_chunk_ready(path);
+            }
+        }
+
+        // Feed newly stable chunk texts to the post-process session so a
+        // preheat LLM request is already in flight before recording stops.
+        {
+            let stable_texts = orchestrator.take_stable_texts();
+            if !stable_texts.is_empty()
+                && let Some(feed) = post_feed.borrow_mut().as_mut()
+            {
+                for text in &stable_texts {
+                    debug!(
+                        text_len = text.len(),
+                        "Feeding stable chunk text to post-processor"
+                    );
+                    feed.push(text);
+                }
             }
         }
 
@@ -602,6 +673,27 @@ mod integration_tests {
     }
 
     #[test]
+    fn test_post_feed_inserts_separator_between_fragments() {
+        use postprocess::{NoopPostProcessor, TextPostProcessor};
+
+        let mut feed = PostFeed::new(NoopPostProcessor.start_session(), " ");
+        feed.push("hello");
+        feed.push("");
+        feed.push("world");
+        assert_eq!(feed.finish().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_post_feed_zh_concatenates_without_separator() {
+        use postprocess::{NoopPostProcessor, TextPostProcessor};
+
+        let mut feed = PostFeed::new(NoopPostProcessor.start_session(), "");
+        feed.push("你好");
+        feed.push("世界");
+        assert_eq!(feed.finish().unwrap(), "你好世界");
+    }
+
+    #[test]
     fn test_audio_module_loads() {
         let audio_result = AudioRecorder::new(1.0);
         assert!(audio_result.is_ok());
@@ -631,7 +723,7 @@ mod integration_tests {
         let result = orch.stop_session();
 
         assert!(result.is_ok(), "Expected Ok, got {:?}", result);
-        assert!(!result.unwrap().is_empty());
+        assert!(!result.unwrap().full_text.is_empty());
     }
 
     #[test]

--- a/src/postprocess/llm.rs
+++ b/src/postprocess/llm.rs
@@ -197,6 +197,18 @@ impl TextPostProcessorSession for ConservativeLlmSession {
 
 // ---------------------------------------------------------------------------
 // Preheat session (streaming_enabled = true): fire LLM on every chunk arrival.
+//
+// Compatibility note: the chat-completions endpoint is a whole-request /
+// whole-response API — there is no incremental input channel to append text
+// to. "Streaming" therefore means: every time a stable chunk arrives, fire a
+// fresh request carrying ALL accumulated text and let the newest generation
+// win; results of superseded generations are silently dropped. This trades
+// redundant tokens for latency: by the time the user stops recording, the
+// request covering (most of) the session text is already in flight, so
+// `finish()` usually only waits for that last round-trip instead of starting
+// from zero. If the backend ever exposes a true incremental interface, only
+// this session type needs replacing — the `TextPostProcessorSession` contract
+// and the main-loop feeding stay the same.
 // ---------------------------------------------------------------------------
 
 /// Shared state between the session and its background LLM threads.

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -15,8 +15,13 @@ pub trait TextPostProcessor: Send + Sync {
 
 /// Incremental post-processing session.
 ///
-/// Stable STT text chunks are pushed via `push_stable_chunk`; `finish` returns the
-/// final processed text once the recording session is complete.
+/// Stable STT text chunks are pushed via `push_stable_chunk` while the
+/// recording is still running; `finish` returns the final processed text once
+/// the recording session is complete.
+///
+/// Fragments are concatenated verbatim — the caller includes any inter-chunk
+/// separators in the pushed text (see `PostFeed` in `main.rs`), so sessions
+/// never have to guess about language-specific spacing.
 pub trait TextPostProcessorSession: Send {
     fn push_stable_chunk(&mut self, text: &str);
     fn finish(&mut self) -> Result<String, Box<dyn std::error::Error>>;

--- a/src/transcriber/mod.rs
+++ b/src/transcriber/mod.rs
@@ -37,16 +37,23 @@ impl fmt::Display for TranscribeError {
 
 impl std::error::Error for TranscribeError {}
 
-/// Merge transcription results from multiple chunks, in order.
+/// Separator inserted between merged chunk texts for a given language.
 ///
-/// Chinese text (zh, zh-CN, zh-TW) is concatenated without a separator.
-/// All other languages use a single space as separator. Empty fragments
-/// are dropped so a failed or silent chunk never produces double separators.
-pub fn merge_texts(texts: &[String], language: Option<&str>) -> String {
-    let separator = match language {
+/// Chinese text (zh, zh-CN, zh-TW) is concatenated without a separator;
+/// all other languages use a single space.
+pub fn merge_separator(language: Option<&str>) -> &'static str {
+    match language {
         Some(lang) if lang.starts_with("zh") => "",
         _ => " ",
-    };
+    }
+}
+
+/// Merge transcription results from multiple chunks, in order.
+///
+/// Empty fragments are dropped so a failed or silent chunk never produces
+/// double separators.
+pub fn merge_texts(texts: &[String], language: Option<&str>) -> String {
+    let separator = merge_separator(language);
     texts
         .iter()
         .filter(|t| !t.is_empty())


### PR DESCRIPTION
## Summary

Closes the gap where `post_process_streaming_enabled` had no real effect: the post-process session used to be created only after `stop_session()` returned and fed the full text once, making preheat mode equivalent to conservative mode. **Stacked on #69** (base branch `fix/codebase-optimizations`).

### Orchestrator (`core/orchestrator.rs`)
- New `take_stable_texts()`: hands out, exactly once and in submission order, the texts of the maximal chunk prefix that has reached a terminal state. Failed chunks contribute no text but advance the prefix (matching merge semantics).
- `stop_session()` now returns `SessionOutput { full_text, unconsumed_text }` — the full merge plus the remainder never handed out via `take_stable_texts` (equal to `full_text` when streaming was unused). Error variants and partial-text behavior are unchanged.

### Main loop (`main.rs`)
- New `PostFeed`: opens a post-process session when recording starts, owns the language-appropriate separator (sessions concatenate fragments verbatim), and is fed newly stable chunk texts every loop tick.
- `finalize` pushes only `unconsumed_text` before `finish()`; on session errors the feed is discarded and raw partial text is typed as before. Empty/failed post-process output still falls back to the raw STT text.
- With conservative/noop sessions the feed simply accumulates — one unified path.

### Compatibility implementation for the non-streaming LLM API
The chat-completions endpoint has no incremental input channel, so "streaming" in `PreheatLlmSession` means: each stable chunk fires a fresh request carrying all accumulated text; the newest generation wins and stale responses are dropped. By stop time the request covering (most of) the session is already in flight, so `finish()` usually waits one round-trip at most. Documented in a new compatibility note in `postprocess/llm.rs` and in the `TextPostProcessorSession` trait docs; if a true incremental interface appears, only that session type needs replacing.

Also extracted `transcriber::merge_separator` so the merge and the feeder share one separator rule, and updated `docs/plan/08-llm-post-processing.md` with the implementation status.

## Tests
- `take_stable_texts` streams the prefix in order and only once; withholds everything while an earlier chunk is still pending even if later chunks finished (gated-transcriber test); `stop_session` reports the correct `unconsumed_text` in both consumed and non-consumed scenarios.
- `PostFeed` separator behavior for spaced and zh (no-separator) languages.
- `cargo test`: 162 passed; clippy clean; fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)