### PR TITLE
docs: keep plan and implementation in one PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ jj new                                    # Start a fresh child change after fin
 jj bookmark set feat/my-change -r @       # Point a bookmark at the current change
 jj git fetch --remote origin              # Sync remote refs before push
 jj git push --remote origin --bookmark feat/my-change  # Push the bookmark to GitHub
+gh pr create --draft --base master --head feat/my-change  # Open the plan PR
+gh pr ready <pr-number>                   # Mark the same PR ready after implementation
 ```
 
 ### Packaging Commands
@@ -125,13 +127,18 @@ When implementing any feature, **strictly follow this order**:
 
 1. Read the feature documentation in `./docs/plan/` directory (if exists)
 2. Write an implementation plan (design doc with tech choices, file structure, implementation steps)
-3. **Submit a PR with the plan only** — push the review bookmark/branch and notify the user to review
-4. **Wait for user approval** before writing any code
-5. Implement the feature according to the approved plan
-6. Append code changes to the same review PR/bookmark flow (do NOT create a separate PR)
-7. Update the corresponding feature doc and `changelog` to reflect the actual implementation
+3. Push the plan-only change through a named `jj` bookmark and open a **draft PR**
+4. Keep that PR open and ask the user to review the plan; plan approval is given through review/comment and **must not merge or close the PR**
+5. **Wait for explicit user approval of the plan** before writing tests or implementation code
+6. Implement the feature with tests first, following the approved plan
+7. Push the implementation, updated feature doc, and `changelog` to the **same bookmark**, which updates the existing PR
+8. Mark the PR ready for final review only after implementation and validation are complete
+9. Merge only after the completed implementation has passed final review
 
-**Never skip the plan review step.** The user must approve the plan before any code is written.
+**One feature uses one bookmark and one PR from plan through implementation.** Never merge
+the plan-only PR, never create a second implementation PR, and never skip the plan review
+step. The user must explicitly approve the plan before any tests or implementation code are
+written.
 
 ### 2. Test-Driven Development (TDD)
 
@@ -184,13 +191,20 @@ Recommended flow from local edits to pushing a review branch:
    - Push with `jj git push --remote origin --bookmark <bookmark-name>`
    - This creates or updates the corresponding remote branch for GitHub PRs
    - If push safety checks fail, fetch again first with `jj git fetch --remote origin`
+   - For feature work, create a draft PR after pushing the plan-only state, for example with `gh pr create --draft --base master --head <bookmark-name>`
+   - Keep the draft PR open after plan approval; approval is a signal to continue implementation, not to merge
+   - Push the implementation to the same bookmark so GitHub updates the same PR
 
 7. **Continue iteration without losing history**
    - Keep making edits in `@`, then update the description if needed
+   - Move the existing bookmark to the latest change with `jj bookmark set <bookmark-name> -r @`, especially after creating child changes with `jj new`
    - Re-push the same bookmark with `jj git push --remote origin --bookmark <bookmark-name>`
+   - Do not create a second bookmark or PR for implementation after the plan is approved
+   - Mark the existing draft PR ready with `gh pr ready <pr-number>` only when implementation, documentation, changelog, and validation are complete
    - When one change is finished and a new one should start, run `jj new` to create the next working change
 
 8. **After merge or when syncing with upstream**
+   - Merge the PR only after final implementation review, never at the plan-only stage
    - Fetch again with `jj git fetch --remote origin`
    - Move local work onto the new base if needed before continuing
    - Keep bookmarks aligned with the active review change; do not accumulate stale review bookmarks unnecessarily


### PR DESCRIPTION
## Summary
- open a draft PR for the plan-only stage
- keep the same bookmark and PR through implementation
- move the existing bookmark to the latest Jujutsu change before each implementation push
- mark the PR ready only after implementation and validation

## Validation
- git diff --check -- AGENTS.md
- confirmed AGENTS.md contains no references to .agents or local skill scripts