### PR TITLE
重构：简化来源无关的录音 Session 事件

### DIFF
--- a/changelog
+++ b/changelog
@@ -31,3 +31,4 @@
 2026-08-01: Replace temporary WAV chunk files with shared in-memory WavChunk payloads for live recording and streaming offline conversion
 2026-08-02: Internalize chunk, STT retry, and session convergence policies; remove unused provider metadata and reject retired fields outside the current canonical v2 config
 2026-08-02: Centralize recording lifecycle changes behind one Session routing gate and an explicit state/event transition table with a lightweight rejected-event log path
+2026-08-02: Normalize hotkey and tray gestures into source-free recording requests; simplify lifecycle state to Session IDs and execute recorder/orchestrator startup and shutdown as composite Session effects

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -80,27 +80,27 @@ session or reach a newer session.
 
 ## Recording Session (`src/core/recording_session.rs`)
 
-`RecordingSessionMachine` is the sole authority for recording lifecycle transitions. Tray and hotkey adapters emit source-tagged `ControlEvent`s and never inspect recorder state directly.
+`RecordingSessionMachine` is the sole authority for recording lifecycle transitions. The listener integration maps source-specific hotkey and tray gestures into source-free `StartRequested` and `StopRequested` events before they enter core.
 
 ### States
 
 - `Idle`
-- `Starting`: recorder/orchestrator startup is in progress
+- `Starting`: the composite recorder/orchestrator startup is in progress
 - `Recording`: one session is accepting audio chunks
-- `Stopping`: recorder stop or orchestrator convergence is in progress
+- `Stopping`: the composite recorder stop, tail-chunk submission, and orchestrator convergence is in progress
 - `ShuttingDown`: new controls are ignored while cleanup effects run
 
-Every accepted start receives a monotonically increasing `SessionId`. The ID is propagated through recorder operations, ready chunks, orchestrator routing, effects, and completion events. Stale chunks are deleted and stale completions cannot mutate the current session.
+The active states carry only a monotonically increasing `SessionId`; input source, interaction mode, and lower-layer phases are not lifecycle state. The ID is propagated through recorder operations, ready chunks, orchestrator routing, effects, and completion events. Stale chunks and stale Session results cannot mutate the current session.
 
 ### Explicit Transition Table
 
-`RecordingSessionMachine::handle` is the only state-writing entry point. It first compares the event's routing `SessionId` with the active state once, then delegates matching events to one private `(RecordingState, SessionEvent)` match that lists every accepted state/phase path and returns the complete next state plus ordered effects. A multi-ID outcome such as `RecorderAlreadyRecording` routes by its requested session ID while retaining the observed lower-layer ID for cleanup. Events rejected by either layer leave the state unchanged, emit no effects, and produce one compact debug record containing only the current state, event name, and optional routing ID.
-
-An orphan recorder discovered during startup transitions directly back to `Idle` with cancellation effects. There is no transient `Recovering` state because the previous value was assigned and cleared inside one `handle` call and could never be observed.
+`RecordingSessionMachine::handle` is the only state-writing entry point. It first compares a result event's routing `SessionId` with the active state once, then delegates matching events to one private `(RecordingState, SessionEvent)` match. The allowed paths are `Idle -> Starting -> Recording -> Stopping -> Idle`, plus chunk submission, failure recovery, and shutdown. Events rejected by either layer leave the state unchanged, emit no effects, and produce one compact debug record containing only the current state, event name, and optional routing ID.
 
 ### Event/Effect Boundary
 
