### PR TITLE
refactor: remove genuinely unused code

### DIFF
--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -11,7 +11,7 @@ The config package intentionally has four files:
 | File | Responsibility |
 |---|---|
 | `document.rs` | `ConfigDocument`, nested v2 serde schema, and defaults |
-| `fields.rs` | one canonical `ConfigKey`/`FieldSpec` catalog used by list/get/set |
+| `fields.rs` | one canonical `ConfigKey` catalog used by list/get/set |
 | `store.rs` | platform path discovery plus fail-closed load and atomic save |
 | `mod.rs` | facade, config errors, validation report, secret-safe value types |
 

--- a/docs/plan/18-config-architecture-refactor.md
+++ b/docs/plan/18-config-architecture-refactor.md
@@ -87,7 +87,7 @@ ConfigStore ── read/write ── ConfigDocument
 src/core/config/
   mod.rs       — public facade、共享错误与必要的安全 value types
   document.rs  — v2 serde schema、默认值和 ConfigDocument
-  fields.rs    — ConfigKey / FieldSpec、list/get/set
+  fields.rs    — ConfigKey catalog、list/get/set
   store.rs     — 追加 canonical 文件名、load/save 和原子发布
 src/runtime_config.rs
                — target/profile 选择、业务校验调用、问题汇总和顶层运行配置
