### PR TITLE
refactor: share transcription text merging

### DIFF
--- a/changelog
+++ b/changelog
@@ -25,3 +25,4 @@
 2026-07-11: Remove the floating overlay; add debounced tray click recording control, an input-independent recording state machine, strict SessionId routing, session-scoped audio paths, and state-aware shutdown cleanup
 2026-07-11: Stop idle-loop chunk polling after recorder shutdown by clearing stop-time readiness bookkeeping and requiring an active session
 2026-07-27: Make transcription chunk state session-owned; workers now return lifecycle events through per-session channels and retain only temporary-file cleanup responsibility after session shutdown
+2026-07-31: Share language-aware transcription text merging across offline chunk uploads and session orchestration

--- a/docs/architecture/transcriber.md
+++ b/docs/architecture/transcriber.md
@@ -7,10 +7,12 @@ Converts a WAV file path to a transcribed text string. The module defines a trai
 ## Module Layout
 
 ```
-src/transcriber/
-  mod.rs      — re-exports all public symbols
-  api.rs      — Transcriber trait + ApiTranscriber + MockTranscriber
-  factory.rs  — create_transcriber factory function
+src/
+  text.rs         — shared language-aware transcription text merging
+  transcriber/
+    mod.rs        — re-exports all public symbols
+    api.rs        — Transcriber trait + ApiTranscriber + MockTranscriber
+    factory.rs    — create_transcriber factory function
 ```
 
 ## `Transcriber` Trait (`src/transcriber/api.rs`)
@@ -90,7 +92,8 @@ Each chunk upload retries on transient failures:
 
 ### Language-Aware Text Merging
 
