### PR TITLE
性能：降低监听循环轮询频率

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,7 +364,7 @@ fn run_listener_with_config(mut config: ListenerConfig) -> Result<(), Box<dyn st
             );
         }
 
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
 }
 


### PR DESCRIPTION
## Summary

- increase the listener loop sleep interval from 10ms to 20ms
- reduce idle wake-up frequency while retaining responsive hotkey and tray handling

## Validation

- `cargo fmt --check`
- `cargo test` (116 passed)

This is an interim improvement toward the fully event-driven loop tracked in #89.