### PR TITLE
重构：显式且轻量的录音状态转换

### DIFF
--- a/changelog
+++ b/changelog
@@ -30,3 +30,4 @@
 2026-08-01: Bound STT chunk retries to a fixed 5-second request timeout and three retries, keeping the worst-case retry window below 30 seconds
 2026-08-01: Replace temporary WAV chunk files with shared in-memory WavChunk payloads for live recording and streaming offline conversion
 2026-08-02: Internalize chunk, STT retry, and session convergence policies; remove unused provider metadata and reject retired fields outside the current canonical v2 config
+2026-08-02: Centralize recording lifecycle changes behind one Session routing gate and an explicit state/event transition table with a lightweight rejected-event log path

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -88,10 +88,15 @@ session or reach a newer session.
 - `Starting`: recorder/orchestrator startup is in progress
 - `Recording`: one session is accepting audio chunks
 - `Stopping`: recorder stop or orchestrator convergence is in progress
-- `Recovering`: an inconsistent lower-layer state is being cancelled
 - `ShuttingDown`: new controls are ignored while cleanup effects run
 
 Every accepted start receives a monotonically increasing `SessionId`. The ID is propagated through recorder operations, ready chunks, orchestrator routing, effects, and completion events. Stale chunks are deleted and stale completions cannot mutate the current session.
+
+### Explicit Transition Table
+
+`RecordingSessionMachine::handle` is the only state-writing entry point. It first compares the event's routing `SessionId` with the active state once, then delegates matching events to one private `(RecordingState, SessionEvent)` match that lists every accepted state/phase path and returns the complete next state plus ordered effects. A multi-ID outcome such as `RecorderAlreadyRecording` routes by its requested session ID while retaining the observed lower-layer ID for cleanup. Events rejected by either layer leave the state unchanged, emit no effects, and produce one compact debug record containing only the current state, event name, and optional routing ID.
+
+An orphan recorder discovered during startup transitions directly back to `Idle` with cancellation effects. There is no transient `Recovering` state because the previous value was assigned and cleared inside one `handle` call and could never be observed.
 
 ### Event/Effect Boundary
 