-`merge_texts(texts, language)` joins transcribed chunks:
+`crate::text::merge_texts(texts, language)` is shared by `ApiTranscriber` and
+`SessionOrchestrator` when joining transcribed chunks:
 
 - **Chinese** (`zh`, `zh-cn`, etc.): Joins without separator (Chinese text doesn't use spaces between words).
 - **Other languages**: Joins with a single space.

--- a/docs/plan/06-end-to-end-stream-recognition.md
+++ b/docs/plan/06-end-to-end-stream-recognition.md
@@ -13,7 +13,7 @@ PR #26（`05-long-audio-streaming.md`）已落地以下底层能力：
 | WAV 离线分片（`split_wav`） | `src/audio/splitter.rs` |
 | Toggle 录音达阈值封片落盘 | `src/audio/recorder.rs` |
 | 单片指数退避重试 | `src/transcriber/api.rs` |
-| 多语言文本合并（`merge_texts`） | `src/transcriber/api.rs` |
+| 多语言文本合并（`merge_texts`） | `src/text.rs` |
 | 三个分片配置项 | `src/core/config.rs` |
 
 然而，**会话（session）级的统一调度层**尚未建立：分片的生成、上传队列、结果收集、错误传播等逻辑散布在 `recorder.rs` 与 `api.rs` 中，Hold 与 Toggle 两种模式也没有共享统一的会话生命周期模型。
@@ -307,7 +307,8 @@ impl SessionOrchestrator {
 | `src/main.rs` | **修改** | `run_listener` 持有 `SessionOrchestrator`；热键事件映射到 `start_session` / `stop_session`；移除原有内联分片转写逻辑 |
 | `src/core/config.rs` | **修改** | 新增 `convergence_timeout_secs: u64`（默认 30），更新 `get_field`/`set_field`/`apply_json` |
 | `src/transcriber/mod.rs` | **不变** | `Transcriber` trait 签名不变 |
-| `src/transcriber/api.rs` | **不变** | `transcribe_chunk_with_retry`、`merge_texts` 不变；orchestrator 直接调用 |
+| `src/text.rs` | **后续新增** | 集中提供 crate 内共享的 `merge_texts` |
+| `src/transcriber/api.rs` | **后续修改** | 保留分片转录与重试，改为调用共享 `merge_texts` |
 | `docs/architecture/core.md` | **修改** | 补充 `SessionOrchestrator` 及其与 recorder / transcriber 的协作关系 |
 
 ## 配置项
@@ -444,6 +445,10 @@ pub convergence_timeout_secs: u64,
 **验收**：`cargo test` 全绿；PR review 通过。
 
 ## 后续扩展方向
+
+共享文本合并后续重构将 `merge_texts` 移至 `src/text.rs`，离线分片转录和
+`SessionOrchestrator` 均通过 crate 内接口复用同一实现；该调整不改变本计划的
+session 生命周期和错误语义。
 
 - **增量式实时字幕**：orchestrator 在每个分片 `Transcribed` 时立即通过回调通知 UI，而非等待收敛。当前接口预留了 `on_chunk_transcribed` 扩展点位置。
 - **失败分片重传**：收敛后对 `PartialFailure` 中的失败分片可选择性重试，无需重录。

--- a/docs/plan/17-shared-text-merge.md
+++ b/docs/plan/17-shared-text-merge.md
@@ -1,0 +1,123 @@
+# 共享转录文本合并工具
+
+## 状态
+
+**已实现。**
+
+`merge_texts` 已集中到 `src/text.rs`，离线 WAV 分片转录与 session orchestrator
+复用同一实现。一条代表性测试验证非中文片段使用空格连接。
+
+## 背景
+
+目前有两条分块转录路径需要把按顺序产生的文本片段合并为最终文本：
+
+- `src/transcriber/api.rs` 的离线 WAV 分片转录路径。
+- `src/core/orchestrator.rs` 的录音 session 收敛、部分失败和超时路径。
+
+两个模块分别定义了私有的 `merge_texts`。两份实现只有局部变量名不同，行为相同，测试也有重复。未来修改语言分隔规则时，可能只更新其中一处，导致两条转录路径产生不同结果。
+
+## 目标
+
+1. 在 `src/text.rs` 中提供唯一的转录文本合并实现。
+2. 让离线分片转录和 session orchestrator 复用该实现。
+3. 集中维护合并规则的单元测试。
+4. 保持现有输出、错误处理和模块公开 API 不变。
+
+## 非目标
+
+- 不改变中文或其他语言的分隔规则。
+- 不增加片段去空白、标点修复、语言标准化或大小写标准化。
+- 不改变分片顺序、转录请求、重试、收敛超时或部分失败语义。
+- 不把该函数公开为 crate 外部 API。
+- 不在本次重构中引入通用 `util` 模块或新的依赖。
+
+## 设计
+
+在 crate 根模块声明新的私有模块：
+
+```rust
+mod text;
+```
+
+`src/text.rs` 提供 crate 内共享函数：
+
+```rust
+pub(crate) fn merge_texts(texts: &[String], language: Option<&str>) -> String;
+```
+
+函数保持当前规则：
+
+1. `language` 为 `Some(lang)` 且 `lang.starts_with("zh")` 时，不插入分隔符。
+2. 其他语言以及 `None` 使用单个空格分隔。
+3. 合并前过滤 `String::is_empty()` 为真的片段。
+4. 保持输入片段原始顺序。
+
+这意味着判断继续区分大小写；例如 `zh-CN` 使用空分隔符，而 `ZH-CN` 仍使用空格。只包含空白的字符串不视为空片段。本次重构不修正或扩展这些既有语义。
+
+调用方统一使用：
+
+```rust
+use crate::text::merge_texts;
+```
+
+`src/transcriber/api.rs` 和 `src/core/orchestrator.rs` 中的本地实现将被删除。共享函数维持 `pub(crate)` 可见性，避免形成不必要的外部接口。
+
+## 文件改动
+
+| 文件 | 计划变更 |
+|---|---|
+| `src/main.rs` | 声明 `mod text;` |
+| `src/text.rs` | 新增共享 `merge_texts` 及集中单元测试 |
+| `src/transcriber/api.rs` | 导入共享函数，删除本地实现和重复的纯函数测试 |
+| `src/core/orchestrator.rs` | 导入共享函数，删除本地实现和重复的纯函数测试 |
+| `docs/architecture/transcriber.md` | 将语言感知合并逻辑的位置更新为 `src/text.rs` |
+| `docs/plan/06-end-to-end-stream-recognition.md` | 记录 orchestrator 复用共享文本模块的后续调整 |
+| `docs/plan/17-shared-text-merge.md` | 实现完成后更新状态和实际差异 |
+| `changelog` | 记录合并逻辑去重 |
+
+## TDD 实施顺序
+
+计划批准后严格按以下顺序实施：
+
+### Phase 1：共享模块测试
+
+先创建 `src/text.rs` 并编写一条单元测试，验证非中文片段以一个空格连接。
+
+此时先运行目标测试并确认因为共享实现尚未完成而失败，再实现函数使测试通过。
+
+### Phase 2：迁移调用方
+
+1. 在 `src/main.rs` 注册 `text` 模块。
+2. 将两个调用方改为导入共享函数。
+3. 删除两个本地 `merge_texts` 实现及重复的纯函数测试。
+4. 运行 transcriber 和 orchestrator 的现有测试，确认两条业务路径行为不变。
+
+### Phase 3：文档与验证
+
+1. 更新架构文档、相关既有计划文档、本计划状态和 `changelog`。
+2. 运行 `cargo fmt --check`。
+3. 运行 `cargo check`。
+4. 运行 `cargo test`。
+5. 检查最终 `jj diff`，将实现推送到本计划使用的同一个 bookmark 和 draft PR。
+
+## 实际实现说明
+
+- 首先添加 `src/text.rs` 的规则测试并运行目标测试，确认因共享函数尚不存在而编译失败。
+- 实现 crate 内可见的 `merge_texts` 后，将两个调用方迁移到共享函数。
+- 保留一条非中文空格连接测试，避免为这个小型辅助函数维护重复用例。
+- 删除 `api.rs` 与 `orchestrator.rs` 中重复的函数定义和纯函数测试。
+
+## 验收标准
+
+- [x] crate 中只存在一个 `merge_texts` 函数定义。
+- [x] 离线 WAV 分片路径使用 `crate::text::merge_texts`。
+- [x] session 正常完成、部分失败和超时路径使用同一个共享函数。
+- [x] 现有语言分隔、空字符串过滤和顺序语义保持不变。
+- [x] 共享函数仅在 crate 内可见。
+- [x] 合并规则测试集中在 `src/text.rs`。
+- [x] `cargo fmt --check`、`cargo check` 和 `cargo test` 全部通过。
+- [x] 架构文档、计划状态和 `changelog` 与实现一致。
+
+## 风险与回滚
+
+本次变更不修改业务算法，主要风险是遗漏某个调用点或模块声明。编译检查和两条路径的现有测试可以覆盖这些问题。若迁移导致回归，可在同一 PR 中恢复调用方的本地实现；不涉及配置、数据格式或持久化迁移。

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -16,6 +16,7 @@ use crate::audio::remove_temp_audio_file;
 
 use crate::core::recording_session::SessionId;
 pub use crate::core::recording_session::SessionMode;
+use crate::text::merge_texts;
 use crate::transcriber::Transcriber;
 // Re-exported so callers can keep using `core::orchestrator::TranscribeError`.
 pub use crate::transcriber::TranscribeError;
@@ -536,21 +537,6 @@ fn remove_chunk_file(path: &str, reason: &str) {
     if let Err(e) = remove_temp_audio_file(path) {
         debug!(path, reason, error = %e, "Could not delete chunk file");
     }
-}
-
-/// Language-aware text merging (duplicated from `transcriber::api` to avoid
-/// cross-module coupling; kept intentionally minimal).
-fn merge_texts(texts: &[String], language: Option<&str>) -> String {
-    let sep = match language {
-        Some(lang) if lang.starts_with("zh") => "",
-        _ => " ",
-    };
-    texts
-        .iter()
-        .filter(|s| !s.is_empty())
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(sep)
 }
 
 fn collect_transcribed_texts(chunks: &[ChunkEntry]) -> Vec<String> {
@@ -1217,23 +1203,5 @@ mod tests {
 
         assert!(matches!(result, Err(SessionError::PartialFailure { .. })));
         assert!(!path.exists(), "panicking worker leaked chunk file");
-    }
-
-    #[test]
-    fn test_merge_texts_zh() {
-        let texts = vec!["你好".to_string(), "世界".to_string()];
-        assert_eq!(merge_texts(&texts, Some("zh")), "你好世界");
-    }
-
-    #[test]
-    fn test_merge_texts_en() {
-        let texts = vec!["hello".to_string(), "world".to_string()];
-        assert_eq!(merge_texts(&texts, Some("en")), "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_empty_filtered() {
-        let texts = vec!["a".to_string(), "".to_string(), "b".to_string()];
-        assert_eq!(merge_texts(&texts, None), "a b");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod input;
 mod local;
 mod platform;
 mod postprocess;
+mod text;
 mod transcriber;
 
 use clap::Parser;

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,29 @@
+/// Merge ordered transcription segments with a language-aware separator.
+///
+/// Chinese languages are joined without a separator. All other languages use
+/// a single space. Empty segments are ignored.
+pub(crate) fn merge_texts(texts: &[String], language: Option<&str>) -> String {
+    let separator = match language {
+        Some(lang) if lang.starts_with("zh") => "",
+        _ => " ",
+    };
+
+    texts
+        .iter()
+        .filter(|text| !text.is_empty())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_texts;
+
+    #[test]
+    fn merges_non_chinese_segments_with_spaces() {
+        let segments = vec!["hello".to_string(), "world".to_string()];
+
+        assert_eq!(merge_texts(&segments, Some("en")), "hello world");
+    }
+}

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -1,5 +1,6 @@
 use crate::audio::split_wav;
 use crate::core::config::AppConfig;
+use crate::text::merge_texts;
 use crate::transcriber::TranscribeError;
 use std::time::Duration;
 use tracing::{info, instrument, warn};
@@ -202,23 +203,6 @@ impl ApiTranscriber {
     }
 }
 
-/// Merge transcription results from multiple chunks.
-///
-/// Chinese text (zh, zh-CN, zh-TW) is concatenated without a separator.
-/// All other languages use a single space as separator.
-fn merge_texts(texts: &[String], language: Option<&str>) -> String {
-    let separator = match language {
-        Some(lang) if lang.starts_with("zh") => "",
-        _ => " ",
-    };
-    texts
-        .iter()
-        .filter(|t| !t.is_empty())
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(separator)
-}
-
 impl Transcriber for ApiTranscriber {
     #[instrument(name = "api_stt", skip(self), fields(path = %wav_path))]
     fn transcribe(&self, wav_path: &str) -> Result<String, TranscribeError> {
@@ -317,48 +301,6 @@ mod tests {
         assert_eq!(t.max_chunk_duration_secs, 60);
         assert_eq!(t.max_chunk_size_bytes, 10_000_000);
         assert_eq!(t.max_retries, 5);
-    }
-
-    #[test]
-    fn test_merge_texts_zh() {
-        let texts = vec!["你好".to_string(), "世界".to_string()];
-        let merged = merge_texts(&texts, Some("zh"));
-        assert_eq!(merged, "你好世界");
-    }
-
-    #[test]
-    fn test_merge_texts_zh_cn() {
-        let texts = vec!["你好".to_string(), "世界".to_string()];
-        let merged = merge_texts(&texts, Some("zh-CN"));
-        assert_eq!(merged, "你好世界");
-    }
-
-    #[test]
-    fn test_merge_texts_en() {
-        let texts = vec!["hello".to_string(), "world".to_string()];
-        let merged = merge_texts(&texts, Some("en"));
-        assert_eq!(merged, "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_no_language() {
-        let texts = vec!["hello".to_string(), "world".to_string()];
-        let merged = merge_texts(&texts, None);
-        assert_eq!(merged, "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_empty_segments_filtered() {
-        let texts = vec!["hello".to_string(), "".to_string(), "world".to_string()];
-        let merged = merge_texts(&texts, Some("en"));
-        assert_eq!(merged, "hello world");
-    }
-
-    #[test]
-    fn test_merge_texts_all_empty() {
-        let texts = vec!["".to_string(), "".to_string()];
-        let merged = merge_texts(&texts, Some("en"));
-        assert_eq!(merged, "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- extract duplicated language-aware merge_texts logic into src/text.rs
- reuse the crate-private helper from offline WAV transcription and session orchestration
- replace duplicated merge tests with one representative non-Chinese spacing test
- update architecture documentation, implementation plan, and changelog

## Validation

- cargo fmt --check
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test: 162 passed

## Review

Independent bookmark review found no production regression. It reported one advisory test-coverage reduction because Chinese and empty-segment branches are intentionally not retained in the single-case test.