-The machine consumes external controls plus structured recorder/orchestrator outcomes and emits declarative effects. `main.rs` executes those effects and feeds results back as internal events. Tray state changes only after successful lifecycle transitions.
+The machine consumes source-free requests plus `SessionStarted`, `SessionStartFailed`, `SessionStopped`, and `SessionStopFailed` results. It emits composite `StartSession` and `StopSession` effects instead of exposing recorder/orchestrator startup phases.
+
+`main.rs` executes `StartSession` as an all-or-nothing recorder/orchestrator acquisition with rollback. `StopSession` stops the recorder, submits tail chunks in order, finishes orchestrator convergence, and runs the existing post-processing and text-injection path. The state machine changes the tray to idle when it accepts a stop and restores the recording indicator if the recorder remains active.
 
 Exit is represented as `ShutdownRequested`. It cancels recorder/orchestrator work, resets tray state, suppresses final text injection, and exits only after `ReadyToExit` is emitted.
 

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -39,6 +39,19 @@ pub struct HotkeyManager {
 
 Spawns an `rdev::listen` thread that maps native events into an ordered channel. Per-binding key-down state suppresses operating-system key-repeat events so one physical toggle press produces one toggle action.
 
+### Recording Input Normalization
+
+Hotkey and tray source details stop at the listener integration boundary in `main.rs`. The integration reads the session machine's current state without mutating it and publishes only source-free core requests:
+
+| Raw gesture | Idle | Recording | Transitional/shutdown state |
+|---|---|---|---|
+| Hold press | `StartRequested` | ignored | ignored |
+| Hold release | ignored | `StopRequested` | ignored |
+| Toggle press | `StartRequested` | `StopRequested` | ignored |
+| Tray left click | `StartRequested` | `StopRequested` | ignored |
+
+Because the core event carries no source, Hold release, Toggle, and tray input can stop a current session regardless of which input started it. Input modules continue to own native classification, key-repeat suppression, and click debounce; they do not own or copy recording state.
+
 ### Key Methods
 
 **`HotkeyManager::new(config: &HotkeyConfig) -> Self`**

--- a/docs/plan/22-source-agnostic-recording-events.md
+++ b/docs/plan/22-source-agnostic-recording-events.md
@@ -1,0 +1,265 @@
+# 22 - 来源无关的录音事件与 Session 级生命周期
+
+## 状态
+
+已实现。输入归一化、来源无关的 Session 状态/事件、复合启停 Effect、无 mode 的
+Orchestrator API、聚焦测试和架构文档均已完成。
+
+## 背景
+
+当前录音状态机同时承载了两类细节：
+
+1. Hold 热键、Toggle 热键和托盘点击的来源与交互语义；
+2. Recorder 与 Orchestrator 各自的启动、停止阶段和完成事件。
+
+这些细节使同一个用户意图表现为 `Start`、`Stop`、`Toggle` 等不同控制事件，并让
+`RecordingState` 持久化 `source`、`mode`、`StartPhase` 和 `StopPhase`。但输入来源并不
+改变录音 Session 的核心生命周期；`SessionMode` 在 Orchestrator 中也只用于启动日志，
+不影响转写行为。
+
+本计划将平台输入先归一化为来源无关的开始/停止请求，再把 Recorder 与 Orchestrator
+的有序协作封装为 Session 级 Effect。状态机继续是唯一决定生命周期转换的组件，但不再
+知道哪个输入设备触发了请求，也不再逐步建模下层组件的同步调用。
+
+## 目标
+
+1. 核心状态机只接收 `StartRequested` 和 `StopRequested` 两种用户意图。
+2. Hold、Toggle 和托盘来源只保留在输入集成层，不进入 `SessionEvent` 或
+   `RecordingState`。
+3. 不同输入可以停止彼此启动的当前录音，核心层不做来源匹配。
+4. 将 Recorder 与 Orchestrator 的同步启动流程合并为一个原子的 Session 启动 Effect。
+5. 将停止录音、提交尾片、等待转写和最终文本处理合并为一个 Session 停止 Effect。
+6. 删除只用于同步下层步骤的 mode、source 和 phase 状态，同时保留 Session ID 路由、
+   失败恢复、chunk 顺序和关闭清理。
+
+## 非目标
+
+- 不实现完全事件驱动主循环；该工作由 GitHub issue #89 跟踪。
+- 不改变 20ms 主循环间隔、热键配置、托盘防抖或原生事件泵。
+- 不改变音频 chunk 大小、转写重试、收敛超时、后处理或文本注入策略。
+- 不移除 Session ID，也不放宽 Recorder/Orchestrator 的 Session 路由检查。
+- 不引入 async runtime、通用 event bus、typestate 或仅为测试而增加的运行时 trait 层。
+
+## 设计
+
+### 1. 输入来源止步于集成层
+
+`HotkeyEvent`、`HotkeySource` 和 `TrayAction` 继续由 `src/input/` 表达原始输入。`main.rs`
+增加一个私有、无副作用的归一化函数，根据当前稳定状态将原始交互转换为核心请求：
+
+| 原始输入 | `Idle` | `Recording` | 其他状态 |
+| --- | --- | --- | --- |
+| Hold 按下 | `StartRequested` | 丢弃 | 丢弃 |
+| Hold 释放 | 丢弃 | `StopRequested` | 丢弃 |
+| Toggle 按下 | `StartRequested` | `StopRequested` | 丢弃 |
+| 托盘点击 | `StartRequested` | `StopRequested` | 丢弃 |
+
+Toggle 键释放仍由现有热键 mapper 丢弃。按键重复和托盘双击仍分别由现有输入层逻辑
+去重。`ShutdownRequested` 保持独立，不参与开始/停止归一化。
+
+归一化发生在事件从 `HotkeyManager` 或 `TrayManager` 取出时，使用状态机的只读
+`state()` 快照；输入模块不持有或复制录音状态。归一化后，来源不再写入核心事件、状态
+或 Effect。
+
+这一规则有一个明确后果：来源无关的 Hold release 会停止当时正在运行的任何 Session，
+即使该 Session 由 Toggle 或托盘启动。这是允许不同输入互相停止的预期行为。
+
+### 2. 精简核心状态
+
+状态收敛为：
+
+```rust
+pub enum RecordingState {
+    Idle,
+    Starting { session_id: SessionId },
+    Recording { session_id: SessionId },
+    Stopping { session_id: SessionId },
+    ShuttingDown { session_id: Option<SessionId> },
+}
+```
+
+`Starting` 和 `Stopping` 保留，因为它们表达“请求已接受，但 Session 级操作尚未完成”的
+真实业务状态。删除以下只描述同步实现步骤的类型和字段：
+
+- `SessionMode`
+- `ControlSource`
+- `ControlAction`
+- `ControlEvent`
+- `StartPhase`
+- `StopPhase`
+- 状态中的 `mode`、`source` 和 `phase`
+
+### 3. 使用 Session 级事件
+
+核心事件收敛为：
+
+```rust
+pub enum SessionEvent {
+    StartRequested,
+    StopRequested,
+    SessionStarted { session_id: SessionId },
+    SessionStartFailed { session_id: SessionId, error: String },
+    ChunkReady { session_id: SessionId, chunk: WavChunk },
+    SessionStopped { session_id: SessionId },
+    SessionStopFailed { session_id: SessionId, error: String },
+    ShutdownRequested,
+}
+```
+
+`SessionStarted` 表示 Recorder 和 Orchestrator 都已成功启动。`SessionStopped` 表示录音已
+停止、尾片已提交、Orchestrator 已完成收敛，并且最终文本结果已经交给现有后处理/注入
+路径。转写为空或转写失败仍按现有规则记录并结束 Session，不将其误报为 recorder 停止
+失败。
+
+事件摘要继续为带 Session ID 的结果事件执行统一路由。旧 Session 的完成、失败或 chunk
+仍不能改变当前 Session。
+
+### 4. 使用 Session 级 Effect
+
+启动和停止 Effect 合并为：
+
+```rust
+pub enum SessionEffect {
+    StartSession { session_id: SessionId },
+    StopSession { session_id: SessionId },
+    SubmitChunk { session_id: SessionId, chunk: WavChunk },
+    CancelRecorder { session_id: SessionId },
+    AbortOrchestrator { session_id: SessionId },
+    SetTrayRecording(bool),
+    ReadyToExit,
+}
+```
+
+删除 `StartRecorder`、`StartOrchestrator`、`StopRecorder` 和 `FinishOrchestrator`。实时
+`ChunkReady` 仍通过 `SubmitChunk` Effect 进入 Orchestrator；只有 Session 启停内部的
+尾片提交由复合 Effect 按固定顺序完成。
+
+`drive_session` 仍只执行状态机批准的 Effect，并把一个 Session 级结果事件放回本地
+队列。它不自行决定是否允许开始或停止。
+
+### 5. 原子启动与失败回滚
+
+`StartSession` 按以下固定顺序执行：
+
+1. 调用 `recorder.start_recording(session_id)`；
+2. Recorder 成功后调用 `orchestrator.start_session(session_id)`；
+3. 两者均成功时产生 `SessionStarted`；
+4. Recorder 已在运行时，清理其报告的 active Session 及对应 Orchestrator；
+5. Orchestrator 启动失败时，取消刚启动的 Recorder，并清理错误报告的 active
+   Orchestrator；
+6. 任一失败路径完成回滚后产生 `SessionStartFailed`。
+
+因此 `SessionStarted` 是全有或全无的 Session 建立结果。状态机无需处理
+`RecorderStarted`、`RecorderAlreadyRecording`、`OrchestratorStarted` 等组件级事件。
+错误日志继续保留具体失败阶段，公共事件只需要 Session ID 和错误正文。
+
+### 6. 原子停止与现有结果语义
+
+状态机接受 `StopRequested` 时立即进入 `Stopping`，先发出
+`SetTrayRecording(false)`，再发出 `StopSession`。这样托盘在停止和转写收敛期间保持
+空闲显示；如果 recorder 报告仍在录音，`SessionStopFailed` 会让状态机回到
+`Recording` 并恢复红色托盘状态。
+
+`StopSession` 按以下固定顺序执行：
+
+1. 调用 `recorder.stop_recording(session_id)`；
+2. 对 `Stopped` 返回的所有尾片按原顺序调用 `orchestrator.on_chunk_ready`；
+3. `NotRecording` 视为没有额外尾片，但仍完成当前 Orchestrator；
+4. 调用 `orchestrator.finish_session(session_id)`，并通过现有 `finish_transcription`
+   完成后处理和文本注入；
+5. 完成后产生 `SessionStopped`；
+6. 只有 `StillRecording` 产生 `SessionStopFailed`，且不结束 Orchestrator。
+
+停止被接受后托盘会比当前实现最多提前一次同步 `stop_recording` 调用切换为空闲；失败时
+会恢复录音显示。除此之外，尾片顺序、warning 日志、转写错误处理和最终文本注入保持
+不变。
+
+### 7. 简化转换表
+
+允许路径变为：
+
+| 当前状态 | 事件 | 下一状态 | Effect |
+| --- | --- | --- | --- |
+| `Idle` | `StartRequested` | `Starting` | `StartSession` |
+| `Starting` | 匹配的 `SessionStarted` | `Recording` | 托盘设为录音中 |
+| `Starting` | 匹配的 `SessionStartFailed` | `Idle` | 托盘设为空闲 |
+| `Recording` | 匹配的 `ChunkReady` | `Recording` | `SubmitChunk` |
+| `Recording` | `StopRequested` | `Stopping` | 托盘设为空闲、`StopSession` |
+| `Stopping` | 匹配的 `SessionStopped` | `Idle` | 无 |
+| `Stopping` | 匹配的 `SessionStopFailed` | `Recording` | 托盘恢复录音中 |
+| 非关闭状态 | `ShutdownRequested` | `ShuttingDown` | 取消、终止、重置托盘、退出 |
+
+其余事件保持现有策略：不改变状态、不产生 Effect，并写一条不包含大载荷的 debug
+拒绝日志。
+
+### 8. 移除无行为差异的 SessionMode
+
+`SessionOrchestrator::start_session` 改为只接收 `session_id`。删除从
+`recording_session` 重导出的 `SessionMode`，并更新调用方与测试。启动日志继续记录
+Session ID；不再记录不影响任何 Orchestrator 分支的 mode。
+
+## 文件改动
+
+| 文件 | 计划改动 |
+| --- | --- |
+| `src/main.rs` | 在输入边界归一化 Hold/Toggle/托盘动作；执行复合的 Session 启停 Effect；更新集成测试。 |
+| `src/core/recording_session.rs` | 删除来源、模式和阶段类型；引入来源无关请求、Session 级结果/Effect；简化转换表和单元测试。 |
+| `src/core/orchestrator.rs` | 从 `start_session` 删除无行为作用的 `SessionMode` 参数并更新测试。 |
+| `docs/architecture/core.md` | 记录来源无关状态机、Session 级 Effect 和简化转换表。 |
+| `docs/architecture/input.md` | 记录原始来源止步输入集成层以及状态感知的归一化规则。 |
+| `docs/plan/22-source-agnostic-recording-events.md` | 保存获批设计并在实现后更新状态。 |
+| `changelog` | 记录事件与状态模型简化。 |
+
+预计不修改 `src/input/hotkey.rs`、`src/input/tray.rs`、`src/audio/recorder.rs`、配置或依赖。
+现有输入枚举和下层结构化 outcome 已足够执行计划。
+
+## 测试优先的实现顺序
+
+获得明确批准后：
+
+1. 先更新状态机测试，覆盖来源无关的开始、停止、启动失败、停止失败、关闭和 Session ID
+   路由；此时测试应因旧事件/Effect API 而失败或无法编译。
+2. 增加纯输入归一化测试，覆盖 Hold/Toggle/托盘在 `Idle`、`Recording` 和过渡状态的映射，
+   包括 Hold release 停止任意当前 Session。
+3. 实现精简后的状态、事件、Effect 和显式转换表，使聚焦测试通过。
+4. 将 `drive_session` 改为执行原子的 `StartSession`/`StopSession`，保持启动失败回滚、尾片
+   顺序、warning、转写和文本注入行为。
+5. 删除 Orchestrator 的 `SessionMode` 参数并更新所有调用方与测试。
+6. 删除过时类型和分支，确认仓库中不再存在核心层 `ControlSource`、`ControlAction`、
+   `ControlEvent`、`StartPhase`、`StopPhase` 或 `SessionMode`。
+7. 更新架构文档、本计划状态和 changelog。
+8. 运行聚焦测试、完整测试、格式检查、拒绝 warning 的 Clippy，并检查最终 diff。
+
+不为实际麦克风、原生托盘或网络调用增加不稳定的集成测试；复合 Effect 使用已有的
+Recorder/Orchestrator 结构化结果和各模块现有测试，核心行为由纯状态机及输入归一化测试
+覆盖。
+
+## 验证方式
+
+```bash
+cargo fmt --check
+cargo test core::recording_session::tests
+cargo test input_normalization
+cargo test
+cargo clippy -- -D warnings
+```
+
+所有新增测试保持确定性，不访问麦克风、托盘、网络或真实计时。
+
+## 验收标准
+
+- `SessionEvent` 的用户控制面只有来源无关的 `StartRequested` 和 `StopRequested`。
+- 输入来源不出现在 `RecordingState`、`SessionEvent` 或 `SessionEffect` 中。
+- Hold、Toggle 和托盘在当前状态允许时都归一化到同一开始/停止事件。
+- 不同输入可以停止彼此启动的当前 Session；Hold release 不进行来源匹配。
+- 不适用于当前状态的原始输入在进入状态机前丢弃。
+- 状态机只保留 `Idle`、`Starting`、`Recording`、`Stopping` 和 `ShuttingDown`，且过渡状态
+  只携带 Session ID。
+- Recorder 和 Orchestrator 只有全部启动成功后才产生 `SessionStarted`；失败会完成回滚并
+  返回 `SessionStartFailed`。
+- 停止路径保持尾片提交顺序、转写收敛、后处理和文本注入行为；recorder 仍在运行时恢复
+  `Recording` 状态和托盘显示。
+- Session ID 路由、陈旧 chunk/完成事件拒绝和关闭清理继续有效。
+- `SessionMode` 从核心与 Orchestrator API 删除，不引入替代配置。
+- 完全事件驱动循环仍留在 #89，本次不扩大范围。
+- 聚焦测试、完整测试、格式检查和 Clippy 全部通过。

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -1,7 +1,7 @@
 //! Session orchestrator for end-to-end stream recognition.
 //!
-//! `SessionOrchestrator` unifies the Hold and Toggle recording session lifecycle:
-//! chunk tracking, background transcription, convergence wait, and result merging.
+//! `SessionOrchestrator` owns recording-session chunk tracking, background transcription,
+//! convergence wait, and result merging.
 
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,7 +14,6 @@ use tracing::{debug, error, info, warn};
 
 use crate::audio::WavChunk;
 use crate::core::recording_session::SessionId;
-pub use crate::core::recording_session::SessionMode;
 use crate::text::merge_texts;
 use crate::transcriber::Transcriber;
 // Re-exported so callers can keep using `core::orchestrator::TranscribeError`.
@@ -218,11 +217,7 @@ impl SessionOrchestrator {
     /// Start a new recording session.
     ///
     /// Returns an error without replacing an existing active session.
-    pub fn start_session(
-        &self,
-        session_id: SessionId,
-        mode: SessionMode,
-    ) -> Result<(), SessionStartError> {
+    pub fn start_session(&self, session_id: SessionId) -> Result<(), SessionStartError> {
         let mut inner = self.inner.lock().unwrap();
         if let Some(active) = inner.as_ref() {
             return Err(SessionStartError::ActiveSession {
@@ -252,7 +247,7 @@ impl SessionOrchestrator {
             cancelled,
         });
 
-        info!(session_id = session_id.0, mode = ?mode, "Session started");
+        info!(session_id = session_id.0, "Session started");
         Ok(())
     }
 
@@ -852,7 +847,7 @@ mod tests {
         let t = Arc::new(FixedTranscriber("hello world".to_string()));
         let orch = default_orchestrator(t);
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
         let result = orch.finish_session(SessionId(1));
 
@@ -870,7 +865,7 @@ mod tests {
         ]));
         let orch = default_orchestrator(t);
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk()); // index 0
         thread::sleep(Duration::from_millis(10));
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk()); // index 1
@@ -888,8 +883,7 @@ mod tests {
         let t = Arc::new(MockTranscriber);
         let orch = default_orchestrator(t);
 
-        orch.start_session(SessionId(1), SessionMode::Toggle)
-            .unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let result = orch.finish_session(SessionId(1));
 
         assert!(matches!(result, Err(SessionError::NoChunks)));
@@ -929,7 +923,7 @@ mod tests {
         ]));
         let orch = default_orchestrator(t);
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
         thread::sleep(Duration::from_millis(10));
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
@@ -964,7 +958,7 @@ mod tests {
         });
         let orch = make_orchestrator_with_timeout(t, Duration::from_millis(100));
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
         let result = orch.finish_session(SessionId(1));
 