--- a/docs/plan/21-lightweight-recording-transitions.md
+++ b/docs/plan/21-lightweight-recording-transitions.md
@@ -1,0 +1,191 @@
+# 21 - 显式且轻量的录音状态转换
+
+## 状态
+
+已实现。统一 Session 路由门、显式转换表、单一状态写入口、统一拒绝日志和
+`Recovering` 清理均已完成；聚焦测试、完整测试、格式检查和 Clippy 全部通过。
+
+## 目标
+
+将 `RecordingSessionMachine` 收敛为一个显式、有限、单入口的运行时状态机，并保持实现
+简单：
+
+1. 状态只能沿代码中明确列出的有限路径转换，其他事件统一进入异常处理。
+2. `handle(SessionEvent)` 是外部改变状态的唯一入口。
+3. 不引入 typestate、每状态事件类型或复杂的转换结果层。
+4. 被拒绝的事件只做轻量日志记录，不影响正常流程。
+
+本次重构保持现有录音生命周期、Effect 顺序和用户行为不变。
+
+## 非目标
+
+- 使用 typestate 泛型替换运行时 `RecordingState`。
+- 为每个状态定义独立的事件枚举和 `TryFrom<SessionEvent>` 转换。
+- 增加 `SessionTransition`、`TransitionOutcome` 或 `IgnoreReason` 等公共结果类型。
+- 修改 Hold、Toggle 或托盘控制语义。
+- 修改 Recorder、Orchestrator、转写、后处理或文本注入行为。
+- 增加异步清理确认协议、指标、持久化诊断或新配置项。
+
+## 设计原则
+
+### 1. 保留一个外部状态写入口
+
+`RecordingSessionMachine` 对外继续只暴露：
+
+```rust
+pub fn state(&self) -> &RecordingState;
+
+pub fn handle(&mut self, event: SessionEvent) -> Vec<SessionEffect>;
+```
+
+`state()` 只提供只读观察；所有状态更新都由 `handle(event)` 完成。状态字段保持私有，
+不增加公开 setter，也不让 `main.rs`、热键、托盘、Recorder 或 Orchestrator 直接修改
+状态。
+
+`handle` 的返回类型保持不变，因此 `drive_session` 和 Effect 执行循环不需要增加新的
+协议或分支。
+
+### 2. 使用一个私有显式转换表
+
+状态机内部增加一个私有、无日志副作用的转换函数。它消费当前状态和一个事件，只在
+匹配明确允许的路径时返回下一状态和 Effect：
+
+```rust
+struct Transition {
+    next: RecordingState,
+    effects: Vec<SessionEffect>,
+}
+
+fn transition(
+    state: RecordingState,
+    event: SessionEvent,
+    next_session_id: &mut u64,
+) -> Option<Transition> {
+    match (state, event) {
+        // 每个允许路径都是一个显式 match arm。
+
+        _ => None,
+    }
+}
+```
+
+`RecordingState` 只包含可复制的小值字段，可派生 `Copy`。`transition` 因此可以取得当前
+状态的值，而只有 `handle` 会把成功转换产生的 `next` 写回 `self.state`。
+
+`handle` 在进入转换表前，统一比较当前活动 Session ID 与事件摘要中的路由 Session
+ID。两者都存在且不相等时直接进入通用拒绝出口；匹配后，转换表只负责状态、阶段和事件
+种类，不在每个分支重复 Session ID guard。`RecorderAlreadyRecording` 等多 ID 事件使用
+requested ID 路由，observed active ID 只用于生成下层清理 Effect。
+
+不增加独立的 `accepts(event)` 预检查，因为那会与真正的转换表重复维护同一套规则。
+一个 match 同时负责“是否允许”和“允许后如何转换”。
+
+### 3. 明确列出所有允许路径
+
+私有转换表只包含以下生命周期路径：
+
+| 当前状态 | 接受事件 | 下一状态 |
+| --- | --- | --- |
+| `Idle` | `Start` / `Toggle` | `Starting(Recorder)` |
+| `Starting(Recorder)` | 匹配 ID 的 `RecorderStarted` | `Starting(Orchestrator)` |
+| `Starting(Recorder)` | 匹配 ID 的 Recorder 启动失败 | `Idle`，并执行现有清理 Effect |
+| `Starting(Orchestrator)` | 匹配 ID 的 `OrchestratorStarted` | `Recording` |
+| `Starting(Orchestrator)` | 匹配 ID 的 Orchestrator 启动失败 | `Idle`，并执行现有清理 Effect |
+| `Recording` | 匹配 ID 的 `ChunkReady` | 保持 `Recording` 并提交 chunk |
+| `Recording` | 当前模式允许的 `Stop` / `Toggle` | `Stopping(Recorder)` |
+| `Stopping(Recorder)` | 匹配 ID 的 `RecorderStopped` / `RecorderNotRecording` | `Stopping(Orchestrator)` |
+| `Stopping(Recorder)` | 匹配 ID 的 `RecorderStillRecording` | 回到 `Recording` |
+| `Stopping(Orchestrator)` | 匹配 ID 的 `OrchestratorFinished` | `Idle` |
+| 除 `ShuttingDown` 外的任意状态 | `ShutdownRequested` | `ShuttingDown` |
+
+session ID 不匹配由统一路由门拒绝；阶段不匹配、当前模式不接受的控制、重复控制及关闭
+后的任何事件不会出现在允许路径中，并统一落入最后的 `_ => None`。两层拒绝都回到
+`handle` 的同一个异常出口。
+
+### 4. 删除没有持久语义的 `Recovering` 状态
+
+当前 `RecorderAlreadyRecording` 分支先把状态设为 `Recovering`，随后在同一次
+`handle()` 调用内立即改回 `Idle`，外部永远观察不到 `Recovering`。这不是一个真实的
+生命周期状态，反而让有限转换路径更难理解。
+
+本次重构删除 `RecordingState::Recovering`。对应异常仍然从 `Starting` 直接转换到
+`Idle`，并保持当前 `CancelRecorder`、`AbortOrchestrator` 和托盘重置 Effect 的顺序。
+这只去除不可观察的中间赋值，不改变运行行为。
+
+### 5. 一个通用的轻量异常处理出口
+
+`handle` 在调用私有转换函数前，从事件取得一个不包含载荷的摘要；摘要中的可选 ID
+同时用于统一 Session 路由：
+
+```rust
+fn summary(&self) -> (&'static str, Option<SessionId>);
+```
+
+转换成功时，`handle` 写入下一状态并返回 Effect。转换返回 `None` 时，`handle` 保持状态
+不变，输出一条 `debug!` 日志，然后返回空 Effect：
+
+```rust
+debug!(
+    state = ?self.state,
+    event,
+    session_id = ?session_id,
+    "Recording session event rejected",
+);
+```
+
+摘要只记录事件名称和可选 session ID，不格式化 `WavChunk`、错误正文或其他大载荷。
+所有异常路径共用这一处逻辑，不增加原因枚举，也不让调用方处理被拒绝事件。
+
+已接受但没有 Effect 的转换，例如 `OrchestratorFinished -> Idle`，仍通过
+`Some(Transition { effects: Vec::new(), ... })` 表示，因此不会被错误地记录为异常。
+
+## 文件改动
+
+| 文件 | 计划改动 |
+| --- | --- |
+| `src/core/recording_session.rs` | 增加统一 Session 路由门、私有显式转换表和事件摘要，删除无持久语义的 `Recovering`，统一记录被拒绝事件，并更新测试。 |
+| `docs/architecture/core.md` | 记录单入口、显式允许路径和统一异常出口。 |
+| `docs/plan/21-lightweight-recording-transitions.md` | 记录获批设计，并在实现后更新状态。 |
+| `changelog` | 记录不改变行为的状态机结构简化。 |
+
+`src/main.rs`、依赖和配置均不计划修改。
+
+## 测试驱动的实现顺序
+
+获得明确的计划批准后：
+
+1. 先增加聚焦测试，证明允许路径能够转换到预期状态并保持现有 Effect 顺序。
+2. 增加拒绝路径测试，证明 session ID 不匹配、阶段不匹配、不接受的控制和关闭后事件
+   都保持原状态且不产生 Effect。
+3. 增加回归测试，证明已接受但没有 Effect 的 `OrchestratorFinished` 能正常进入
+   `Idle`，不会与拒绝路径混淆。
+4. 实现统一 Session 路由、私有 `Transition`、显式 `(state, event)` 转换表和通用异常出口，使测试通过。
+5. 删除不可观察的 `Recovering` 状态，并保持对应清理 Effect 不变。
+6. 更新架构文档、本计划状态和 `changelog`。
+7. 运行格式检查、聚焦测试、完整测试、拒绝警告的 Clippy，以及最终 diff 检查。
+
+日志本身不做脆弱的文本匹配测试；测试状态和 Effect 结果即可证明异常出口不会改变业务
+行为。
+
+## 验证方式
+
+```bash
+cargo fmt --check
+cargo test core::recording_session::tests
+cargo test
+cargo clippy -- -D warnings
+```
+
+测试保持确定性并独立于平台，不访问麦克风、托盘、网络或真实计时。
+
+## 验收标准
+
+- `handle(SessionEvent)` 是外部改变录音状态的唯一方法。
+- Session ID 只在进入转换表前统一比较一次，多 ID 事件明确选择路由 ID。
+- 每一条允许的状态转换都在一个私有 `(state, event)` match 中显式列出。
+- 未列出的路径统一保持状态不变、返回空 Effect，并产生一条轻量 debug 日志。
+- 日志只包含当前状态、事件名称和可选 session ID，不包含音频或错误大载荷。
+- `Recovering` 不再作为不可观察的伪状态存在。
+- 已有允许路径、Effect 顺序和用户行为保持不变。
+- 不增加公共转换结果类型、不修改 `drive_session`，也不引入 typestate。
+- 聚焦测试、完整测试、格式检查和 Clippy 全部通过。

