### PR TITLE
refactor(postprocess): use trait-based dispatch

### DIFF
--- a/docs/architecture/postprocess.md
+++ b/docs/architecture/postprocess.md
@@ -8,14 +8,14 @@ Optional LLM-based text cleanup applied after STT transcription. Adds punctuatio
 
 ```
 src/postprocess/
-  mod.rs      — PostProcessor facade, session facade, typed config and errors
+  mod.rs      — processor/session traits and facades, typed config and errors
   llm.rs      — LlmPostProcessor, ConservativeLlmSession, PreheatLlmSession
 ```
 
 ## `PostProcessor` Facade
 
 ```rust
-pub struct PostProcessor(/* private implementation enum */);
+pub struct PostProcessor(Box<dyn TextPostProcessor>);
 
 impl PostProcessor {
     pub fn new(config: PostProcessConfig) -> Self;
@@ -28,18 +28,20 @@ Two interfaces for different use cases:
 - `process`: one-shot processing for the `convert` CLI path
 - `start_session`: incremental session for the `run_listener` path
 
-The supported implementations are a closed set, so the module uses a concrete facade over a private enum instead of allocating boxed trait objects. Only the much larger LLM session variant uses `Box`, preventing the pass-through session from inheriting its stack size. Construction selects pass-through or LLM behavior from the validated config. If HTTP-client initialization fails, it logs the error and falls back to pass-through because cleanup is optional.
+`TextPostProcessor` defines the shared behavior implemented by `NoopPostProcessor` and `LlmPostProcessor`. The facade selects and boxes one implementation during construction, then delegates directly through the trait without repeating implementation-specific matches. The trait remains private so callers depend only on the stable `PostProcessor` API. If HTTP-client initialization fails, construction logs the error and selects the pass-through implementation because cleanup is optional.
 
 ## `PostProcessorSession`
 
 ```rust