@@ -1005,7 +999,7 @@ mod tests {
             release: Arc::clone(&release),
         });
         let orch = default_orchestrator(t);
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
 
         let started = Instant::now();
         for _ in 0..100 {
@@ -1032,19 +1026,15 @@ mod tests {
     }
 
     #[test]
-    fn test_hold_and_toggle_same_lifecycle() {
-        // Both modes should go through the same start/stop path.
-        for mode in [SessionMode::Hold, SessionMode::Toggle] {
-            let t = Arc::new(FixedTranscriber("text".to_string()));
-            let orch = default_orchestrator(t);
+    fn test_session_lifecycle_is_mode_free() {
+        let t = Arc::new(FixedTranscriber("text".to_string()));
+        let orch = default_orchestrator(t);
 
-            orch.start_session(SessionId(1), mode).unwrap();
-            let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
-            let result = orch.finish_session(SessionId(1));
+        orch.start_session(SessionId(1)).unwrap();
+        let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
+        let result = orch.finish_session(SessionId(1));
 
-            assert!(result.is_ok(), "Mode {:?} failed: {:?}", mode, result);
-            assert_eq!(result.unwrap(), "text");
-        }
+        assert_eq!(result.unwrap(), "text");
     }
 
     #[test]
@@ -1052,12 +1042,10 @@ mod tests {
         let t = Arc::new(FixedTranscriber("new session".to_string()));
         let orch = default_orchestrator(t);
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
 
-        let error = orch
-            .start_session(SessionId(2), SessionMode::Toggle)
-            .unwrap_err();
+        let error = orch.start_session(SessionId(2)).unwrap_err();
         assert_eq!(
             error,
             SessionStartError::ActiveSession {
@@ -1074,8 +1062,7 @@ mod tests {
     #[test]
     fn mismatched_chunk_and_finish_do_not_mutate_active_session() {
         let orch = default_orchestrator(Arc::new(FixedTranscriber("active".into())));
-        orch.start_session(SessionId(1), SessionMode::Toggle)
-            .unwrap();
+        orch.start_session(SessionId(1)).unwrap();
 
         assert!(matches!(
             orch.on_chunk_ready(SessionId(2), test_chunk()),
@@ -1096,7 +1083,7 @@ mod tests {
     #[test]
     fn abort_rejects_wrong_id_and_preserves_active_session() {
         let orch = default_orchestrator(Arc::new(MockTranscriber));
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
 
         assert!(matches!(
             orch.abort_session(SessionId(2)),
@@ -1111,7 +1098,7 @@ mod tests {
         let t = Arc::new(PanicTranscriber);
         let orch = make_orchestrator_with_timeout(t, Duration::from_millis(200));
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
         let result = orch.finish_session(SessionId(1));
 
@@ -1132,7 +1119,7 @@ mod tests {
         let t = Arc::new(PanicTranscriber);
         let orch = default_orchestrator(t);
 
-        orch.start_session(SessionId(1), SessionMode::Hold).unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let _ = orch.on_chunk_ready(SessionId(1), test_chunk());
         let result = orch.finish_session(SessionId(1));
 

--- a/src/core/recording_session.rs
+++ b/src/core/recording_session.rs
@@ -5,130 +5,50 @@ use tracing::debug;
 pub struct SessionId(pub u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SessionMode {
-    Hold,
-    Toggle,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ControlSource {
-    HoldHotkey,
-    ToggleHotkey,
-    Tray,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ControlAction {
-    Start(SessionMode),
-    Stop,
-    Toggle(SessionMode),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ControlEvent {
-    pub source: ControlSource,
-    pub action: ControlAction,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StartPhase {
-    Recorder,
-    Orchestrator,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StopPhase {
-    Recorder,
-    Orchestrator,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordingState {
     Idle,
-    Starting {
-        session_id: SessionId,
-        mode: SessionMode,
-        source: ControlSource,
-        phase: StartPhase,
-    },
-    Recording {
-        session_id: SessionId,
-        mode: SessionMode,
-        source: ControlSource,
-    },
-    Stopping {
-        session_id: SessionId,
-        mode: SessionMode,
-        source: ControlSource,
-        phase: StopPhase,
-    },
-    ShuttingDown {
-        session_id: Option<SessionId>,
-    },
+    Starting { session_id: SessionId },
+    Recording { session_id: SessionId },
+    Stopping { session_id: SessionId },
+    ShuttingDown { session_id: Option<SessionId> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionEvent {
-    Control(ControlEvent),
-    RecorderStarted {
+    StartRequested,
+    StopRequested,
+    SessionStarted {
         session_id: SessionId,
     },
-    RecorderStartFailed {
+    SessionStartFailed {
         session_id: SessionId,
-        error: String,
-    },
-    RecorderAlreadyRecording {
-        requested_session_id: SessionId,
-        active_session_id: SessionId,
-    },
-    OrchestratorStarted {
-        session_id: SessionId,
-    },
-    OrchestratorStartFailed {
-        requested_session_id: SessionId,
-        active_session_id: Option<SessionId>,
         error: String,
     },
     ChunkReady {
         session_id: SessionId,
         chunk: WavChunk,
     },
-    RecorderStopped {
+    SessionStopped {
         session_id: SessionId,
-        chunks: Vec<WavChunk>,
-        warning: Option<String>,
     },
-    RecorderStillRecording {
+    SessionStopFailed {
         session_id: SessionId,
         error: String,
-    },
-    RecorderNotRecording {
-        session_id: SessionId,
-    },
-    OrchestratorFinished {
-        session_id: SessionId,
     },
     ShutdownRequested,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionEffect {
-    StartRecorder {
+    StartSession {
         session_id: SessionId,
     },
-    StartOrchestrator {
-        session_id: SessionId,
-        mode: SessionMode,
-    },
-    StopRecorder {
+    StopSession {
         session_id: SessionId,
     },
     SubmitChunk {
         session_id: SessionId,
         chunk: WavChunk,
-    },
-    FinishOrchestrator {
-        session_id: SessionId,
     },
     CancelRecorder {
         session_id: SessionId,
@@ -143,37 +63,16 @@ pub enum SessionEffect {
 impl SessionEvent {
     fn summary(&self) -> (&'static str, Option<SessionId>) {
         match self {
-            Self::Control(ControlEvent { action, .. }) => {
-                let name = match action {
-                    ControlAction::Start(_) => "control_start",
-                    ControlAction::Stop => "control_stop",
-                    ControlAction::Toggle(_) => "control_toggle",
-                };
-                (name, None)
+            Self::StartRequested => ("start_requested", None),
+            Self::StopRequested => ("stop_requested", None),
+            Self::SessionStarted { session_id } => ("session_started", Some(*session_id)),
+            Self::SessionStartFailed { session_id, .. } => {
+                ("session_start_failed", Some(*session_id))
             }
-            Self::RecorderStarted { session_id } => ("recorder_started", Some(*session_id)),
-            Self::RecorderStartFailed { session_id, .. } => {
-                ("recorder_start_failed", Some(*session_id))
-            }
-            Self::RecorderAlreadyRecording {
-                requested_session_id,
-                ..
-            } => ("recorder_already_recording", Some(*requested_session_id)),
-            Self::OrchestratorStarted { session_id } => ("orchestrator_started", Some(*session_id)),
-            Self::OrchestratorStartFailed {
-                requested_session_id,
-                ..
-            } => ("orchestrator_start_failed", Some(*requested_session_id)),
             Self::ChunkReady { session_id, .. } => ("chunk_ready", Some(*session_id)),
-            Self::RecorderStopped { session_id, .. } => ("recorder_stopped", Some(*session_id)),
-            Self::RecorderStillRecording { session_id, .. } => {
-                ("recorder_still_recording", Some(*session_id))
-            }
-            Self::RecorderNotRecording { session_id } => {
-                ("recorder_not_recording", Some(*session_id))
-            }
-            Self::OrchestratorFinished { session_id } => {
-                ("orchestrator_finished", Some(*session_id))
+            Self::SessionStopped { session_id } => ("session_stopped", Some(*session_id)),
+            Self::SessionStopFailed { session_id, .. } => {
+                ("session_stop_failed", Some(*session_id))
             }
             Self::ShutdownRequested => ("shutdown_requested", None),
         }
@@ -240,7 +139,7 @@ impl RecordingSessionMachine {
 
 /// Enumerate every event that may change or act on the recording lifecycle.
 /// The caller validates session routing first; events not represented by a
-/// state/phase match arm are then rejected without mutating the current state.
+/// state/event match arm are then rejected without mutating the current state.
 fn transition(
     state: RecordingState,
     event: SessionEvent,
@@ -249,107 +148,26 @@ fn transition(
     match (state, event) {
         (RecordingState::ShuttingDown { .. }, _) => None,
         (state, SessionEvent::ShutdownRequested) => Some(shutdown_transition(state)),
-        (
-            RecordingState::Idle,
-            SessionEvent::Control(ControlEvent {
-                source,
-                action: ControlAction::Start(mode) | ControlAction::Toggle(mode),
-            }),
-        ) => {
+        (RecordingState::Idle, SessionEvent::StartRequested) => {
             let session_id = SessionId(*next_session_id);
             *next_session_id += 1;
             Some(Transition {
-                next: RecordingState::Starting {
-                    session_id,
-                    mode,
-                    source,
-                    phase: StartPhase::Recorder,
-                },
-                effects: vec![SessionEffect::StartRecorder { session_id }],
+                next: RecordingState::Starting { session_id },
+                effects: vec![SessionEffect::StartSession { session_id }],
             })
         }
-        (
-            RecordingState::Starting {
-                session_id,
-                mode,
-                source,
-                phase: StartPhase::Recorder,
-            },
-            SessionEvent::RecorderStarted { .. },
-        ) => Some(Transition {
-            next: RecordingState::Starting {
-                session_id,
-                mode,
-                source,
-                phase: StartPhase::Orchestrator,
-            },
-            effects: vec![SessionEffect::StartOrchestrator { session_id, mode }],
-        }),
-        (
-            RecordingState::Starting {
-                phase: StartPhase::Recorder,
-                ..
-            },
-            SessionEvent::RecorderStartFailed { .. },
-        ) => Some(Transition {
-            next: RecordingState::Idle,
-            effects: vec![SessionEffect::SetTrayRecording(false)],
-        }),
-        (
-            RecordingState::Starting {
-                phase: StartPhase::Recorder,
-                ..
-            },
-            SessionEvent::RecorderAlreadyRecording {
-                active_session_id, ..
-            },
-        ) => Some(Transition {
-            next: RecordingState::Idle,
-            effects: vec![
-                SessionEffect::CancelRecorder {
-                    session_id: active_session_id,
-                },
-                SessionEffect::AbortOrchestrator {
-                    session_id: active_session_id,
-                },
-                SessionEffect::SetTrayRecording(false),
-            ],
-        }),
-        (
-            RecordingState::Starting {
-                session_id,
-                mode,
-                source,
-                phase: StartPhase::Orchestrator,
-            },
-            SessionEvent::OrchestratorStarted { .. },
-        ) => Some(Transition {
-            next: RecordingState::Recording {
-                session_id,
-                mode,
-                source,
-            },
-            effects: vec![SessionEffect::SetTrayRecording(true)],
-        }),
-        (
-            RecordingState::Starting {
-                session_id,
-                phase: StartPhase::Orchestrator,
-                ..
-            },
-            SessionEvent::OrchestratorStartFailed {
-                active_session_id, ..
-            },
-        ) => Some(Transition {
-            next: RecordingState::Idle,
-            effects: vec![
-                SessionEffect::CancelRecorder { session_id },
-                SessionEffect::AbortOrchestrator {
-                    session_id: active_session_id.unwrap_or(session_id),
-                },
-                SessionEffect::SetTrayRecording(false),
-            ],
-        }),
+        (RecordingState::Starting { session_id }, SessionEvent::SessionStarted { .. }) => {
+            Some(Transition {
+                next: RecordingState::Recording { session_id },
+                effects: vec![SessionEffect::SetTrayRecording(true)],
+            })
+        }
+        (RecordingState::Starting { .. }, SessionEvent::SessionStartFailed { .. }) => {
+            Some(Transition {
+                next: RecordingState::Idle,
+                effects: vec![SessionEffect::SetTrayRecording(false)],
+            })
+        }
         (
             state @ RecordingState::Recording { session_id, .. },
             SessionEvent::ChunkReady { chunk, .. },
@@ -357,118 +175,28 @@ fn transition(
             next: state,
             effects: vec![SessionEffect::SubmitChunk { session_id, chunk }],
         }),
-        (
-            RecordingState::Recording {
-                session_id,
-                mode,
-                source,
-            },
-            SessionEvent::Control(ControlEvent {
-                action: ControlAction::Toggle(_),
-                ..
-            }),
-        ) => Some(stop_transition(session_id, mode, source)),
-        (
-            RecordingState::Recording {
-                session_id,
-                mode: SessionMode::Hold,
-                source,
-            },
-            SessionEvent::Control(ControlEvent {
-                source: ControlSource::HoldHotkey,
-                action: ControlAction::Stop,
-            }),
-        ) => Some(stop_transition(session_id, SessionMode::Hold, source)),
-        (
-            RecordingState::Stopping {
-                session_id,
-                mode,
-                source,
-                phase: StopPhase::Recorder,
-            },
-            SessionEvent::RecorderStopped { chunks, .. },
-        ) => Some(recorder_stopped_transition(
-            session_id, mode, source, chunks,
-        )),
-        (
-            RecordingState::Stopping {
-                session_id,
-                mode,
-                source,
-                phase: StopPhase::Recorder,
-            },
-            SessionEvent::RecorderNotRecording { .. },
-        ) => Some(recorder_stopped_transition(
-            session_id,
-            mode,
-            source,
-            Vec::new(),
-        )),
-        (
-            RecordingState::Stopping {
-                session_id,
-                mode,
-                source,
-                phase: StopPhase::Recorder,
-            },
-            SessionEvent::RecorderStillRecording { .. },
-        ) => Some(Transition {
-            next: RecordingState::Recording {
-                session_id,
-                mode,
-                source,
-            },
-            effects: vec![SessionEffect::SetTrayRecording(true)],
-        }),
-        (
-            RecordingState::Stopping {
-                phase: StopPhase::Orchestrator,
-                ..
-            },
-            SessionEvent::OrchestratorFinished { .. },
-        ) => Some(Transition {
-            next: RecordingState::Idle,
-            effects: Vec::new(),
-        }),
+        (RecordingState::Recording { session_id }, SessionEvent::StopRequested) => {
+            Some(Transition {
+                next: RecordingState::Stopping { session_id },
+                effects: vec![
+                    SessionEffect::SetTrayRecording(false),
+                    SessionEffect::StopSession { session_id },
+                ],
+            })
+        }
+        (RecordingState::Stopping { .. }, SessionEvent::SessionStopped { .. }) => {
+            Some(Transition {
+                next: RecordingState::Idle,
+                effects: Vec::new(),
+            })
+        }
+        (RecordingState::Stopping { session_id }, SessionEvent::SessionStopFailed { .. }) => {
+            Some(Transition {
+                next: RecordingState::Recording { session_id },
+                effects: vec![SessionEffect::SetTrayRecording(true)],
+            })
+        }
         _ => None,
-    }
-}
-
-fn stop_transition(session_id: SessionId, mode: SessionMode, source: ControlSource) -> Transition {
-    Transition {
-        next: RecordingState::Stopping {
-            session_id,
-            mode,
-            source,
-            phase: StopPhase::Recorder,
-        },
-        effects: vec![SessionEffect::StopRecorder { session_id }],
-    }
-}
-
-fn recorder_stopped_transition(
-    session_id: SessionId,
-    mode: SessionMode,
-    source: ControlSource,
-    chunks: Vec<WavChunk>,
-) -> Transition {
-    let mut effects = Vec::with_capacity(chunks.len() + 2);
-    effects.push(SessionEffect::SetTrayRecording(false));
-    effects.extend(
-        chunks
-            .into_iter()
-            .map(|chunk| SessionEffect::SubmitChunk { session_id, chunk }),
-    );
-    effects.push(SessionEffect::FinishOrchestrator { session_id });
-
-    Transition {
-        next: RecordingState::Stopping {
-            session_id,
-            mode,
-            source,
-            phase: StopPhase::Orchestrator,
-        },
-        effects,
     }
 }
 
@@ -506,13 +234,6 @@ mod tests {
         WavChunk::from_encoded_bytes(b"test wav chunk".to_vec())
     }
 
-    fn toggle(source: ControlSource) -> SessionEvent {
-        SessionEvent::Control(ControlEvent {
-            source,
-            action: ControlAction::Toggle(SessionMode::Toggle),
-        })
-    }
-
     #[test]
     fn explicit_transition_table_rejects_unlisted_paths() {
         let mut next_session_id = 2;
@@ -520,13 +241,8 @@ mod tests {
         let result = transition(
             RecordingState::Starting {
                 session_id: SessionId(1),
-                mode: SessionMode::Toggle,
-                source: ControlSource::Tray,
-                phase: StartPhase::Orchestrator,
             },
-            SessionEvent::RecorderStarted {
-                session_id: SessionId(1),
-            },
+            SessionEvent::StopRequested,
             &mut next_session_id,
         );
 
@@ -543,11 +259,8 @@ mod tests {
         let result = transition(
             RecordingState::Stopping {
                 session_id: SessionId(1),
-                mode: SessionMode::Toggle,
-                source: ControlSource::Tray,
-                phase: StopPhase::Orchestrator,
             },
-            SessionEvent::OrchestratorFinished {
+            SessionEvent::SessionStopped {
                 session_id: SessionId(1),
             },
             &mut next_session_id,
@@ -560,132 +273,78 @@ mod tests {
     }
 
     #[test]
-    fn orphan_recorder_routes_by_requested_session_id() {
-        // The requested ID routes the event to this machine; the different active
-        // ID identifies the orphan lower-layer resources that need cleanup.
-        let mut machine = RecordingSessionMachine::new();
-        machine.handle(toggle(ControlSource::Tray));
-
-        let effects = machine.handle(SessionEvent::RecorderAlreadyRecording {
-            requested_session_id: SessionId(1),
-            active_session_id: SessionId(7),
-        });
-
-        assert_eq!(machine.state(), &RecordingState::Idle);
-        assert_eq!(
-            effects,
-            vec![
-                SessionEffect::CancelRecorder {
-                    session_id: SessionId(7),
-                },
-                SessionEffect::AbortOrchestrator {
-                    session_id: SessionId(7),
-                },
-                SessionEffect::SetTrayRecording(false),
-            ]
-        );
-    }
-
-    #[test]
-    fn toggle_session_runs_one_start_and_stop_chain() {
+    fn session_runs_one_start_and_stop_chain() {
         let mut machine = RecordingSessionMachine::new();
         let chunk = test_chunk();
 
         assert_eq!(
-            machine.handle(toggle(ControlSource::Tray)),
-            vec![SessionEffect::StartRecorder {
+            machine.handle(SessionEvent::StartRequested),
+            vec![SessionEffect::StartSession {
                 session_id: SessionId(1)
             }]
         );
         assert_eq!(
-            machine.handle(SessionEvent::RecorderStarted {
+            machine.state(),
+            &RecordingState::Starting {
                 session_id: SessionId(1)
-            }),
-            vec![SessionEffect::StartOrchestrator {
-                session_id: SessionId(1),
-                mode: SessionMode::Toggle,
-            }]
+            }
         );
         assert_eq!(
-            machine.handle(SessionEvent::OrchestratorStarted {
+            machine.handle(SessionEvent::SessionStarted {
                 session_id: SessionId(1)
             }),
             vec![SessionEffect::SetTrayRecording(true)]
         );
-        assert!(matches!(machine.state(), RecordingState::Recording { .. }));
+        assert_eq!(
+            machine.state(),
+            &RecordingState::Recording {
+                session_id: SessionId(1)
+            }
+        );
 
         assert_eq!(
-            machine.handle(toggle(ControlSource::ToggleHotkey)),
-            vec![SessionEffect::StopRecorder {
-                session_id: SessionId(1)
+            machine.handle(SessionEvent::ChunkReady {
+                session_id: SessionId(1),
+                chunk: chunk.clone(),
+            }),
+            vec![SessionEffect::SubmitChunk {
+                session_id: SessionId(1),
+                chunk,
             }]
         );
         assert_eq!(
-            machine.handle(SessionEvent::RecorderStopped {
-                session_id: SessionId(1),
-                chunks: vec![chunk.clone()],
-                warning: None,
-            }),
+            machine.handle(SessionEvent::StopRequested),
             vec![
                 SessionEffect::SetTrayRecording(false),
-                SessionEffect::SubmitChunk {
-                    session_id: SessionId(1),
-                    chunk,
-                },
-                SessionEffect::FinishOrchestrator {
-                    session_id: SessionId(1),
+                SessionEffect::StopSession {
+                    session_id: SessionId(1)
                 },
             ]
         );
         assert_eq!(
-            machine.handle(SessionEvent::OrchestratorFinished {
+            machine.state(),
+            &RecordingState::Stopping {
                 session_id: SessionId(1)
-            }),
-            Vec::<SessionEffect>::new()
+            }
+        );
+        assert!(
+            machine
+                .handle(SessionEvent::SessionStopped {
+                    session_id: SessionId(1)
+                })
+                .is_empty()
         );
         assert_eq!(machine.state(), &RecordingState::Idle);
+
+        // A source-free release or toggle normalized after completion is rejected.
+        assert!(machine.handle(SessionEvent::StopRequested).is_empty());
     }
 
     #[test]
-    fn hold_release_after_tray_stop_is_a_noop() {
+    fn stale_chunks_and_session_results_cannot_mutate_active_session() {
         let mut machine = RecordingSessionMachine::new();
-        let hold_start = SessionEvent::Control(ControlEvent {
-            source: ControlSource::HoldHotkey,
-            action: ControlAction::Start(SessionMode::Hold),
-        });
-        machine.handle(hold_start);
-        machine.handle(SessionEvent::RecorderStarted {
-            session_id: SessionId(1),
-        });
-        machine.handle(SessionEvent::OrchestratorStarted {
-            session_id: SessionId(1),
-        });
-        machine.handle(toggle(ControlSource::Tray));
-        machine.handle(SessionEvent::RecorderStopped {
-            session_id: SessionId(1),
-            chunks: vec![],
-            warning: None,
-        });
-        machine.handle(SessionEvent::OrchestratorFinished {
-            session_id: SessionId(1),
-        });
-
-        let release = SessionEvent::Control(ControlEvent {
-            source: ControlSource::HoldHotkey,
-            action: ControlAction::Stop,
-        });
-        assert!(machine.handle(release).is_empty());
-        assert_eq!(machine.state(), &RecordingState::Idle);
-    }
-
-    #[test]
-    fn stale_chunks_and_completions_cannot_mutate_active_session() {
-        let mut machine = RecordingSessionMachine::new();
-        machine.handle(toggle(ControlSource::Tray));
-        machine.handle(SessionEvent::RecorderStarted {
-            session_id: SessionId(1),
-        });
-        machine.handle(SessionEvent::OrchestratorStarted {
+        machine.handle(SessionEvent::StartRequested);
+        machine.handle(SessionEvent::SessionStarted {
             session_id: SessionId(1),
         });
 
@@ -698,8 +357,9 @@ mod tests {
         );
         assert!(
             machine
-                .handle(SessionEvent::OrchestratorFinished {
-                    session_id: SessionId(99)
+                .handle(SessionEvent::SessionStopFailed {
+                    session_id: SessionId(99),
+                    error: "stale".into(),
                 })
                 .is_empty()
         );
@@ -709,11 +369,8 @@ mod tests {
     #[test]
     fn shutdown_cancels_active_session_and_is_idempotent() {
         let mut machine = RecordingSessionMachine::new();
-        machine.handle(toggle(ControlSource::Tray));
-        machine.handle(SessionEvent::RecorderStarted {
-            session_id: SessionId(1),
-        });
-        machine.handle(SessionEvent::OrchestratorStarted {
+        machine.handle(SessionEvent::StartRequested);
+        machine.handle(SessionEvent::SessionStarted {
             session_id: SessionId(1),
         });
 
@@ -735,15 +392,15 @@ mod tests {
             RecordingState::ShuttingDown { .. }
         ));
         assert!(machine.handle(SessionEvent::ShutdownRequested).is_empty());
-        assert!(machine.handle(toggle(ControlSource::Tray)).is_empty());
+        assert!(machine.handle(SessionEvent::StartRequested).is_empty());
     }
 
     #[test]
-    fn start_failure_and_orchestrator_failure_return_to_idle() {
+    fn session_start_failure_returns_to_idle_and_next_start_gets_a_new_id() {
         let mut machine = RecordingSessionMachine::new();
-        machine.handle(toggle(ControlSource::Tray));
+        machine.handle(SessionEvent::StartRequested);
         assert_eq!(
-            machine.handle(SessionEvent::RecorderStartFailed {
+            machine.handle(SessionEvent::SessionStartFailed {
                 session_id: SessionId(1),
                 error: "device unavailable".into(),
             }),
@@ -751,61 +408,35 @@ mod tests {
         );
         assert_eq!(machine.state(), &RecordingState::Idle);
 
-        machine.handle(toggle(ControlSource::Tray));
-        machine.handle(SessionEvent::RecorderStarted {
-            session_id: SessionId(2),
-        });
         assert_eq!(
-            machine.handle(SessionEvent::OrchestratorStartFailed {
-                requested_session_id: SessionId(2),
-                active_session_id: Some(SessionId(99)),
-                error: "active session".into(),
-            }),
-            vec![
-                SessionEffect::CancelRecorder {
-                    session_id: SessionId(2)
-                },
-                SessionEffect::AbortOrchestrator {
-                    session_id: SessionId(99)
-                },
-                SessionEffect::SetTrayRecording(false),
-            ]
+            machine.handle(SessionEvent::StartRequested),
+            vec![SessionEffect::StartSession {
+                session_id: SessionId(2)
+            }]
         );
-        assert_eq!(machine.state(), &RecordingState::Idle);
     }
 
     #[test]
-    fn recorder_outcome_controls_stop_recovery() {
+    fn session_stop_failure_restores_recording() {
         let mut machine = RecordingSessionMachine::new();
-        machine.handle(toggle(ControlSource::Tray));
-        machine.handle(SessionEvent::RecorderStarted {
+        machine.handle(SessionEvent::StartRequested);
+        machine.handle(SessionEvent::SessionStarted {
             session_id: SessionId(1),
         });
-        machine.handle(SessionEvent::OrchestratorStarted {
-            session_id: SessionId(1),
-        });
-        machine.handle(toggle(ControlSource::Tray));
+        machine.handle(SessionEvent::StopRequested);
 
         assert_eq!(
-            machine.handle(SessionEvent::RecorderStillRecording {
+            machine.handle(SessionEvent::SessionStopFailed {
                 session_id: SessionId(1),
                 error: "backend busy".into(),
             }),
             vec![SessionEffect::SetTrayRecording(true)]
         );
-        assert!(matches!(machine.state(), RecordingState::Recording { .. }));
-
-        machine.handle(toggle(ControlSource::Tray));
         assert_eq!(
-            machine.handle(SessionEvent::RecorderNotRecording {
+            machine.state(),
+            &RecordingState::Recording {
                 session_id: SessionId(1)
-            }),
-            vec![
-                SessionEffect::SetTrayRecording(false),
-                SessionEffect::FinishOrchestrator {
-                    session_id: SessionId(1)
-                }
-            ]
+            }
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,13 +233,41 @@ fn run_listener() -> Result<(), Box<dyn std::error::Error>> {
     run_listener_with_config(config)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordingInput {
+    HoldPressed,
+    HoldReleased,
+    TogglePressed,
+    TrayClicked,
+}
+
+fn normalize_recording_input(
+    input: RecordingInput,
+    state: &core::recording_session::RecordingState,
+) -> Option<core::recording_session::SessionEvent> {
+    use core::recording_session::{RecordingState, SessionEvent};
+
+    match (input, state) {
+        (
+            RecordingInput::HoldPressed
+            | RecordingInput::TogglePressed
+            | RecordingInput::TrayClicked,
+            RecordingState::Idle,
+        ) => Some(SessionEvent::StartRequested),
+        (
+            RecordingInput::HoldReleased
+            | RecordingInput::TogglePressed
+            | RecordingInput::TrayClicked,
+            RecordingState::Recording { .. },
+        ) => Some(SessionEvent::StopRequested),
+        _ => None,
+    }
+}
+
 fn run_listener_with_config(mut config: ListenerConfig) -> Result<(), Box<dyn std::error::Error>> {
     use audio::AudioRecorder;
     use core::orchestrator::SessionOrchestrator;
-    use core::recording_session::{
-        ControlAction, ControlEvent, ControlSource, RecordingSessionMachine, SessionEvent,
-        SessionMode,
-    };
+    use core::recording_session::{RecordingSessionMachine, SessionEvent};
     use input::hotkey::{HotkeyEvent, HotkeyManager, HotkeySource};
     use input::tray::{TrayAction, TrayManager};
     use postprocess::PostProcessor;
@@ -290,45 +318,39 @@ fn run_listener_with_config(mut config: ListenerConfig) -> Result<(), Box<dyn st
 
         if let Some(action) = tray.check_action() {
             let event = match action {
-                TrayAction::Exit => SessionEvent::ShutdownRequested,
-                TrayAction::ToggleRecording => SessionEvent::Control(ControlEvent {
-                    source: ControlSource::Tray,
-                    action: ControlAction::Toggle(SessionMode::Toggle),
-                }),
+                TrayAction::Exit => Some(SessionEvent::ShutdownRequested),
+                TrayAction::ToggleRecording => {
+                    normalize_recording_input(RecordingInput::TrayClicked, session_machine.state())
+                }
             };
-            if drive_session(
-                &mut session_machine,
-                event,
-                &mut recorder,
-                &orchestrator,
-                &mut tray,
-                &post_processor,
-                &typer,
-            ) {
+            if let Some(event) = event
+                && drive_session(
+                    &mut session_machine,
+                    event,
+                    &mut recorder,
+                    &orchestrator,
+                    &mut tray,
+                    &post_processor,
+                    &typer,
+                )
+            {
                 break Ok(());
             }
         }
 
         if let Some(event) = hotkey_manager.check_event() {
-            let control = match event {
-                HotkeyEvent::Pressed(HotkeySource::Hold) => Some(ControlEvent {
-                    source: ControlSource::HoldHotkey,
-                    action: ControlAction::Start(SessionMode::Hold),
-                }),
-                HotkeyEvent::Released(HotkeySource::Hold) => Some(ControlEvent {
-                    source: ControlSource::HoldHotkey,
-                    action: ControlAction::Stop,
-                }),
-                HotkeyEvent::Pressed(HotkeySource::Toggle) => Some(ControlEvent {
-                    source: ControlSource::ToggleHotkey,
-                    action: ControlAction::Toggle(SessionMode::Toggle),
-                }),
+            let input = match event {
+                HotkeyEvent::Pressed(HotkeySource::Hold) => Some(RecordingInput::HoldPressed),
+                HotkeyEvent::Released(HotkeySource::Hold) => Some(RecordingInput::HoldReleased),
+                HotkeyEvent::Pressed(HotkeySource::Toggle) => Some(RecordingInput::TogglePressed),
                 HotkeyEvent::Released(HotkeySource::Toggle) => None,
             };
-            if let Some(control) = control {
+            if let Some(event) =
+                input.and_then(|input| normalize_recording_input(input, session_machine.state()))
+            {
                 let _ = drive_session(
                     &mut session_machine,
-                    SessionEvent::Control(control),
+                    event,
                     &mut recorder,
                     &orchestrator,
                     &mut tray,
@@ -386,50 +408,87 @@ fn drive_session(
     while let Some(event) = events.pop_front() {
         for effect in machine.handle(event) {
             match effect {
-                SessionEffect::StartRecorder { session_id } => {
+                SessionEffect::StartSession { session_id } => {
                     let event = match recorder.start_recording(session_id) {
                         RecorderStartOutcome::Started { session_id } => {
-                            SessionEvent::RecorderStarted { session_id }
+                            match orchestrator.start_session(session_id) {
+                                Ok(()) => SessionEvent::SessionStarted { session_id },
+                                Err(error) => {
+                                    let active_session_id = match &error {
+                                        core::orchestrator::SessionStartError::ActiveSession {
+                                            active,
+                                            ..
+                                        } => *active,
+                                    };
+                                    let cancel_outcome = recorder.cancel_recording(session_id);
+                                    debug!(
+                                        session_id = session_id.0,
+                                        ?cancel_outcome,
+                                        "Recorder startup rollback handled"
+                                    );
+                                    if let Err(abort_error) =
+                                        orchestrator.abort_session(active_session_id)
+                                    {
+                                        debug!(
+                                            session_id = active_session_id.0,
+                                            error = %abort_error,
+                                            "Orchestrator startup rollback had no matching session"
+                                        );
+                                    }
+                                    error!(
+                                        session_id = session_id.0,
+                                        error = %error,
+                                        "Failed to start recording session"
+                                    );
+                                    SessionEvent::SessionStartFailed {
+                                        session_id,
+                                        error: error.to_string(),
+                                    }
+                                }
+                            }
                         }
                         RecorderStartOutcome::AlreadyRecording {
                             requested_session_id,
                             active_session_id,
-                        } => SessionEvent::RecorderAlreadyRecording {
-                            requested_session_id,
-                            active_session_id,
-                        },
+                        } => {
+                            let cancel_outcome = recorder.cancel_recording(active_session_id);
+                            debug!(
+                                session_id = active_session_id.0,
+                                ?cancel_outcome,
+                                "Orphan recorder cleanup handled"
+                            );
+                            if let Err(error) = orchestrator.abort_session(active_session_id) {
+                                debug!(
+                                    session_id = active_session_id.0,
+                                    error = %error,
+                                    "Orphan orchestrator cleanup had no matching session"
+                                );
+                            }
+                            let error = format!(
+                                "recorder session {} is already active",
+                                active_session_id.0
+                            );
+                            error!(
+                                requested_session_id = requested_session_id.0,
+                                active_session_id = active_session_id.0,
+                                "Failed to start recording session"
+                            );
+                            SessionEvent::SessionStartFailed {
+                                session_id: requested_session_id,
+                                error,
+                            }
+                        }
                         RecorderStartOutcome::Failed { session_id, error } => {
                             error!(
                                 session_id = session_id.0,
-                                error, "Failed to start recording"
+                                error, "Failed to start recording session"
                             );
-                            SessionEvent::RecorderStartFailed { session_id, error }
+                            SessionEvent::SessionStartFailed { session_id, error }
                         }
                     };
                     events.push_back(event);
                 }
-                SessionEffect::StartOrchestrator { session_id, mode } => {
-                    match orchestrator.start_session(session_id, mode) {
-                        Ok(()) => {
-                            events.push_back(SessionEvent::OrchestratorStarted { session_id })
-                        }
-                        Err(error) => {
-                            let active_session_id = match &error {
-                                core::orchestrator::SessionStartError::ActiveSession {
-                                    active,
-                                    ..
-                                } => Some(*active),
-                            };
-                            error!(session_id = session_id.0, error = %error, "Failed to start session orchestrator");
-                            events.push_back(SessionEvent::OrchestratorStartFailed {
-                                requested_session_id: session_id,
-                                active_session_id,
-                                error: error.to_string(),
-                            });
-                        }
-                    }
-                }
-                SessionEffect::StopRecorder { session_id } => {
+                SessionEffect::StopSession { session_id } => {
                     let event = match recorder.stop_recording(session_id) {
                         RecorderStopOutcome::Stopped {
                             session_id,
@@ -442,21 +501,34 @@ fn drive_session(
                                     warning, "Recorder stopped with a warning"
                                 );
                             }
-                            SessionEvent::RecorderStopped {
-                                session_id,
-                                chunks,
-                                warning,
+                            for chunk in chunks {
+                                if let Err(error) = orchestrator.on_chunk_ready(session_id, chunk) {
+                                    warn!(session_id = session_id.0, error = %error, "Stop-time chunk was rejected");
+                                }
                             }
+                            finish_transcription(
+                                orchestrator.finish_session(session_id),
+                                post_processor,
+                                typer,
+                            );
+                            SessionEvent::SessionStopped { session_id }
                         }
                         RecorderStopOutcome::StillRecording { session_id, error } => {
                             error!(session_id = session_id.0, error, "Failed to stop recorder");
-                            SessionEvent::RecorderStillRecording { session_id, error }
+                            SessionEvent::SessionStopFailed { session_id, error }
                         }
                         RecorderStopOutcome::NotRecording {
                             requested_session_id,
-                        } => SessionEvent::RecorderNotRecording {
-                            session_id: requested_session_id,
-                        },
+                        } => {
+                            finish_transcription(
+                                orchestrator.finish_session(requested_session_id),
+                                post_processor,
+                                typer,
+                            );
+                            SessionEvent::SessionStopped {
+                                session_id: requested_session_id,
+                            }
+                        }
                     };
                     events.push_back(event);
                 }
@@ -464,14 +536,6 @@ fn drive_session(
                     if let Err(error) = orchestrator.on_chunk_ready(session_id, chunk) {
                         warn!(session_id = session_id.0, error = %error, "Chunk was rejected");
                     }
-                }
-                SessionEffect::FinishOrchestrator { session_id } => {
-                    finish_transcription(
-                        orchestrator.finish_session(session_id),
-                        post_processor,
-                        typer,
-                    );
-                    events.push_back(SessionEvent::OrchestratorFinished { session_id });
                 }
                 SessionEffect::CancelRecorder { session_id } => {
                     let outcome = recorder.cancel_recording(session_id);
@@ -660,6 +724,57 @@ mod integration_tests {
     use transcriber::{MockTranscriber, Transcriber};
 
     #[test]
+    fn input_normalization_is_source_free_and_state_aware() {
+        use self::core::recording_session::{RecordingState, SessionEvent, SessionId};
+
+        let idle = RecordingState::Idle;
+        let recording = RecordingState::Recording {
+            session_id: SessionId(1),
+        };
+        let starting = RecordingState::Starting {
+            session_id: SessionId(2),
+        };
+
+        assert_eq!(
+            normalize_recording_input(RecordingInput::HoldPressed, &idle),
+            Some(SessionEvent::StartRequested)
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::HoldReleased, &recording),
+            Some(SessionEvent::StopRequested)
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::TogglePressed, &idle),
+            Some(SessionEvent::StartRequested)
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::TogglePressed, &recording),
+            Some(SessionEvent::StopRequested)
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::TrayClicked, &idle),
+            Some(SessionEvent::StartRequested)
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::TrayClicked, &recording),
+            Some(SessionEvent::StopRequested)
+        );
+
+        assert_eq!(
+            normalize_recording_input(RecordingInput::HoldPressed, &recording),
+            None
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::HoldReleased, &idle),
+            None
+        );
+        assert_eq!(
+            normalize_recording_input(RecordingInput::TogglePressed, &starting),
+            None
+        );
+    }
+
+    #[test]
     fn test_full_pipeline_mock() {
         use input::typer::{MockTyper, TextTyper};
         let transcriber = MockTranscriber;
@@ -671,17 +786,14 @@ mod integration_tests {
 
     #[test]
     fn test_orchestrator_integration_single_chunk() {
-        use self::core::orchestrator::{OrchestratorConfig, SessionMode, SessionOrchestrator};
+        use self::core::orchestrator::{OrchestratorConfig, SessionOrchestrator};
         use std::sync::Arc;
 
         let t: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
         let orch = SessionOrchestrator::new(t, OrchestratorConfig::new(Some("en".to_string())));
 
-        orch.start_session(
-            crate::core::recording_session::SessionId(1),
-            SessionMode::Hold,
-        )
-        .unwrap();
+        orch.start_session(crate::core::recording_session::SessionId(1))
+            .unwrap();
         let chunk = audio::WavChunk::from_encoded_bytes(b"fake wav".to_vec());
         let _ = orch.on_chunk_ready(crate::core::recording_session::SessionId(1), chunk);
         let result = orch.finish_session(crate::core::recording_session::SessionId(1));
@@ -692,19 +804,14 @@ mod integration_tests {
 
     #[test]
     fn test_orchestrator_no_chunks() {
-        use self::core::orchestrator::{
-            OrchestratorConfig, SessionError, SessionMode, SessionOrchestrator,
-        };
+        use self::core::orchestrator::{OrchestratorConfig, SessionError, SessionOrchestrator};
         use std::sync::Arc;
 
         let t: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
         let orch = SessionOrchestrator::new(t, OrchestratorConfig::new(None));
 
-        orch.start_session(
-            crate::core::recording_session::SessionId(1),
-            SessionMode::Toggle,
-        )
-        .unwrap();
+        orch.start_session(crate::core::recording_session::SessionId(1))
+            .unwrap();
         let result = orch.finish_session(crate::core::recording_session::SessionId(1));
         assert!(matches!(result, Err(SessionError::NoChunks)));
     }


### PR DESCRIPTION
## Summary

- normalize hold, toggle, and tray gestures into source-free `StartRequested` / `StopRequested` events
- reduce recording lifecycle state to state plus `SessionId`
- combine recorder/orchestrator coordination behind session-level start and stop effects
- remove behavior-free `SessionMode` from the orchestrator API
- preserve session routing, startup rollback, chunk ordering, transcription, and shutdown cleanup

## Behavior

- toggle hotkey, tray click, and hold release can stop the current recording regardless of which input started it
- inputs not applicable to the current stable state are discarded before reaching core
- accepting stop changes the tray to idle; a recorder stop failure restores the recording indicator

## Validation

- `cargo fmt --check`
- `cargo test core::recording_session::tests`
- `cargo test input_normalization`
- `cargo test` (115 passed)
- `cargo clippy -- -D warnings`
- independent Codex review gate: no findings
- GitHub CI: macOS, Windows, and Python passed

The approved design and implementation record is in `docs/plan/22-source-agnostic-recording-events.md`.