--- a/src/core/recording_session.rs
+++ b/src/core/recording_session.rs
@@ -1,4 +1,5 @@
 use crate::audio::WavChunk;
+use tracing::debug;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SessionId(pub u64);
@@ -41,7 +42,7 @@ pub enum StopPhase {
     Orchestrator,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordingState {
     Idle,
     Starting {
@@ -60,9 +61,6 @@ pub enum RecordingState {
         mode: SessionMode,
         source: ControlSource,
         phase: StopPhase,
-    },
-    Recovering {
-        session_id: Option<SessionId>,
     },
     ShuttingDown {
         session_id: Option<SessionId>,
@@ -142,6 +140,51 @@ pub enum SessionEffect {
     ReadyToExit,
 }
 
+impl SessionEvent {
+    fn summary(&self) -> (&'static str, Option<SessionId>) {
+        match self {
+            Self::Control(ControlEvent { action, .. }) => {
+                let name = match action {
+                    ControlAction::Start(_) => "control_start",
+                    ControlAction::Stop => "control_stop",
+                    ControlAction::Toggle(_) => "control_toggle",
+                };
+                (name, None)
+            }
+            Self::RecorderStarted { session_id } => ("recorder_started", Some(*session_id)),
+            Self::RecorderStartFailed { session_id, .. } => {
+                ("recorder_start_failed", Some(*session_id))
+            }
+            Self::RecorderAlreadyRecording {
+                requested_session_id,
+                ..
+            } => ("recorder_already_recording", Some(*requested_session_id)),
+            Self::OrchestratorStarted { session_id } => ("orchestrator_started", Some(*session_id)),
+            Self::OrchestratorStartFailed {
+                requested_session_id,
+                ..
+            } => ("orchestrator_start_failed", Some(*requested_session_id)),
+            Self::ChunkReady { session_id, .. } => ("chunk_ready", Some(*session_id)),
+            Self::RecorderStopped { session_id, .. } => ("recorder_stopped", Some(*session_id)),
+            Self::RecorderStillRecording { session_id, .. } => {
+                ("recorder_still_recording", Some(*session_id))
+            }
+            Self::RecorderNotRecording { session_id } => {
+                ("recorder_not_recording", Some(*session_id))
+            }
+            Self::OrchestratorFinished { session_id } => {
+                ("orchestrator_finished", Some(*session_id))
+            }
+            Self::ShutdownRequested => ("shutdown_requested", None),
+        }
+    }
+}
+
+struct Transition {
+    next: RecordingState,
+    effects: Vec<SessionEffect>,
+}
+
 pub struct RecordingSessionMachine {
     state: RecordingState,
     next_session_id: u64,
@@ -165,260 +208,293 @@ impl RecordingSessionMachine {
         &self.state
     }
 
+    /// Apply one external or lower-layer event to the recording lifecycle.
+    ///
+    /// This is the machine's only state-writing entry point. Events outside the
+    /// explicit transition table are logged and leave the current state unchanged.
     pub fn handle(&mut self, event: SessionEvent) -> Vec<SessionEffect> {
-        if matches!(self.state, RecordingState::ShuttingDown { .. }) {
+        let (event_name, routing_session_id) = event.summary();
+        let session_mismatch = matches!(
+            (active_session_id(self.state), routing_session_id),
+            (Some(active), Some(routed)) if active != routed
+        );
+        let transition = if session_mismatch {
+            None
+        } else {
+            transition(self.state, event, &mut self.next_session_id)
+        };
+        let Some(transition) = transition else {
+            debug!(
+                state = ?self.state,
+                event = event_name,
+                session_id = ?routing_session_id.map(|id| id.0),
+                "Recording session event rejected"
+            );
             return Vec::new();
-        }
+        };
 
-        if matches!(event, SessionEvent::ShutdownRequested) {
-            return self.shutdown();
-        }
-
-        match event {
-            SessionEvent::Control(control) => self.handle_control(control),
-            SessionEvent::RecorderStarted { session_id } => {
-                let RecordingState::Starting {
-                    session_id: active_id,
-                    mode,
-                    phase: StartPhase::Recorder,
-                    ..
-                } = self.state
-                else {
-                    return Vec::new();
-                };
-                if session_id != active_id {
-                    return Vec::new();
-                }
-                if let RecordingState::Starting { phase, .. } = &mut self.state {
-                    *phase = StartPhase::Orchestrator;
-                }
-                vec![SessionEffect::StartOrchestrator { session_id, mode }]
-            }
-            SessionEvent::RecorderStartFailed { session_id, .. } => {
-                if self.matches_start(session_id) {
-                    self.state = RecordingState::Idle;
-                    vec![SessionEffect::SetTrayRecording(false)]
-                } else {
-                    Vec::new()
-                }
-            }
-            SessionEvent::RecorderAlreadyRecording {
-                requested_session_id,
-                active_session_id,
-            } => {
-                if !self.matches_start(requested_session_id) {
-                    return Vec::new();
-                }
-                self.state = RecordingState::Recovering {
-                    session_id: Some(active_session_id),
-                };
-                let effects = vec![
-                    SessionEffect::CancelRecorder {
-                        session_id: active_session_id,
-                    },
-                    SessionEffect::AbortOrchestrator {
-                        session_id: active_session_id,
-                    },
-                    SessionEffect::SetTrayRecording(false),
-                ];
-                self.state = RecordingState::Idle;
-                effects
-            }
-            SessionEvent::OrchestratorStarted { session_id } => {
-                let RecordingState::Starting {
-                    session_id: active_id,
-                    mode,
-                    source,
-                    phase: StartPhase::Orchestrator,
-                } = self.state
-                else {
-                    return Vec::new();
-                };
-                if session_id != active_id {
-                    return Vec::new();
-                }
-                self.state = RecordingState::Recording {
-                    session_id,
-                    mode,
-                    source,
-                };
-                vec![SessionEffect::SetTrayRecording(true)]
-            }
-            SessionEvent::OrchestratorStartFailed {
-                requested_session_id,
-                active_session_id,
-                ..
-            } => {
-                if !self.matches_start(requested_session_id) {
-                    return Vec::new();
-                }
-                self.state = RecordingState::Idle;
-                vec![
-                    SessionEffect::CancelRecorder {
-                        session_id: requested_session_id,
-                    },
-                    SessionEffect::AbortOrchestrator {
-                        session_id: active_session_id.unwrap_or(requested_session_id),
-                    },
-                    SessionEffect::SetTrayRecording(false),
-                ]
-            }
-            SessionEvent::ChunkReady { session_id, chunk } => {
-                if self.active_session_id() == Some(session_id)
-                    && matches!(self.state, RecordingState::Recording { .. })
-                {
-                    vec![SessionEffect::SubmitChunk { session_id, chunk }]
-                } else {
-                    Vec::new()
-                }
-            }
-            SessionEvent::RecorderStopped {
-                session_id, chunks, ..
-            } => self.recorder_stopped(session_id, chunks),
-            SessionEvent::RecorderNotRecording { session_id } => {
-                self.recorder_stopped(session_id, Vec::new())
-            }
-            SessionEvent::RecorderStillRecording { session_id, .. } => {
-                let RecordingState::Stopping {
-                    session_id: active_id,
-                    mode,
-                    source,
-                    phase: StopPhase::Recorder,
-                } = self.state
-                else {
-                    return Vec::new();
-                };
-                if session_id != active_id {
-                    return Vec::new();
-                }
-                self.state = RecordingState::Recording {
-                    session_id,
-                    mode,
-                    source,
-                };
-                vec![SessionEffect::SetTrayRecording(true)]
-            }
-            SessionEvent::OrchestratorFinished { session_id } => {
-                let RecordingState::Stopping {
-                    session_id: active_id,
-                    phase: StopPhase::Orchestrator,
-                    ..
-                } = self.state
-                else {
-                    return Vec::new();
-                };
-                if session_id != active_id {
-                    return Vec::new();
-                }
-                self.state = RecordingState::Idle;
-                Vec::new()
-            }
-            SessionEvent::ShutdownRequested => unreachable!(),
-        }
+        self.state = transition.next;
+        transition.effects
     }
+}
 
-    fn handle_control(&mut self, control: ControlEvent) -> Vec<SessionEffect> {
-        match self.state {
-            RecordingState::Idle => match control.action {
-                ControlAction::Start(mode) | ControlAction::Toggle(mode) => {
-                    let session_id = SessionId(self.next_session_id);
-                    self.next_session_id += 1;
-                    self.state = RecordingState::Starting {
-                        session_id,
-                        mode,
-                        source: control.source,
-                        phase: StartPhase::Recorder,
-                    };
-                    vec![SessionEffect::StartRecorder { session_id }]
-                }
-                ControlAction::Stop => Vec::new(),
+/// Enumerate every event that may change or act on the recording lifecycle.
+/// The caller validates session routing first; events not represented by a
+/// state/phase match arm are then rejected without mutating the current state.
+fn transition(
+    state: RecordingState,
+    event: SessionEvent,
+    next_session_id: &mut u64,
+) -> Option<Transition> {
+    match (state, event) {
+        (RecordingState::ShuttingDown { .. }, _) => None,
+        (state, SessionEvent::ShutdownRequested) => Some(shutdown_transition(state)),
+        (
+            RecordingState::Idle,
+            SessionEvent::Control(ControlEvent {
+                source,
+                action: ControlAction::Start(mode) | ControlAction::Toggle(mode),
+            }),
+        ) => {
+            let session_id = SessionId(*next_session_id);
+            *next_session_id += 1;
+            Some(Transition {
+                next: RecordingState::Starting {
+                    session_id,
+                    mode,
+                    source,
+                    phase: StartPhase::Recorder,
+                },
+                effects: vec![SessionEffect::StartRecorder { session_id }],
+            })
+        }
+        (
+            RecordingState::Starting {
+                session_id,
+                mode,
+                source,
+                phase: StartPhase::Recorder,
             },
+            SessionEvent::RecorderStarted { .. },
+        ) => Some(Transition {
+            next: RecordingState::Starting {
+                session_id,
+                mode,
+                source,
+                phase: StartPhase::Orchestrator,
+            },
+            effects: vec![SessionEffect::StartOrchestrator { session_id, mode }],
+        }),
+        (
+            RecordingState::Starting {
+                phase: StartPhase::Recorder,
+                ..
+            },
+            SessionEvent::RecorderStartFailed { .. },
+        ) => Some(Transition {
+            next: RecordingState::Idle,
+            effects: vec![SessionEffect::SetTrayRecording(false)],
+        }),
+        (
+            RecordingState::Starting {
+                phase: StartPhase::Recorder,
+                ..
+            },
+            SessionEvent::RecorderAlreadyRecording {
+                active_session_id, ..
+            },
+        ) => Some(Transition {
+            next: RecordingState::Idle,
+            effects: vec![
+                SessionEffect::CancelRecorder {
+                    session_id: active_session_id,
+                },
+                SessionEffect::AbortOrchestrator {
+                    session_id: active_session_id,
+                },
+                SessionEffect::SetTrayRecording(false),
+            ],
+        }),
+        (
+            RecordingState::Starting {
+                session_id,
+                mode,
+                source,
+                phase: StartPhase::Orchestrator,
+            },
+            SessionEvent::OrchestratorStarted { .. },
+        ) => Some(Transition {
+            next: RecordingState::Recording {
+                session_id,
+                mode,
+                source,
+            },
+            effects: vec![SessionEffect::SetTrayRecording(true)],
+        }),
+        (
+            RecordingState::Starting {
+                session_id,
+                phase: StartPhase::Orchestrator,
+                ..
+            },
+            SessionEvent::OrchestratorStartFailed {
+                active_session_id, ..
+            },
+        ) => Some(Transition {
+            next: RecordingState::Idle,
+            effects: vec![
+                SessionEffect::CancelRecorder { session_id },
+                SessionEffect::AbortOrchestrator {
+                    session_id: active_session_id.unwrap_or(session_id),
+                },
+                SessionEffect::SetTrayRecording(false),
+            ],
+        }),
+        (
+            state @ RecordingState::Recording { session_id, .. },
+            SessionEvent::ChunkReady { chunk, .. },
+        ) => Some(Transition {
+            next: state,
+            effects: vec![SessionEffect::SubmitChunk { session_id, chunk }],
+        }),
+        (
             RecordingState::Recording {
                 session_id,
                 mode,
                 source,
-            } => {
-                let should_stop = matches!(control.action, ControlAction::Toggle(_))
-                    || (matches!(control.action, ControlAction::Stop)
-                        && control.source == ControlSource::HoldHotkey
-                        && mode == SessionMode::Hold);
-                if !should_stop {
-                    return Vec::new();
-                }
-                self.state = RecordingState::Stopping {
-                    session_id,
-                    mode,
-                    source,
-                    phase: StopPhase::Recorder,
-                };
-                vec![SessionEffect::StopRecorder { session_id }]
-            }
-            _ => Vec::new(),
-        }
-    }
-
-    fn recorder_stopped(
-        &mut self,
-        session_id: SessionId,
-        chunks: Vec<WavChunk>,
-    ) -> Vec<SessionEffect> {
-        let RecordingState::Stopping {
-            session_id: active_id,
-            phase: StopPhase::Recorder,
-            ..
-        } = self.state
-        else {
-            return Vec::new();
-        };
-        if session_id != active_id {
-            return Vec::new();
-        }
-        if let RecordingState::Stopping { phase, .. } = &mut self.state {
-            *phase = StopPhase::Orchestrator;
-        }
-        let mut effects = Vec::with_capacity(chunks.len() + 2);
-        effects.push(SessionEffect::SetTrayRecording(false));
-        effects.extend(
-            chunks
-                .into_iter()
-                .map(|chunk| SessionEffect::SubmitChunk { session_id, chunk }),
-        );
-        effects.push(SessionEffect::FinishOrchestrator { session_id });
-        effects
-    }
-
-    fn shutdown(&mut self) -> Vec<SessionEffect> {
-        let session_id = self.active_session_id();
-        self.state = RecordingState::ShuttingDown { session_id };
-        let mut effects = Vec::new();
-        if let Some(session_id) = session_id {
-            effects.push(SessionEffect::CancelRecorder { session_id });
-            effects.push(SessionEffect::AbortOrchestrator { session_id });
-        }
-        effects.push(SessionEffect::SetTrayRecording(false));
-        effects.push(SessionEffect::ReadyToExit);
-        effects
-    }
-
-    fn active_session_id(&self) -> Option<SessionId> {
-        match self.state {
-            RecordingState::Starting { session_id, .. }
-            | RecordingState::Recording { session_id, .. }
-            | RecordingState::Stopping { session_id, .. } => Some(session_id),
-            RecordingState::Recovering { session_id }
-            | RecordingState::ShuttingDown { session_id } => session_id,
-            RecordingState::Idle => None,
-        }
-    }
-
-    fn matches_start(&self, session_id: SessionId) -> bool {
-        matches!(
-            self.state,
-            RecordingState::Starting {
-                session_id: active_id,
+            },
+            SessionEvent::Control(ControlEvent {
+                action: ControlAction::Toggle(_),
                 ..
-            } if active_id == session_id
-        )
+            }),
+        ) => Some(stop_transition(session_id, mode, source)),
+        (
+            RecordingState::Recording {
+                session_id,
+                mode: SessionMode::Hold,
+                source,
+            },
+            SessionEvent::Control(ControlEvent {
+                source: ControlSource::HoldHotkey,
+                action: ControlAction::Stop,
+            }),
+        ) => Some(stop_transition(session_id, SessionMode::Hold, source)),
+        (
+            RecordingState::Stopping {
+                session_id,
+                mode,
+                source,
+                phase: StopPhase::Recorder,
+            },
+            SessionEvent::RecorderStopped { chunks, .. },
+        ) => Some(recorder_stopped_transition(
+            session_id, mode, source, chunks,
+        )),
+        (
+            RecordingState::Stopping {
+                session_id,
+                mode,
+                source,
+                phase: StopPhase::Recorder,
+            },
+            SessionEvent::RecorderNotRecording { .. },
+        ) => Some(recorder_stopped_transition(
+            session_id,
+            mode,
+            source,
+            Vec::new(),
+        )),
+        (
+            RecordingState::Stopping {
+                session_id,
+                mode,
+                source,
+                phase: StopPhase::Recorder,
+            },
+            SessionEvent::RecorderStillRecording { .. },
+        ) => Some(Transition {
+            next: RecordingState::Recording {
+                session_id,
+                mode,
+                source,
+            },
+            effects: vec![SessionEffect::SetTrayRecording(true)],
+        }),
+        (
+            RecordingState::Stopping {
+                phase: StopPhase::Orchestrator,
+                ..
+            },
+            SessionEvent::OrchestratorFinished { .. },
+        ) => Some(Transition {
+            next: RecordingState::Idle,
+            effects: Vec::new(),
+        }),
+        _ => None,
+    }
+}
+
+fn stop_transition(session_id: SessionId, mode: SessionMode, source: ControlSource) -> Transition {
+    Transition {
+        next: RecordingState::Stopping {
+            session_id,
+            mode,
+            source,
+            phase: StopPhase::Recorder,
+        },
+        effects: vec![SessionEffect::StopRecorder { session_id }],
+    }
+}
+
+fn recorder_stopped_transition(
+    session_id: SessionId,
+    mode: SessionMode,
+    source: ControlSource,
+    chunks: Vec<WavChunk>,
+) -> Transition {
+    let mut effects = Vec::with_capacity(chunks.len() + 2);
+    effects.push(SessionEffect::SetTrayRecording(false));
+    effects.extend(
+        chunks
+            .into_iter()
+            .map(|chunk| SessionEffect::SubmitChunk { session_id, chunk }),
+    );
+    effects.push(SessionEffect::FinishOrchestrator { session_id });
+
+    Transition {
+        next: RecordingState::Stopping {
+            session_id,
+            mode,
+            source,
+            phase: StopPhase::Orchestrator,
+        },
+        effects,
+    }
+}
+
+fn shutdown_transition(state: RecordingState) -> Transition {
+    let session_id = active_session_id(state);
+    let mut effects = Vec::new();
+    if let Some(session_id) = session_id {
+        effects.push(SessionEffect::CancelRecorder { session_id });
+        effects.push(SessionEffect::AbortOrchestrator { session_id });
+    }
+    effects.push(SessionEffect::SetTrayRecording(false));
+    effects.push(SessionEffect::ReadyToExit);
+
+    Transition {
+        next: RecordingState::ShuttingDown { session_id },
+        effects,
+    }
+}
+
+fn active_session_id(state: RecordingState) -> Option<SessionId> {
+    match state {
+        RecordingState::Starting { session_id, .. }
+        | RecordingState::Recording { session_id, .. }
+        | RecordingState::Stopping { session_id, .. } => Some(session_id),
+        RecordingState::ShuttingDown { session_id } => session_id,
+        RecordingState::Idle => None,
     }
 }
 
@@ -435,6 +511,79 @@ mod tests {
             source,
             action: ControlAction::Toggle(SessionMode::Toggle),
         })
+    }
+
+    #[test]
+    fn explicit_transition_table_rejects_unlisted_paths() {
+        let mut next_session_id = 2;
+
+        let result = transition(
+            RecordingState::Starting {
+                session_id: SessionId(1),
+                mode: SessionMode::Toggle,
+                source: ControlSource::Tray,
+                phase: StartPhase::Orchestrator,
+            },
+            SessionEvent::RecorderStarted {
+                session_id: SessionId(1),
+            },
+            &mut next_session_id,
+        );
+
+        assert!(result.is_none());
+        assert_eq!(next_session_id, 2);
+    }
+
+    #[test]
+    fn explicit_transition_table_accepts_applied_zero_effect_path() {
+        // Finishing convergence changes lifecycle state even though the runtime has
+        // no follow-up command to execute, so it must not hit the rejection fallback.
+        let mut next_session_id = 2;
+
+        let result = transition(
+            RecordingState::Stopping {
+                session_id: SessionId(1),
+                mode: SessionMode::Toggle,
+                source: ControlSource::Tray,
+                phase: StopPhase::Orchestrator,
+            },
+            SessionEvent::OrchestratorFinished {
+                session_id: SessionId(1),
+            },
+            &mut next_session_id,
+        )
+        .expect("listed transition should be accepted");
+
+        assert_eq!(result.next, RecordingState::Idle);
+        assert!(result.effects.is_empty());
+        assert_eq!(next_session_id, 2);
+    }
+
+    #[test]
+    fn orphan_recorder_routes_by_requested_session_id() {
+        // The requested ID routes the event to this machine; the different active
+        // ID identifies the orphan lower-layer resources that need cleanup.
+        let mut machine = RecordingSessionMachine::new();
+        machine.handle(toggle(ControlSource::Tray));
+
+        let effects = machine.handle(SessionEvent::RecorderAlreadyRecording {
+            requested_session_id: SessionId(1),
+            active_session_id: SessionId(7),
+        });
+
+        assert_eq!(machine.state(), &RecordingState::Idle);
+        assert_eq!(
+            effects,
+            vec![
+                SessionEffect::CancelRecorder {
+                    session_id: SessionId(7),
+                },
+                SessionEffect::AbortOrchestrator {
+                    session_id: SessionId(7),
+                },
+                SessionEffect::SetTrayRecording(false),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
已完成 RecordingSessionMachine 状态机重构：handle(SessionEvent) 保持为唯一外部状态写入口；Session ID 在入口统一路由一次，多 ID 事件按 requested ID 路由、observed active ID 仅用于清理；所有允许路径集中在一个私有 state/event 转换表中；未列出的事件统一记录轻量 debug 日志并忽略；删除不可观察的 Recovering 状态，同时保持原有 Effect 顺序和运行行为。验证结果：状态机测试 10/10、完整测试 116/116、cargo fmt --check 和 cargo clippy -- -D warnings 全部通过；独立 Codex 审查 0 findings。