+pub struct PostProcessorSession(Box<dyn TextPostProcessorSession>);
+
 impl PostProcessorSession {
     pub fn push_stable_chunk(&mut self, text: &str);
     pub fn finish(&mut self) -> Result<String, PostProcessError>;
 }
 ```
 
-Designed for incremental input: stable STT chunks are pushed as they become available; `finish` returns the final processed text.
+`TextPostProcessorSession` provides the common incremental interface implemented by `NoopSession`, `ConservativeLlmSession`, and `PreheatLlmSession`. The session facade delegates to the boxed implementation. The interface accepts stable STT chunks incrementally, and `finish` returns the final processed text.
 
 ## Implementations
 

--- a/src/postprocess/llm.rs
+++ b/src/postprocess/llm.rs
@@ -1,5 +1,7 @@
 use crate::core::config::ApiAuth;
-use crate::postprocess::{LlmConfig, PostProcessError};
+use crate::postprocess::{
+    LlmConfig, PostProcessError, TextPostProcessor, TextPostProcessorSession,
+};
 use reqwest::blocking::Client;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
@@ -50,8 +52,10 @@ impl LlmPostProcessor {
             text,
         )
     }
+}
 
-    pub(crate) fn process(&self, text: &str) -> Result<String, PostProcessError> {
+impl TextPostProcessor for LlmPostProcessor {
+    fn process(&self, text: &str) -> Result<String, PostProcessError> {
         if text.is_empty() {
             return Ok(text.to_string());
         }
@@ -61,9 +65,9 @@ impl LlmPostProcessor {
         Ok(result)
     }
 
-    pub(crate) fn start_session(&self) -> LlmSession {
-        let session = if self.streaming_enabled {
-            LlmSessionKind::Preheat(PreheatLlmSession::new(
+    fn start_session(&self) -> Box<dyn TextPostProcessorSession> {
+        if self.streaming_enabled {
+            Box::new(PreheatLlmSession::new(
                 self.auth.clone(),
                 self.api_url.clone(),
                 self.model.clone(),
@@ -72,7 +76,7 @@ impl LlmPostProcessor {
                 self.client.clone(),
             ))
         } else {
-            LlmSessionKind::Conservative(ConservativeLlmSession {
+            Box::new(ConservativeLlmSession {
                 auth: self.auth.clone(),
                 api_url: self.api_url.clone(),
                 model: self.model.clone(),
@@ -81,8 +85,7 @@ impl LlmPostProcessor {
                 client: self.client.clone(),
                 chunks: Vec::new(),
             })
-        };
-        LlmSession(session)
+        }
     }
 }
 
@@ -152,7 +155,7 @@ struct ConservativeLlmSession {
     chunks: Vec<String>,
 }
 
-impl ConservativeLlmSession {
+impl TextPostProcessorSession for ConservativeLlmSession {
     fn push_stable_chunk(&mut self, text: &str) {
         if !text.is_empty() {
             self.chunks.push(text.to_string());
@@ -279,7 +282,7 @@ impl PreheatLlmSession {
     }
 }
 
-impl PreheatLlmSession {
+impl TextPostProcessorSession for PreheatLlmSession {
     fn push_stable_chunk(&mut self, text: &str) {
         if !text.is_empty() {
             self.chunks.push(text.to_string());
@@ -344,29 +347,6 @@ impl PreheatLlmSession {
                     &combined,
                 )
             }
-        }
-    }
-}
-
-pub(crate) struct LlmSession(LlmSessionKind);
-
-enum LlmSessionKind {
-    Conservative(ConservativeLlmSession),
-    Preheat(PreheatLlmSession),
-}
-
-impl LlmSession {
-    pub(crate) fn push_stable_chunk(&mut self, text: &str) {
-        match &mut self.0 {
-            LlmSessionKind::Conservative(session) => session.push_stable_chunk(text),
-            LlmSessionKind::Preheat(session) => session.push_stable_chunk(text),
-        }
-    }
-
-    pub(crate) fn finish(&mut self) -> Result<String, PostProcessError> {
-        match &mut self.0 {
-            LlmSessionKind::Conservative(session) => session.finish(),
-            LlmSessionKind::Preheat(session) => session.finish(),
         }
     }
 }

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -1,7 +1,7 @@
 mod llm;
 
 use crate::core::config::{ApiAuth, ConfigKey, PostProcessSection, ValidationIssue};
-use llm::{LlmPostProcessor, LlmSession};
+use llm::LlmPostProcessor;
 use std::fmt;
 use tracing::warn;
 
@@ -134,66 +134,66 @@ impl From<serde_json::Error> for PostProcessError {
 ///
 /// LLM client construction falls back to pass-through behavior because cleanup
 /// is optional and must not make speech-to-text unavailable.
-pub struct PostProcessor(PostProcessorKind);
+pub struct PostProcessor(Box<dyn TextPostProcessor>);
 
-enum PostProcessorKind {
-    Noop,
-    Llm(LlmPostProcessor),
+/// Text-cleanup behavior selected once from the validated runtime config.
+trait TextPostProcessor: Send + Sync {
+    fn process(&self, text: &str) -> Result<String, PostProcessError>;
+    fn start_session(&self) -> Box<dyn TextPostProcessorSession>;
+}
+
+/// Mutable cleanup state owned by one recording session.
+trait TextPostProcessorSession: Send {
+    fn push_stable_chunk(&mut self, text: &str);
+    fn finish(&mut self) -> Result<String, PostProcessError>;
 }
 
 impl PostProcessor {
     pub fn new(config: PostProcessConfig) -> Self {
-        match config {
-            PostProcessConfig::Disabled => Self(PostProcessorKind::Noop),
+        let processor: Box<dyn TextPostProcessor> = match config {
+            PostProcessConfig::Disabled => Box::new(NoopPostProcessor),
             PostProcessConfig::Llm(config) => match LlmPostProcessor::new(config) {
-                Ok(processor) => Self(PostProcessorKind::Llm(processor)),
+                Ok(processor) => Box::new(processor),
                 Err(error) => {
                     warn!(error = %error, "Failed to create LLM post-processor, falling back to noop");
-                    Self(PostProcessorKind::Noop)
+                    Box::new(NoopPostProcessor)
                 }
             },
-        }
+        };
+        Self(processor)
     }
 
     pub fn process(&self, text: &str) -> Result<String, PostProcessError> {
-        match &self.0 {
-            PostProcessorKind::Noop => Ok(text.to_string()),
-            PostProcessorKind::Llm(processor) => processor.process(text),
-        }
+        self.0.process(text)
     }
 
     pub fn start_session(&self) -> PostProcessorSession {
-        let session = match &self.0 {
-            PostProcessorKind::Noop => PostProcessorSessionKind::Noop(NoopSession::default()),
-            PostProcessorKind::Llm(processor) => {
-                PostProcessorSessionKind::Llm(Box::new(processor.start_session()))
-            }
-        };
-        PostProcessorSession(session)
+        PostProcessorSession(self.0.start_session())
     }
 }
 
 /// Incremental cleanup state for one recording session.
-pub struct PostProcessorSession(PostProcessorSessionKind);
-
-enum PostProcessorSessionKind {
-    Noop(NoopSession),
-    Llm(Box<LlmSession>),
-}
+pub struct PostProcessorSession(Box<dyn TextPostProcessorSession>);
 
 impl PostProcessorSession {
     pub fn push_stable_chunk(&mut self, text: &str) {
-        match &mut self.0 {
-            PostProcessorSessionKind::Noop(session) => session.push_stable_chunk(text),
-            PostProcessorSessionKind::Llm(session) => session.push_stable_chunk(text),
-        }
+        self.0.push_stable_chunk(text);
     }
 
     pub fn finish(&mut self) -> Result<String, PostProcessError> {
-        match &mut self.0 {
-            PostProcessorSessionKind::Noop(session) => Ok(session.finish()),
-            PostProcessorSessionKind::Llm(session) => session.finish(),
-        }
+        self.0.finish()
+    }
+}
+
+struct NoopPostProcessor;
+
+impl TextPostProcessor for NoopPostProcessor {
+    fn process(&self, text: &str) -> Result<String, PostProcessError> {
+        Ok(text.to_string())
+    }
+
+    fn start_session(&self) -> Box<dyn TextPostProcessorSession> {
+        Box::new(NoopSession::default())
     }
 }
 
@@ -202,15 +202,15 @@ struct NoopSession {
     chunks: Vec<String>,
 }
 
-impl NoopSession {
+impl TextPostProcessorSession for NoopSession {
     fn push_stable_chunk(&mut self, text: &str) {
         if !text.is_empty() {
             self.chunks.push(text.to_string());
         }
     }
 
-    fn finish(&mut self) -> String {
-        self.chunks.join("")
+    fn finish(&mut self) -> Result<String, PostProcessError> {
+        Ok(self.chunks.join(""))
     }
 }
 


### PR DESCRIPTION
## Summary

- replace repeated `PostProcessorKind` and session enum matching with private processor/session traits
- implement the processor trait for noop and LLM cleanup strategies
- implement the session trait for noop, conservative LLM, and preheat LLM sessions
- keep the existing public facades and runtime behavior unchanged
- update the postprocess architecture documentation

## Validation

- `cargo fmt --check`
- `cargo test` (113 passed)
- `cargo clippy --all-targets -- -D warnings`