### PR TITLE
refactor(config): internalize runtime policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ viberwhisper config path
 - Windows：`%APPDATA%\ViberWhisper\config.json`
 
 配置文件不存在时使用内置默认值。可将 [`config.example.json`](config.example.json) 复制到上述路径，或使用
-`config set` 创建完整配置。已有文件必须包含 `schema_version: 2` 和完整结构；缺字段、未知字段、损坏 JSON
-或其他 schema 版本都会明确报错，不会静默回退默认值。
+`config set` 创建完整配置。已有文件必须包含 `schema_version: 2` 和当前完整结构；缺字段、未知字段、损坏
+JSON 或其他 schema 版本都会明确报错，不会静默回退默认值。已退役的 `chunking`、`session` 和
+`inference.api.provider` 均视为未知字段。
 
 API 密钥优先从环境变量读取，其次才读取配置文件中的对应 secret 字段：
 
@@ -116,17 +117,16 @@ viberwhisper convert input.wav --output output.txt
 
 CLI 只接受下表中的 canonical dotted key；`hotkey`、`model`、`local_mode` 等旧别名不再支持。
 
-### 输入、音频与会话
+### 输入与音频
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `input.hold_hotkey` | 字符串 | `F8` | 按住录音热键；空字符串可禁用 |
 | `input.toggle_hotkey` | 字符串 | `F9` | 切换录音热键；空字符串可禁用 |
 | `audio.mic_gain` | 数字 | `1.0` | 麦克风增益倍数 |
-| `chunking.max_duration_secs` | 数字 | `30` | 每个分片最大秒数（`0` = 不限） |
-| `chunking.max_size_bytes` | 数字 | `24117248` | 每个分片最大字节数（`0` = 不限） |
-| `chunking.max_retries` | 数字 | `3` | 分片上传失败最大重试次数（最大 16） |
-| `session.convergence_timeout_secs` | 数字 | `30` | 等待分片收敛的超时秒数（最大 3600） |
+
+内部可靠性策略不作为用户配置：实时与离线音频统一按 30 秒或 23 MiB 的较小限制分片；每个 STT 请求
+最多等待 12 秒，网络错误或 HTTP 5xx 最多重试一次；停止录音后的 session 收敛窗口固定为 30 秒。
 
 ### 转写与 API profile
 