@@ -230,13 +230,11 @@ v2 使用嵌套配置表达用户可理解的配置分组，并以必填的 `sch
 
 ## 字段目录与 CLI
 
-`fields.rs` 定义唯一的 `ConfigKey` / `FieldSpec` catalog。每个字段记录：
+`fields.rs` 定义唯一的 `ConfigKey` catalog。每个字段记录：
 
 - canonical dotted key；
-- value kind；
-- optional、secret、writable 属性；
-- 受影响的业务 owner，仅用于 `config set` 后选择校验函数；
-- getter/setter。
+- writable 属性；
+- getter/setter 分派。
 
 `schema_version` 进入 catalog，但固定为 read-only metadata。使用一个小型 declarative macro 生成 key、lookup、
 list/get/set 分派；持久化 struct 保持普通 Rust 定义，并用 schema-leaf 与 catalog coverage test 防止漂移。

--- a/src/core/config/fields.rs
+++ b/src/core/config/fields.rs
@@ -2,25 +2,11 @@ use std::fmt;
 
 use super::{ConfigDocument, InferenceProfile, SecretSource};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValueKind {
-    Version,
-    String,
-    Float,
-    U16,
-    U32,
-    U64,
-    Bool,
-    Profile,
-}
-
 macro_rules! define_config_fields {
     ($(
         $variant:ident => {
             name: $name:literal,
-            kind: $kind:ident,
-            writable: $writable:literal,
-            secret: $secret:literal
+            writable: $writable:literal
         }
     ),+ $(,)?) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -49,52 +35,39 @@ macro_rules! define_config_fields {
             }
         }
 
-        const FIELD_SPECS: &[FieldSpec] = &[
-            $(FieldSpec {
-                key: ConfigKey::$variant,
-                kind: ValueKind::$kind,
-                writable: $writable,
-                secret: $secret,
-            }),+
+        const CONFIG_KEYS: &[ConfigKey] = &[
+            $(ConfigKey::$variant),+
         ];
     };
 }
 
 define_config_fields! {
-    SchemaVersion => { name: "schema_version", kind: Version, writable: false, secret: false },
-    InputHoldHotkey => { name: "input.hold_hotkey", kind: String, writable: true, secret: false },
-    InputToggleHotkey => { name: "input.toggle_hotkey", kind: String, writable: true, secret: false },
-    AudioMicGain => { name: "audio.mic_gain", kind: Float, writable: true, secret: false },
-    ChunkingMaxDurationSecs => { name: "chunking.max_duration_secs", kind: U32, writable: true, secret: false },
-    ChunkingMaxSizeBytes => { name: "chunking.max_size_bytes", kind: U64, writable: true, secret: false },
-    ChunkingMaxRetries => { name: "chunking.max_retries", kind: U32, writable: true, secret: false },
-    SessionConvergenceTimeoutSecs => { name: "session.convergence_timeout_secs", kind: U64, writable: true, secret: false },
-    TranscriptionLanguage => { name: "transcription.language", kind: String, writable: true, secret: false },
-    TranscriptionPrompt => { name: "transcription.prompt", kind: String, writable: true, secret: false },
-    TranscriptionTemperature => { name: "transcription.temperature", kind: Float, writable: true, secret: false },
-    PostProcessEnabled => { name: "post_process.enabled", kind: Bool, writable: true, secret: false },
-    PostProcessPreheatEnabled => { name: "post_process.preheat_enabled", kind: Bool, writable: true, secret: false },
-    PostProcessPrompt => { name: "post_process.prompt", kind: String, writable: true, secret: false },
-    PostProcessTemperature => { name: "post_process.temperature", kind: Float, writable: true, secret: false },
-    InferenceActive => { name: "inference.active", kind: Profile, writable: true, secret: false },
-    ApiProvider => { name: "inference.api.provider", kind: String, writable: true, secret: false },
-    ApiTranscriptionUrl => { name: "inference.api.transcription.api_url", kind: String, writable: true, secret: false },
-    ApiTranscriptionModel => { name: "inference.api.transcription.model", kind: String, writable: true, secret: false },
-    ApiTranscriptionKey => { name: "inference.api.transcription.api_key", kind: String, writable: false, secret: true },
-    ApiPostProcessUrl => { name: "inference.api.post_process.api_url", kind: String, writable: true, secret: false },
-    ApiPostProcessModel => { name: "inference.api.post_process.model", kind: String, writable: true, secret: false },
-    ApiPostProcessKey => { name: "inference.api.post_process.api_key", kind: String, writable: false, secret: true },
-    LocalDataDir => { name: "inference.local.data_dir", kind: String, writable: true, secret: false },
-    LocalServerPort => { name: "inference.local.server_port", kind: U16, writable: true, secret: false },
-    LocalQuantization => { name: "inference.local.quantization", kind: String, writable: true, secret: false },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FieldSpec {
-    pub key: ConfigKey,
-    pub kind: ValueKind,
-    pub writable: bool,
-    pub secret: bool,
+    SchemaVersion => { name: "schema_version", writable: false },
+    InputHoldHotkey => { name: "input.hold_hotkey", writable: true },
+    InputToggleHotkey => { name: "input.toggle_hotkey", writable: true },
+    AudioMicGain => { name: "audio.mic_gain", writable: true },
+    ChunkingMaxDurationSecs => { name: "chunking.max_duration_secs", writable: true },
+    ChunkingMaxSizeBytes => { name: "chunking.max_size_bytes", writable: true },
+    ChunkingMaxRetries => { name: "chunking.max_retries", writable: true },
+    SessionConvergenceTimeoutSecs => { name: "session.convergence_timeout_secs", writable: true },
+    TranscriptionLanguage => { name: "transcription.language", writable: true },
+    TranscriptionPrompt => { name: "transcription.prompt", writable: true },
+    TranscriptionTemperature => { name: "transcription.temperature", writable: true },
+    PostProcessEnabled => { name: "post_process.enabled", writable: true },
+    PostProcessPreheatEnabled => { name: "post_process.preheat_enabled", writable: true },
+    PostProcessPrompt => { name: "post_process.prompt", writable: true },
+    PostProcessTemperature => { name: "post_process.temperature", writable: true },
+    InferenceActive => { name: "inference.active", writable: true },
+    ApiProvider => { name: "inference.api.provider", writable: true },
+    ApiTranscriptionUrl => { name: "inference.api.transcription.api_url", writable: true },
+    ApiTranscriptionModel => { name: "inference.api.transcription.model", writable: true },
+    ApiTranscriptionKey => { name: "inference.api.transcription.api_key", writable: false },
+    ApiPostProcessUrl => { name: "inference.api.post_process.api_url", writable: true },
+    ApiPostProcessModel => { name: "inference.api.post_process.model", writable: true },
+    ApiPostProcessKey => { name: "inference.api.post_process.api_key", writable: false },
+    LocalDataDir => { name: "inference.local.data_dir", writable: true },
+    LocalServerPort => { name: "inference.local.server_port", writable: true },
+    LocalQuantization => { name: "inference.local.quantization", writable: true },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -155,8 +128,8 @@ impl fmt::Display for FieldError {
 impl std::error::Error for FieldError {}
 
 impl ConfigDocument {
-    pub fn field_specs() -> &'static [FieldSpec] {
-        FIELD_SPECS
+    pub fn field_keys() -> &'static [ConfigKey] {
+        CONFIG_KEYS
     }
 
     pub fn get_field(

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -10,8 +10,9 @@ pub(crate) use document::{
     AudioSection, ChunkingSection, InferenceProfile, InputSection, LocalSection,
     PostProcessSection, SessionSection, TranscriptionSection,
 };
-#[allow(unused_imports)]
-pub use fields::{ConfigKey, FieldError, FieldSpec, FieldValue, SecretStatus, ValueKind};
+pub use fields::ConfigKey;
+#[cfg(test)]
+use fields::{FieldError, FieldValue, SecretStatus};
 pub use store::ConfigStore;
 
 #[derive(Debug)]
@@ -217,9 +218,9 @@ mod tests {
 
     #[test]
     fn field_catalog_uses_canonical_keys_and_rejects_legacy_aliases() {
-        let keys: Vec<_> = ConfigDocument::field_specs()
+        let keys: Vec<_> = ConfigDocument::field_keys()
             .iter()
-            .map(|spec| spec.key.as_str())
+            .map(|key| key.as_str())
             .collect();
         assert!(keys.contains(&"input.hold_hotkey"));
         assert!(keys.contains(&"inference.api.transcription.api_url"));
@@ -230,8 +231,8 @@ mod tests {
 
         let document = ConfigDocument::default();
         let secrets = MapSecrets(HashMap::new());
-        for spec in ConfigDocument::field_specs() {
-            document.get_field(spec.key.as_str(), &secrets).unwrap();
+        for key in ConfigDocument::field_keys() {
+            document.get_field(key.as_str(), &secrets).unwrap();
         }
     }
 

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -152,12 +152,7 @@ enum ChunkState {
     /// Written to disk; not yet picked up by the worker.
     Flushed,
     /// Worker is transcribing this chunk.
-    /// `attempt` is reserved for future orchestrator-level retry logic;
-    /// retry is not yet implemented — on failure the chunk transitions directly to `Failed`.
-    Uploading {
-        #[allow(dead_code)]
-        attempt: u32,
-    },
+    Uploading,
     /// Successfully transcribed.
     Transcribed(String),
     /// Transcription failed (all retries exhausted, or timeout).
@@ -191,8 +186,6 @@ enum WorkerEvent {
 
 struct ActiveSessionInner {
     session_id: SessionId,
-    #[allow(dead_code)]
-    mode: SessionMode,
     chunks: Vec<ChunkEntry>,
     chunk_tx: mpsc::SyncSender<WorkerMsg>,
     result_rx: mpsc::Receiver<WorkerEvent>,
@@ -260,7 +253,6 @@ impl SessionOrchestrator {
 
         *inner = Some(ActiveSessionInner {
             session_id,
-            mode,
             chunks: Vec::new(),
             chunk_tx,
             result_rx,
@@ -557,7 +549,7 @@ fn begin_upload(entry: &mut ChunkEntry) -> bool {
         );
         return false;
     }
-    entry.state = ChunkState::Uploading { attempt: 1 };
+    entry.state = ChunkState::Uploading;
     true
 }
 
@@ -761,10 +753,7 @@ mod tests {
         }];
 
         apply_worker_event(&mut chunks, WorkerEvent::UploadStarted { index: 3 });
-        assert!(matches!(
-            chunks[0].state,
-            ChunkState::Uploading { attempt: 1 }
-        ));
+        assert!(matches!(chunks[0].state, ChunkState::Uploading));
 
         apply_worker_event(
             &mut chunks,

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -15,7 +15,6 @@ pub(crate) const MODEL_NAME: &str = "gemma-4-E2B-it";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct LocalPaths {
-    data_dir: PathBuf,
     pub(crate) venv_dir: PathBuf,
     pub(crate) model_dir: PathBuf,
 }
@@ -50,7 +49,6 @@ impl LocalPaths {
         Ok(Self {
             venv_dir: data_dir.join("venv"),
             model_dir: data_dir.join("model"),
-            data_dir,
         })
     }
 }
@@ -151,8 +149,12 @@ mod config_tests {
         )
         .unwrap();
         assert_eq!(
-            paths.data_dir,
-            Path::new("/config/viberwhisper/models/local")
+            paths.venv_dir,
+            Path::new("/config/viberwhisper/models/local/venv")
+        );
+        assert_eq!(
+            paths.model_dir,
+            Path::new("/config/viberwhisper/models/local/model")
         );
 
         let home = LocalSection {
@@ -165,6 +167,13 @@ mod config_tests {
             Path::new("/home/test"),
         )
         .unwrap();
-        assert_eq!(paths.data_dir, Path::new("/home/test/.custom-viberwhisper"));
+        assert_eq!(
+            paths.venv_dir,
+            Path::new("/home/test/.custom-viberwhisper/venv")
+        );
+        assert_eq!(
+            paths.model_dir,
+            Path::new("/home/test/.custom-viberwhisper/model")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,9 +583,9 @@ fn handle_config(action: ConfigAction) -> Result<(), Box<dyn std::error::Error>>
         ConfigAction::List => {
             println!("{:<48} Value", "Key");
             println!("{}", "-".repeat(80));
-            for spec in ConfigDocument::field_specs() {
-                let value = document.get_field(spec.key.as_str(), &secrets)?;
-                println!("{:<48} {}", spec.key.as_str(), value);
+            for key in ConfigDocument::field_keys() {
+                let value = document.get_field(key.as_str(), &secrets)?;
+                println!("{:<48} {}", key.as_str(), value);
             }
         }
         ConfigAction::Get { key } => {


### PR DESCRIPTION
## Summary

- remove the unused `FieldSpec` / `ValueKind` config metadata layer and iterate the canonical `ConfigKey` catalog directly
- remove unused orchestrator upload-attempt and session-mode state
- remove the unused `LocalPaths.data_dir` field while preserving the derived venv and model paths
- update architecture and plan documentation to match the simplified APIs

Cross-platform `MockTyper` support remains unchanged because it has real non-macOS/Windows and test consumers.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (112 passed)
- independent Codex review: no actionable findings