@@ -136,7 +136,6 @@ CLI 只接受下表中的 canonical dotted key；`hotkey`、`model`、`local_mod
 | `transcription.prompt` | 字符串/null | 中文提示词 | 转写提示词 |
 | `transcription.temperature` | 数字 | `0` | 转写温度 |
 | `inference.active` | `api`/`local` | `api` | 默认使用的推理 profile |
-| `inference.api.provider` | 字符串/null | 无 | 仅用于标注 |
 | `inference.api.transcription.api_url` | URL | Groq Whisper URL | OpenAI-compatible multipart 地址 |
 | `inference.api.transcription.model` | 字符串 | `whisper-large-v3-turbo` | 转写模型 |
 | `inference.api.transcription.api_key` | secret | 无 | 只读状态；环境变量为 `TRANSCRIPTION_API_KEY` |

--- a/changelog
+++ b/changelog
@@ -29,3 +29,4 @@
 2026-08-01: Replace the flat working-directory config with strict canonical v2 persistence, module-owned consumer configs, explicit API/Local profiles, canonical dotted CLI keys, active-profile checks, optional API authentication, secret-safe runtime assembly, concrete errors, and allocation-light consumer construction
 2026-08-01: Bound STT chunk retries to a fixed 5-second request timeout and three retries, keeping the worst-case retry window below 30 seconds
 2026-08-01: Replace temporary WAV chunk files with shared in-memory WavChunk payloads for live recording and streaming offline conversion
+2026-08-02: Internalize chunk, STT retry, and session convergence policies; remove unused provider metadata and reject retired fields outside the current canonical v2 config

--- a/config.example.json
+++ b/config.example.json
@@ -7,14 +7,6 @@
   "audio": {
     "mic_gain": 3.0
   },
-  "chunking": {
-    "max_duration_secs": 30,
-    "max_size_bytes": 24117248,
-    "max_retries": 3
-  },
-  "session": {
-    "convergence_timeout_secs": 30
-  },
   "transcription": {
     "language": "zh",
     "prompt": "以下是一段简体中文的普通话句子，去掉首尾的语气词",
@@ -29,7 +21,6 @@
   "inference": {
     "active": "api",
     "api": {
-      "provider": "groq",
       "transcription": {
         "api_url": "https://api.groq.com/openai/v1/audio/transcriptions",
         "model": "whisper-large-v3-turbo"

--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -23,9 +23,14 @@ which lets retries create fresh multipart readers without copying the payload.
 
 ## Chunk Capacity
 
+Production uses one module-owned policy for both live recording and offline conversion: a chunk is
+limited to 30 seconds or 23 MiB, whichever produces fewer complete frames. These safety values are
+not persisted configuration.
+
 `max_frames_per_chunk(max_duration_secs, max_size_bytes, output_spec)` is the only duration/size
 conversion. It works in complete audio frames and accounts for channel count, sample width, and
-the 44-byte or 68-byte header that `hound` emits for the output spec.
+the 44-byte or 68-byte header that `hound` emits for the output spec. Its explicit parameters keep
+the capacity calculation independently testable; production callers pass the module policy.
 
 - `Ok(None)`: both limits are disabled; the producer does not proactively slice.
 - `Ok(Some(0))`: a nonzero size limit can hold no more than 0.5 seconds; the producer emits no

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -15,7 +15,10 @@ The config package intentionally has four files:
 | `store.rs` | platform path discovery plus fail-closed load and atomic save |
 | `mod.rs` | facade, config errors, validation report, secret-safe value types |
 
-`ConfigDocument` accepts only a complete document with `schema_version: 2`. Missing or unknown fields, wrong versions, invalid JSON, and non-finite floats are errors. A missing file alone returns the in-memory defaults.
+`ConfigDocument` accepts only the current complete canonical document with `schema_version: 2`.
+Missing or unknown fields, wrong versions, invalid JSON, and non-finite floats are errors. Retired
+fields such as `chunking`, `session`, and `inference.api.provider` are not accepted. A missing file
+alone returns the in-memory defaults.
 
 `ConfigStore::discover()` gets the application directory from `platform::config_dir()` and appends `config.json`. Reads and writes therefore use the same canonical path independent of the launch working directory. Writes use a temporary file in the destination directory followed by atomic publication.
 
@@ -53,13 +56,17 @@ No subcommand runs the recording listener. Other commands are:
 
 - **Chunk State Machine**: `Flushed → Uploading → Transcribed / Failed`
 - **Session-owned Results**: Each active session exclusively owns its `Vec<ChunkEntry>`. The worker never reads or mutates chunk state; it reports `UploadStarted` and `Completed` events through a session-specific result channel.
-- **Convergence Timeout**: Configurable via `convergence_timeout_secs`; chunks still pending at the deadline are marked `Failed(Timeout)`
+- **Convergence Timeout**: A module-owned 30-second deadline marks chunks still pending as `Failed(Timeout)`
 - **Partial Failure**: If some chunks succeed and others fail, returns partial text with an error
 - **Bounded Queue**: The capacity-two in-memory `WavChunk` queue is non-blocking. A full queue marks the chunk failed rather than stalling session shutdown.
 - **Memory Ownership**: Queued chunks are immutable shared WAV bytes. Rejected, stale, cancelled, or completed chunks are released by normal ownership drops; the orchestrator performs no chunk-file cleanup.
 - **Strict Session Routing**: start, chunk, finish, and abort operations carry `SessionId`; duplicate starts and mismatched IDs are rejected without replacing active work.
 
-`on_chunk_ready` opportunistically drains completed worker events while recording. During shutdown, `finish_session` closes the bounded input sender and waits on the result receiver with the configured convergence deadline. Timeout or abort drops session-owned chunk state immediately; a detached worker can finish synchronous transcription, but late events cannot retain or mutate the ended session or reach a newer session.
+`on_chunk_ready` opportunistically drains completed worker events while recording. During shutdown,
+`finish_session` closes the bounded input sender and waits on the result receiver with the fixed
+convergence deadline. Timeout or abort drops session-owned chunk state immediately; a detached
+worker can finish synchronous transcription, but late events cannot retain or mutate the ended
+session or reach a newer session.
 
 ### `SessionError` Enum
 

--- a/docs/architecture/transcriber.md
+++ b/docs/architecture/transcriber.md
@@ -20,8 +20,8 @@ owned by `SessionOrchestrator`; offline conversion iterates `WavChunkReader` and
 ## `ApiTranscriber`
 
 `ApiTranscriber` is compatible with OpenAI-style multipart transcription endpoints. Construction
-consumes endpoint, authentication, model, language, prompt, temperature, and retry configuration.
-Chunk duration and size limits are producer configuration and are not stored in the transcriber.
+consumes endpoint, authentication, model, language, prompt, and temperature. Retry policy is owned
+by the module; chunk duration and size limits are owned by the audio producer.
 
 Each request builds a multipart form containing `model`, `temperature`,
 `response_format=verbose_json`, optional `language` and `prompt`, plus an `audio.wav` file part. The
@@ -31,10 +31,9 @@ reader and request body.
 ## Retry Budget
 
 - 4xx responses fail immediately.
-- 5xx and network errors retry up to the configured maximum.
-- The maximum is three retries, for at most four attempts.
-- Each request has a five-second timeout; 1s, 2s, and 4s backoffs keep the worst-case window near
-  27 seconds and below 30 seconds.
+- 5xx and network errors retry once, for at most two attempts.
+- Each request has a 12-second timeout; the 1-second retry backoff keeps the worst-case window near
+  25 seconds and below the 30-second session convergence budget.
 
 `TranscribeError` preserves API status/body, network and response parsing failures, and the
 orchestrator-owned timeout variant.

--- a/docs/plan/20-fixed-stt-retry-policy.md
+++ b/docs/plan/20-fixed-stt-retry-policy.md
@@ -1,0 +1,142 @@
+# 内部运行策略与配置面精简
+
+## 背景
+
+当前 canonical v2 配置同时包含用户意图和模块内部运行策略。后者包括 chunk 切分安全值、请求重试预算、
+session 收敛预算，以及一个不参与任何运行时分支的 provider 标注。把这些值暴露给用户会允许相互耦合的
+时间/容量预算失配，也扩大了无效配置、CLI 和文档的维护面。
+
+本计划先审计全部 26 个 canonical key，再把没有真实用户选择的字段收回对应模块。STT 策略固定为：
+单次请求最多 12 秒，网络错误或 HTTP 5xx 最多重试一次，重试前等待 1 秒；最坏请求窗口约为
+`12 + 1 + 12 = 25` 秒。HTTP 4xx 仍立即失败。
+
+## 配置审计结论
+
+### 移除并内置
+
+| 当前字段 | 结论 | 新所有者/固定值 |
+| --- | --- | --- |
+| `chunking.max_duration_secs` | producer 的分片/延迟策略，不是用户业务意图 | `audio`，30 秒 |
+| `chunking.max_size_bytes` | WAV payload 安全护栏，不应允许关闭或突破 | `audio`，23 MiB |
+| `chunking.max_retries` | 与 HTTP/session 时间预算耦合 | `transcriber`，1 次 |
+| `session.convergence_timeout_secs` | 与 retry 窗口耦合的 session 生命周期策略 | `orchestrator`，30 秒 |
+| `inference.api.provider` | 仅作标注，运行时没有读取点 | 删除，不替换 |
+
+删除前三项后 canonical JSON 不再需要 `chunking` section；删除收敛字段后也不再需要 `session`
+section。API profile 只由 endpoint、model 和认证决定，不再保存 provider 标签。
+
+### 保留为显式用户选择
+
+| 分组 | 保留字段 | 理由 |
+| --- | --- | --- |
+| 格式元数据 | `schema_version` | 只读但用于识别持久化格式，不是运行策略 |
+| 输入 | `input.hold_hotkey`、`input.toggle_hotkey` | 用户快捷键选择，可分别禁用 |
+| 音频 | `audio.mic_gain` | 麦克风硬件和输入音量存在真实差异 |
+| 转写 | `transcription.language`、`prompt`、`temperature` | 直接改变识别请求和结果 |
+| 后处理 | `post_process.enabled`、`preheat_enabled`、`prompt`、`temperature` | 分别控制开关、延迟/成本取舍和输出策略 |
+| profile | `inference.active` | API/Local 是明确的用户选择 |
+| API | transcription/post-process 的 URL、model、只读 key 状态 | 支持不同 OpenAI-compatible 服务与模型 |
+| Local | `data_dir`、`server_port`、`quantization` | 分别对应存储位置、端口冲突和硬件/精度取舍 |
+
+审计后 canonical key 从 26 个缩减到 21 个。
+
+## 目标
+
+1. audio、transcriber、orchestrator 各自用模块常量拥有内部容量和时间预算。
+2. 从 canonical JSON、CLI 字段目录、运行时组装参数和用户文档中删除上述五个字段。
+3. 只接受当前 `schema_version = 2` canonical 结构；已删除字段与其他未知字段一样直接拒绝。
+4. 保持错误分类、chunk 内容、session partial-result 语义和用户可配置字段的行为不变。
+
+## 非目标
+
+- 不开放请求超时、退避间隔或其他替代运行策略。
+- 不改变并发模型、队列容量或超时后的 detached-worker 行为。
+- 不移除高级但确有用户取舍的模型、后处理和 Local 设置。
+- 不修改历史 plan 中记录的当时设计；只更新当前架构和用户文档。
+
+## 设计
+
+### 模块内策略
+
+各模块直接拥有自己唯一的生产策略：
+
+```rust
+// audio
+pub(crate) const MAX_CHUNK_DURATION_SECS: u32 = 30;
+pub(crate) const MAX_CHUNK_SIZE_BYTES: u64 = 23 * 1024 * 1024;
+
+// transcriber
+const STT_REQUEST_TIMEOUT: Duration = Duration::from_secs(12);
+const STT_MAX_RETRIES: u32 = 1;
+
+// orchestrator
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
+```
+
+生产组装不再从 `ConfigDocument` 搬运这些值：
+
+- `AudioConfig` 只从持久化配置接收 `mic_gain`，内部填入固定 chunk limits；
+- 离线 `ConvertConfig` 使用相同 audio 模块常量，避免实时/离线策略漂移；
+- `TranscriberConfig` 不再携带 retry 次数，也不再接收 `ChunkingSection`；
+- `OrchestratorConfig` 不再接收或校验 `SessionSection`，生产构造固定使用 30 秒；模块内测试仍可直接构造短 timeout，保持测试快速确定。
+
+底层 `max_frames_per_chunk` 和 `WavChunkReader::open` 仍接受明确参数，便于纯逻辑测试和复用；只是生产调用点
+不再由用户配置这些参数。
+
+### 严格 v2 配置
+
+新的 canonical JSON 顶层不再含 `chunking`、`session`，API profile 不再含 `provider`。
+
+`ConfigDocument` 直接派生严格反序列化，只接受新的 21-key canonical 结构。顶层出现 `chunking`、
+`session`，或 API profile 出现 `provider` 时，均按未知字段失败；不设置迁移 DTO，也不保留旧配置读取路径。
+`schema_version` 继续为 2，但只描述当前结构。
+
+## 文件改动
+
+| 文件 | 改动 |
+| --- | --- |
+| `src/audio/mod.rs` | 拥有生产 chunk limits，`AudioConfig` 不再接收 `ChunkingSection` |
+| `src/transcriber/api.rs` | 固定 12 秒请求超时和一次重试；删除 retry 配置传递与校验 |
+| `src/core/orchestrator.rs` | 固定 30 秒生产收敛预算；删除 session 配置校验 |
+| `src/core/config/document.rs` | 删除 `chunking`、`session`、API provider 字段，只反序列化当前 canonical 结构 |
+| `src/core/config/fields.rs` | 从 canonical CLI 字段目录及 get/set 分支删除五个 key |
+| `src/runtime_config.rs` | 用模块策略组装 listener/convert，不再传递已移除字段 |
+| `config.example.json` | 删除两个内部策略 section 和 provider 标签 |
+| `README.md`、`docs/architecture/{audio,core,transcriber}.md` | 记录精简后的配置面和固定策略 |
+| `changelog` | 记录用户可见配置面收窄 |
+
+## 实现顺序
+
+1. 先增加严格配置与字段目录测试，锁定已退役字段被拒绝、新 v2 不输出五个字段。
+2. 在 audio、transcriber、orchestrator 中建立单一生产常量，并增加最小行为测试。
+3. 删除运行时配置传递、领域字段、验证分支和 CLI get/set 分支。
+4. 删除 serde 边界中的旧字段读取逻辑。
+5. 更新示例、当前架构文档、README 和 changelog。
+6. 运行格式、全量测试和 lint，并通过代码审查 gate 后更新同一个 PR。
+
+## 测试策略
+
+- 新配置 round-trip：canonical 示例不包含五个已移除字段，仍能完整序列化/反序列化。
+- 严格结构：向新示例分别注入旧 `chunking`、`session` 和 provider 后均加载失败。
+- CLI 字段目录：五个 key 不在 catalog 中，`get`/`set` 返回 unknown key，总数为 21。
+- chunk 行为：实时录音和离线 reader 都使用 30 秒/23 MiB 的同一生产限制；容量换算纯函数测试保持可注入边界值。
+- retry 行为：HTTP 503 恰好收到两次请求；HTTP 4xx 仍只收到一次请求。
+- convergence 行为：生产配置得到 30 秒预算；现有短 timeout 单元测试不变慢。
+- 回归：`cargo fmt --check`、`cargo test`、`cargo clippy -- -D warnings`。
+
+## 验收条件
+
+- 用户无法通过 JSON 或 CLI 改变 chunk limits、STT retry 次数或 session convergence timeout。
+- 每个 chunk 最多发起两次 STT 请求，每次最多 12 秒，重试间隔 1 秒。
+- 实时和离线生产路径统一使用 30 秒/23 MiB chunk limits，session 使用 30 秒 convergence timeout。
+- API provider 标签不再存在，endpoint/model/auth 行为不变。
+- 含已退役字段的旧 v2 配置启动失败，并明确报告未知字段。
+- 其余未知字段继续被拒绝，现有转写、离线转换和 session 测试保持通过。
+
+## 实现状态
+
+- [x] 五个内部/无行为字段已从 canonical JSON 和 CLI catalog 移除。
+- [x] audio、transcriber、orchestrator 已接管固定生产策略。
+- [x] 已退役的旧 v2 字段会被严格拒绝，不存在兼容反序列化入口。
+- [x] 示例、README、架构文档和 changelog 已同步。
+- [x] 严格配置、固定 chunk limits、一次 retry 和固定 convergence timeout 均有回归测试。

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,4 +1,8 @@
-use crate::core::config::{AudioSection, ChunkingSection};
+use crate::core::config::AudioSection;
+
+// Keep API payloads below common service limits while producing chunks often enough for live STT.
+pub(crate) const MAX_CHUNK_DURATION_SECS: u32 = 30;
+pub(crate) const MAX_CHUNK_SIZE_BYTES: u64 = 23 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AudioConfig {
@@ -8,11 +12,11 @@ pub struct AudioConfig {
 }
 
 impl AudioConfig {
-    pub(crate) fn from_sections(audio: &AudioSection, chunking: &ChunkingSection) -> Self {
+    pub(crate) fn from_section(audio: &AudioSection) -> Self {
         Self {
             mic_gain: audio.mic_gain,
-            max_chunk_duration_secs: chunking.max_duration_secs,
-            max_chunk_size_bytes: chunking.max_size_bytes,
+            max_chunk_duration_secs: MAX_CHUNK_DURATION_SECS,
+            max_chunk_size_bytes: MAX_CHUNK_SIZE_BYTES,
         }
     }
 }

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -93,9 +93,9 @@ pub struct AudioRecorder {
     ready_chunk_count: Arc<AtomicUsize>,
     /// Maximum mono frames per chunk. `None` means unlimited and `Some(0)` suppresses output.
     chunk_max_samples: Option<usize>,
-    /// Config: max chunk duration in seconds.
+    /// Production policy: max chunk duration in seconds.
     max_chunk_duration_secs: u32,
-    /// Config: max chunk size in bytes (including 44-byte WAV header).
+    /// Production policy: max chunk size in bytes, including the encoded WAV header.
     max_chunk_size_bytes: u64,
 }
 
@@ -125,11 +125,7 @@ fn push_mono_chunk(
 }
 
 impl AudioRecorder {
-    /// Create a recorder with chunk-splitting config.
-    ///
-    /// - `max_chunk_duration_secs`: flush a chunk every N seconds; 0 = no duration limit.
-    /// - `max_chunk_size_bytes`: flush when the uncompressed PCM + 44-byte header exceeds
-    ///   this size; 0 = no size limit.
+    /// Create a recorder with the module-owned production chunk policy.
     pub fn with_config(config: &AudioConfig) -> Self {
         let gain = config.mic_gain;
         let max_chunk_duration_secs = config.max_chunk_duration_secs;
@@ -516,10 +512,7 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "windows"))]
     fn test_recorder_with_config() {
-        let config = AudioConfig::from_sections(
-            &crate::core::config::AudioSection::default(),
-            &crate::core::config::ChunkingSection::default(),
-        );
+        let config = AudioConfig::from_section(&crate::core::config::AudioSection::default());
         let recorder = AudioRecorder::with_config(&config);
         assert!(!recorder.is_recording());
         assert_eq!(recorder.max_chunk_duration_secs, 30);

--- a/src/core/config/document.rs
+++ b/src/core/config/document.rs
@@ -11,8 +11,6 @@ pub struct ConfigDocument {
     pub(super) schema_version: u32,
     pub(crate) input: InputSection,
     pub(crate) audio: AudioSection,
-    pub(crate) chunking: ChunkingSection,
-    pub(crate) session: SessionSection,
     pub(crate) transcription: TranscriptionSection,
     pub(crate) post_process: PostProcessSection,
     pub(crate) inference: InferenceSection,
@@ -24,8 +22,6 @@ impl Default for ConfigDocument {
             schema_version: 2,
             input: InputSection::default(),
             audio: AudioSection::default(),
-            chunking: ChunkingSection::default(),
-            session: SessionSection::default(),
             transcription: TranscriptionSection::default(),
             post_process: PostProcessSection::default(),
             inference: InferenceSection::default(),
@@ -87,38 +83,6 @@ pub(crate) struct AudioSection {
 impl Default for AudioSection {
     fn default() -> Self {
         Self { mic_gain: 1.0 }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct ChunkingSection {
-    pub(crate) max_duration_secs: u32,
-    pub(crate) max_size_bytes: u64,
-    pub(crate) max_retries: u32,
-}
-
-impl Default for ChunkingSection {
-    fn default() -> Self {
-        Self {
-            max_duration_secs: 30,
-            max_size_bytes: 23 * 1024 * 1024,
-            max_retries: 3,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct SessionSection {
-    pub(crate) convergence_timeout_secs: u64,
-}
-
-impl Default for SessionSection {
-    fn default() -> Self {
-        Self {
-            convergence_timeout_secs: 30,
-        }
     }
 }
 
@@ -190,7 +154,6 @@ impl Default for InferenceSection {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ApiInferenceSection {
-    pub(crate) provider: Option<String>,
     pub(crate) transcription: ApiTranscriptionSection,
     pub(crate) post_process: ApiPostProcessSection,
 }

--- a/src/core/config/fields.rs
+++ b/src/core/config/fields.rs
@@ -46,10 +46,6 @@ define_config_fields! {
     InputHoldHotkey => { name: "input.hold_hotkey", writable: true },
     InputToggleHotkey => { name: "input.toggle_hotkey", writable: true },
     AudioMicGain => { name: "audio.mic_gain", writable: true },
-    ChunkingMaxDurationSecs => { name: "chunking.max_duration_secs", writable: true },
-    ChunkingMaxSizeBytes => { name: "chunking.max_size_bytes", writable: true },
-    ChunkingMaxRetries => { name: "chunking.max_retries", writable: true },
-    SessionConvergenceTimeoutSecs => { name: "session.convergence_timeout_secs", writable: true },
     TranscriptionLanguage => { name: "transcription.language", writable: true },
     TranscriptionPrompt => { name: "transcription.prompt", writable: true },
     TranscriptionTemperature => { name: "transcription.temperature", writable: true },
@@ -58,7 +54,6 @@ define_config_fields! {
     PostProcessPrompt => { name: "post_process.prompt", writable: true },
     PostProcessTemperature => { name: "post_process.temperature", writable: true },
     InferenceActive => { name: "inference.active", writable: true },
-    ApiProvider => { name: "inference.api.provider", writable: true },
     ApiTranscriptionUrl => { name: "inference.api.transcription.api_url", writable: true },
     ApiTranscriptionModel => { name: "inference.api.transcription.model", writable: true },
     ApiTranscriptionKey => { name: "inference.api.transcription.api_key", writable: false },
@@ -156,18 +151,6 @@ impl ConfigDocument {
             ConfigKey::InputHoldHotkey => FieldValue::Value(self.input.hold_hotkey.clone()),
             ConfigKey::InputToggleHotkey => FieldValue::Value(self.input.toggle_hotkey.clone()),
             ConfigKey::AudioMicGain => FieldValue::Value(self.audio.mic_gain.to_string()),
-            ConfigKey::ChunkingMaxDurationSecs => {
-                FieldValue::Value(self.chunking.max_duration_secs.to_string())
-            }
-            ConfigKey::ChunkingMaxSizeBytes => {
-                FieldValue::Value(self.chunking.max_size_bytes.to_string())
-            }
-            ConfigKey::ChunkingMaxRetries => {
-                FieldValue::Value(self.chunking.max_retries.to_string())
-            }
-            ConfigKey::SessionConvergenceTimeoutSecs => {
-                FieldValue::Value(self.session.convergence_timeout_secs.to_string())
-            }
             ConfigKey::TranscriptionLanguage => optional_field(&self.transcription.language),
             ConfigKey::TranscriptionPrompt => optional_field(&self.transcription.prompt),
             ConfigKey::TranscriptionTemperature => {
@@ -190,7 +173,6 @@ impl ConfigDocument {
                 }
                 .to_string(),
             ),
-            ConfigKey::ApiProvider => optional_field(&self.inference.api.provider),
             ConfigKey::ApiTranscriptionUrl => {
                 FieldValue::Value(self.inference.api.transcription.api_url.clone())
             }
@@ -227,19 +209,6 @@ impl ConfigDocument {
             ConfigKey::AudioMicGain => {
                 self.audio.mic_gain = parse_f32(value).map_err(invalid)?;
             }
-            ConfigKey::ChunkingMaxDurationSecs => {
-                self.chunking.max_duration_secs = parse_number::<u32>(value).map_err(invalid)?;
-            }
-            ConfigKey::ChunkingMaxSizeBytes => {
-                self.chunking.max_size_bytes = parse_number::<u64>(value).map_err(invalid)?;
-            }
-            ConfigKey::ChunkingMaxRetries => {
-                self.chunking.max_retries = parse_number::<u32>(value).map_err(invalid)?;
-            }
-            ConfigKey::SessionConvergenceTimeoutSecs => {
-                self.session.convergence_timeout_secs =
-                    parse_number::<u64>(value).map_err(invalid)?;
-            }
             ConfigKey::TranscriptionLanguage => self.transcription.language = parse_optional(value),
             ConfigKey::TranscriptionPrompt => self.transcription.prompt = parse_optional(value),
             ConfigKey::TranscriptionTemperature => {
@@ -262,7 +231,6 @@ impl ConfigDocument {
                     _ => return Err(invalid("expected `api` or `local`".to_string())),
                 };
             }
-            ConfigKey::ApiProvider => self.inference.api.provider = parse_optional(value),
             ConfigKey::ApiTranscriptionUrl => {
                 self.inference.api.transcription.api_url = value.to_string()
             }

--- a/src/core/config/mod.rs
+++ b/src/core/config/mod.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 
 pub use document::ConfigDocument;
 pub(crate) use document::{
-    AudioSection, ChunkingSection, InferenceProfile, InputSection, LocalSection,
-    PostProcessSection, SessionSection, TranscriptionSection,
+    AudioSection, InferenceProfile, InputSection, LocalSection, PostProcessSection,
+    TranscriptionSection,
 };
 pub use fields::ConfigKey;
 #[cfg(test)]
@@ -163,10 +163,38 @@ mod tests {
             serde_json::from_str(include_str!("../../../config.example.json")).unwrap();
         assert_eq!(document.schema_version, 2);
         let encoded = serde_json::to_string(&document).unwrap();
+        let encoded_value: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        assert!(encoded_value.get("chunking").is_none());
+        assert!(encoded_value.get("session").is_none());
+        assert!(encoded_value["inference"]["api"].get("provider").is_none());
         assert_eq!(
             serde_json::from_str::<ConfigDocument>(&encoded).unwrap(),
             document
         );
+    }
+
+    #[test]
+    fn retired_policy_fields_are_rejected() {
+        // The current schema is the only accepted shape: removed policy knobs must not be
+        // mistaken for live settings that still affect runtime behavior.
+        let canonical: serde_json::Value =
+            serde_json::from_str(include_str!("../../../config.example.json")).unwrap();
+
+        let mut with_chunking = canonical.clone();
+        with_chunking["chunking"] = serde_json::json!({
+            "max_duration_secs": 30,
+            "max_size_bytes": 24117248,
+            "max_retries": 1
+        });
+        assert!(serde_json::from_value::<ConfigDocument>(with_chunking).is_err());
+
+        let mut with_session = canonical.clone();
+        with_session["session"] = serde_json::json!({"convergence_timeout_secs": 30});
+        assert!(serde_json::from_value::<ConfigDocument>(with_session).is_err());
+
+        let mut with_provider = canonical;
+        with_provider["inference"]["api"]["provider"] = serde_json::json!("groq");
+        assert!(serde_json::from_value::<ConfigDocument>(with_provider).is_err());
     }
 
     #[test]
@@ -227,7 +255,16 @@ mod tests {
         assert!(keys.contains(&"inference.local.server_port"));
         assert!(!keys.contains(&"hold_hotkey"));
         assert!(!keys.contains(&"local_mode"));
-        assert_eq!(keys.len(), 26);
+        for retired in [
+            "chunking.max_duration_secs",
+            "chunking.max_size_bytes",
+            "chunking.max_retries",
+            "session.convergence_timeout_secs",
+            "inference.api.provider",
+        ] {
+            assert!(!keys.contains(&retired));
+        }
+        assert_eq!(keys.len(), 21);
 
         let document = ConfigDocument::default();
         let secrets = MapSecrets(HashMap::new());
@@ -248,6 +285,10 @@ mod tests {
         );
         assert!(matches!(
             document.get_field("model", &secrets),
+            Err(FieldError::UnknownKey(_))
+        ));
+        assert!(matches!(
+            document.set_field("chunking.max_retries", "1"),
             Err(FieldError::UnknownKey(_))
         ));
         assert!(matches!(

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -13,14 +13,15 @@ use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use crate::audio::WavChunk;
-use crate::core::config::{ConfigKey, SessionSection, ValidationIssue};
-
 use crate::core::recording_session::SessionId;
 pub use crate::core::recording_session::SessionMode;
 use crate::text::merge_texts;
 use crate::transcriber::Transcriber;
 // Re-exported so callers can keep using `core::orchestrator::TranscribeError`.
 pub use crate::transcriber::TranscribeError;
+
+// The STT retry window is kept below this deadline so a tail chunk can normally converge on stop.
+const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -31,21 +32,11 @@ pub struct OrchestratorConfig {
 }
 
 impl OrchestratorConfig {
-    pub(crate) fn validate(
-        session: &SessionSection,
-        language: Option<String>,
-    ) -> Result<Self, Vec<ValidationIssue>> {
-        if session.convergence_timeout_secs > 60 * 60 {
-            return Err(vec![ValidationIssue::new(
-                ConfigKey::SessionConvergenceTimeoutSecs,
-                "session.timeout_too_large",
-                "convergence timeout must be at most 3600 seconds",
-            )]);
-        }
-        Ok(Self {
+    pub(crate) fn new(language: Option<String>) -> Self {
+        Self {
             language,
-            convergence_timeout: Duration::from_secs(session.convergence_timeout_secs),
-        })
+            convergence_timeout: CONVERGENCE_TIMEOUT,
+        }
     }
 }
 
@@ -620,6 +611,13 @@ mod tests {
 
     fn default_orchestrator(transcriber: Arc<dyn Transcriber>) -> SessionOrchestrator {
         make_orchestrator_with_timeout(transcriber, Duration::from_secs(5))
+    }
+
+    #[test]
+    fn production_config_uses_fixed_convergence_timeout() {
+        let config = OrchestratorConfig::new(Some("zh".to_string()));
+
+        assert_eq!(config.convergence_timeout, Duration::from_secs(30));
     }
 
     fn test_chunk() -> WavChunk {

--- a/src/main.rs
+++ b/src/main.rs
@@ -675,14 +675,7 @@ mod integration_tests {
         use std::sync::Arc;
 
         let t: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
-        let orch = SessionOrchestrator::new(
-            t,
-            OrchestratorConfig::validate(
-                &crate::core::config::SessionSection::default(),
-                Some("en".to_string()),
-            )
-            .unwrap(),
-        );
+        let orch = SessionOrchestrator::new(t, OrchestratorConfig::new(Some("en".to_string())));
 
         orch.start_session(
             crate::core::recording_session::SessionId(1),
@@ -705,11 +698,7 @@ mod integration_tests {
         use std::sync::Arc;
 
         let t: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
-        let orch = SessionOrchestrator::new(
-            t,
-            OrchestratorConfig::validate(&crate::core::config::SessionSection::default(), None)
-                .unwrap(),
-        );
+        let orch = SessionOrchestrator::new(t, OrchestratorConfig::new(None));
 
         orch.start_session(
             crate::core::recording_session::SessionId(1),

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use crate::audio::AudioConfig;
+use crate::audio::{AudioConfig, MAX_CHUNK_DURATION_SECS, MAX_CHUNK_SIZE_BYTES};
 use crate::core::config::{
     ApiAuth, ConfigDocument, InferenceProfile, SecretSource, SecretValue, ValidationIssue,
     ValidationReport,
@@ -58,25 +58,20 @@ pub fn resolve_listener(
 ) -> Result<ListenerConfig, ValidationReport> {
     let mut issues = Vec::new();
     let hotkeys = collect_issues(HotkeyConfig::validate(&document.input), &mut issues);
-    let audio = AudioConfig::from_sections(&document.audio, &document.chunking);
-    let orchestrator = collect_issues(
-        OrchestratorConfig::validate(&document.session, document.transcription.language.clone()),
-        &mut issues,
-    );
+    let audio = AudioConfig::from_section(&document.audio);
+    let orchestrator = OrchestratorConfig::new(document.transcription.language.clone());
     let backend = collect_issues(
         resolve_backend(document, secrets, selection, config_dir, home_dir),
         &mut issues,
     );
 
-    match (hotkeys, orchestrator, backend) {
-        (Some(hotkeys), Some(orchestrator), Some(backend)) if issues.is_empty() => {
-            Ok(ListenerConfig {
-                hotkeys,
-                audio,
-                orchestrator,
-                backend,
-            })
-        }
+    match (hotkeys, backend) {
+        (Some(hotkeys), Some(backend)) if issues.is_empty() => Ok(ListenerConfig {
+            hotkeys,
+            audio,
+            orchestrator,
+            backend,
+        }),
         _ => Err(report(issues)),
     }
 }
@@ -99,8 +94,8 @@ pub fn resolve_convert(
     Ok(ConvertConfig {
         backend,
         language: document.transcription.language.clone(),
-        max_chunk_duration_secs: document.chunking.max_duration_secs,
-        max_chunk_size_bytes: document.chunking.max_size_bytes,
+        max_chunk_duration_secs: MAX_CHUNK_DURATION_SECS,
+        max_chunk_size_bytes: MAX_CHUNK_SIZE_BYTES,
     })
 }
 
@@ -172,7 +167,6 @@ fn resolve_api_backend(
             transcription_secret.map_or(ApiAuth::None, ApiAuth::Bearer),
             &document.inference.api.transcription.model,
             &document.transcription,
-            &document.chunking,
         ),
         &mut issues,
     );
@@ -225,7 +219,6 @@ fn resolve_local_backend(
             ApiAuth::None,
             LOCAL_MODEL_NAME,
             &document.transcription,
-            &document.chunking,
         ),
         &mut issues,
     );
@@ -354,6 +347,8 @@ mod tests {
         .unwrap();
 
         assert!(config.backend.local_service.is_none());
+        assert_eq!(config.max_chunk_duration_secs, 30);
+        assert_eq!(config.max_chunk_size_bytes, 23 * 1024 * 1024);
     }
 
     #[test]

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -1,14 +1,13 @@
 use crate::audio::WavChunk;
-use crate::core::config::{
-    ApiAuth, ChunkingSection, ConfigKey, TranscriptionSection, ValidationIssue,
-};
+use crate::core::config::{ApiAuth, ConfigKey, TranscriptionSection, ValidationIssue};
 use crate::transcriber::TranscribeError;
 use std::io::Cursor;
 use std::time::Duration;
 use tracing::{info, instrument, warn};
 
-/// Four attempts plus exponential backoff stay below the 30-second session budget.
-const STT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// Two attempts plus the retry backoff stay below the 30-second session budget.
+const STT_REQUEST_TIMEOUT: Duration = Duration::from_secs(12);
+const STT_MAX_RETRIES: u32 = 1;
 
 pub trait Transcriber: Send + Sync {
     fn transcribe(&self, chunk: &WavChunk) -> Result<String, TranscribeError>;
@@ -36,7 +35,6 @@ pub struct TranscriberConfig {
     language: Option<String>,
     prompt: Option<String>,
     temperature: f32,
-    max_retries: u32,
 }
 
 impl TranscriberConfig {
@@ -45,7 +43,6 @@ impl TranscriberConfig {
         auth: ApiAuth,
         model: &str,
         transcription: &TranscriptionSection,
-        chunking: &ChunkingSection,
     ) -> Result<Self, Vec<ValidationIssue>> {
         let mut issues = Vec::new();
         let endpoint = match reqwest::Url::parse(endpoint) {
@@ -74,13 +71,6 @@ impl TranscriberConfig {
                 "transcription model cannot be empty",
             ));
         }
-        if chunking.max_retries > 3 {
-            issues.push(ValidationIssue::new(
-                ConfigKey::ChunkingMaxRetries,
-                "transcriber.retries_too_large",
-                "max retries must be at most 3",
-            ));
-        }
         match endpoint {
             Some(endpoint) if issues.is_empty() => Ok(Self {
                 endpoint,
@@ -89,7 +79,6 @@ impl TranscriberConfig {
                 language: transcription.language.clone(),
                 prompt: transcription.prompt.clone(),
                 temperature: transcription.temperature,
-                max_retries: chunking.max_retries,
             }),
             _ => Err(issues),
         }
@@ -110,8 +99,6 @@ pub struct ApiTranscriber {
     language: Option<String>,
     prompt: Option<String>,
     temperature: f32,
-    /// Maximum retry attempts per chunk on transient errors (5xx / network).
-    max_retries: u32,
     /// Shared HTTP client (connection reuse + request timeout).
     client: reqwest::blocking::Client,
 }
@@ -125,7 +112,6 @@ impl ApiTranscriber {
             language: config.language,
             prompt: config.prompt,
             temperature: config.temperature,
-            max_retries: config.max_retries,
             client: reqwest::blocking::Client::builder()
                 .timeout(STT_REQUEST_TIMEOUT)
                 .build()?,
@@ -134,7 +120,7 @@ impl ApiTranscriber {
             model = %transcriber.model,
             api_url = %transcriber.api_url,
             language = transcriber.language.as_deref().unwrap_or("auto"),
-            max_retries = transcriber.max_retries,
+            max_retries = STT_MAX_RETRIES,
             "Using API transcriber for speech recognition"
         );
         Ok(transcriber)
@@ -208,7 +194,7 @@ impl ApiTranscriber {
     fn upload_chunk_with_retry(&self, chunk: &WavChunk) -> Result<String, TranscribeError> {
         let mut last_error = TranscribeError::Network("upload not attempted".to_string());
 
-        for attempt in 0..=self.max_retries {
+        for attempt in 0..=STT_MAX_RETRIES {
             if attempt > 0 {
                 let wait_secs = std::cmp::min(1u64 << (attempt - 1), 16);
                 warn!(
@@ -241,7 +227,7 @@ impl ApiTranscriber {
         }
 
         warn!(
-            attempts = self.max_retries + 1,
+            attempts = STT_MAX_RETRIES + 1,
             error = %last_error,
             "Chunk upload failed after all retries"
         );
@@ -262,31 +248,18 @@ impl Transcriber for ApiTranscriber {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::config::{ApiAuth, ChunkingSection, SecretValue, TranscriptionSection};
+    use crate::core::config::{ApiAuth, SecretValue, TranscriptionSection};
 
-    fn validated_config(endpoint: &str, max_retries: u32) -> TranscriberConfig {
-        validated_config_with_auth(
-            endpoint,
-            max_retries,
-            ApiAuth::Bearer(SecretValue::new("test_key")),
-        )
+    fn validated_config(endpoint: &str) -> TranscriberConfig {
+        validated_config_with_auth(endpoint, ApiAuth::Bearer(SecretValue::new("test_key")))
     }
 
-    fn validated_config_with_auth(
-        endpoint: &str,
-        max_retries: u32,
-        auth: ApiAuth,
-    ) -> TranscriberConfig {
-        let chunking = ChunkingSection {
-            max_retries,
-            ..ChunkingSection::default()
-        };
+    fn validated_config_with_auth(endpoint: &str, auth: ApiAuth) -> TranscriberConfig {
         TranscriberConfig::validate(
             endpoint,
             auth,
             "whisper-large-v3-turbo",
             &TranscriptionSection::default(),
-            &chunking,
         )
         .unwrap()
     }
@@ -358,11 +331,8 @@ mod tests {
         (port, receiver)
     }
 
-    fn transcriber_for_port(port: u16, max_retries: u32) -> ApiTranscriber {
-        let config = validated_config(
-            &format!("http://127.0.0.1:{port}/v1/audio/transcriptions"),
-            max_retries,
-        );
+    fn transcriber_for_port(port: u16) -> ApiTranscriber {
+        let config = validated_config(&format!("http://127.0.0.1:{port}/v1/audio/transcriptions"));
         ApiTranscriber::new(config).unwrap()
     }
 
@@ -373,7 +343,7 @@ mod tests {
     #[test]
     fn test_upload_success_returns_trimmed_text() {
         let (port, _requests) = spawn_http_stub("HTTP/1.1 200 OK", "{\"text\": \" hello \"}");
-        let t = transcriber_for_port(port, 3);
+        let t = transcriber_for_port(port);
         let chunk = test_chunk();
 
         let result = t.upload_chunk_with_retry(&chunk);
@@ -393,7 +363,6 @@ mod tests {
             let (port, request) = spawn_request_stub();
             let config = validated_config_with_auth(
                 &format!("http://127.0.0.1:{port}/v1/audio/transcriptions"),
-                0,
                 auth,
             );
             let transcriber = ApiTranscriber::new(config).unwrap();
@@ -416,7 +385,7 @@ mod tests {
     #[test]
     fn multipart_upload_contains_the_shared_chunk_bytes() {
         let (port, request) = spawn_request_stub();
-        let transcriber = transcriber_for_port(port, 0);
+        let transcriber = transcriber_for_port(port);
         let chunk = test_chunk();
 
         assert_eq!(transcriber.upload_chunk(&chunk).unwrap(), "ok");
@@ -434,7 +403,7 @@ mod tests {
     fn test_client_error_is_structured_and_not_retried() {
         let (port, requests) =
             spawn_http_stub("HTTP/1.1 400 Bad Request", "{\"error\":\"bad model\"}");
-        let t = transcriber_for_port(port, 3);
+        let t = transcriber_for_port(port);
         let chunk = test_chunk();
 
         let started = std::time::Instant::now();
@@ -455,7 +424,7 @@ mod tests {
     fn test_server_error_is_retried_and_kept_structured() {
         let (port, requests) =
             spawn_http_stub("HTTP/1.1 503 Service Unavailable", "{\"error\":\"busy\"}");
-        let t = transcriber_for_port(port, 1);
+        let t = transcriber_for_port(port);
         let chunk = test_chunk();
 
         let result = t.upload_chunk_with_retry(&chunk);


### PR DESCRIPTION
## Summary

- Internalize chunk duration/size, STT retry count, request timeout, and session convergence policies in their owning modules.
- Fix STT requests at a 12-second timeout with one retry.
- Remove the unused API provider label and reduce the canonical CLI config catalog from 26 to 21 keys.
- Accept only the current canonical schema-v2 structure; retired `chunking`, `session`, and `inference.api.provider` fields are rejected as unknown.
- Update the example config, architecture docs, implementation plan, and changelog.

## Fixed policy

- Chunk duration: 30 seconds
- Chunk size: 23 MiB
- STT attempts: initial request plus one retry
- Per-request timeout: 12 seconds
- Retry backoff: 1 second
- Session convergence: 30 seconds

## Validation

- `cargo test` — 113 passed
- `cargo fmt --check` — passed
- `cargo clippy -- -D warnings` — passed
- Independent review completed with two advisory findings; per workflow they do not block the push.