### PR TITLE
重构：提取共享 SessionId 类型

### DIFF
--- a/changelog
+++ b/changelog
@@ -32,3 +32,4 @@
 2026-08-02: Internalize chunk, STT retry, and session convergence policies; remove unused provider metadata and reject retired fields outside the current canonical v2 config
 2026-08-02: Centralize recording lifecycle changes behind one Session routing gate and an explicit state/event transition table with a lightweight rejected-event log path
 2026-08-02: Normalize hotkey and tray gestures into source-free recording requests; simplify lifecycle state to Session IDs and execute recorder/orchestrator startup and shutdown as composite Session effects
+2026-08-03: Extract SessionId into a shared leaf module so audio and core use a neutral session identity without changing routing behavior

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -90,7 +90,7 @@ session or reach a newer session.
 - `Stopping`: the composite recorder stop, tail-chunk submission, and orchestrator convergence is in progress
 - `ShuttingDown`: new controls are ignored while cleanup effects run
 
-The active states carry only a monotonically increasing `SessionId`; input source, interaction mode, and lower-layer phases are not lifecycle state. The ID is propagated through recorder operations, ready chunks, orchestrator routing, effects, and completion events. Stale chunks and stale Session results cannot mutate the current session.
+The active states carry only a monotonically increasing `SessionId`; input source, interaction mode, and lower-layer phases are not lifecycle state. The shared identity type is defined in `src/session.rs`, while this state machine remains responsible for allocating IDs. The ID is propagated through recorder operations, ready chunks, orchestrator routing, effects, and completion events. Stale chunks and stale Session results cannot mutate the current session.
 
 ### Explicit Transition Table
 

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, info, instrument, warn};
 
 use super::chunk::{ChunkError, WavChunk, encode_i16_wav};
 use super::{AudioConfig, max_frames_per_chunk};
-use crate::core::recording_session::SessionId;
+use crate::session::SessionId;
 
 #[derive(Debug)]
 enum RecorderError {

--- a/src/core/orchestrator.rs
+++ b/src/core/orchestrator.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use crate::audio::WavChunk;
-use crate::core::recording_session::SessionId;
+use crate::session::SessionId;
 use crate::text::merge_texts;
 use crate::transcriber::Transcriber;
 // Re-exported so callers can keep using `core::orchestrator::TranscribeError`.

--- a/src/core/recording_session.rs
+++ b/src/core/recording_session.rs
@@ -1,8 +1,6 @@
 use crate::audio::WavChunk;
+use crate::session::SessionId;
 use tracing::debug;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SessionId(pub u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordingState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod local;
 mod platform;
 mod postprocess;
 mod runtime_config;
+mod session;
 mod text;
 mod transcriber;
 
@@ -721,12 +722,12 @@ fn handle_convert(input: &str, output: Option<&str>) -> Result<(), Box<dyn std::
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use crate::session::SessionId;
     use transcriber::{MockTranscriber, Transcriber};
 
     #[test]
     fn input_normalization_is_source_free_and_state_aware() {
-        use self::core::recording_session::{RecordingState, SessionEvent, SessionId};
-
+        use self::core::recording_session::{RecordingState, SessionEvent};
         let idle = RecordingState::Idle;
         let recording = RecordingState::Recording {
             session_id: SessionId(1),
@@ -792,11 +793,10 @@ mod integration_tests {
         let t: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
         let orch = SessionOrchestrator::new(t, OrchestratorConfig::new(Some("en".to_string())));
 
-        orch.start_session(crate::core::recording_session::SessionId(1))
-            .unwrap();
+        orch.start_session(SessionId(1)).unwrap();
         let chunk = audio::WavChunk::from_encoded_bytes(b"fake wav".to_vec());
-        let _ = orch.on_chunk_ready(crate::core::recording_session::SessionId(1), chunk);
-        let result = orch.finish_session(crate::core::recording_session::SessionId(1));
+        let _ = orch.on_chunk_ready(SessionId(1), chunk);
+        let result = orch.finish_session(SessionId(1));
 
         assert!(result.is_ok(), "Expected Ok, got {:?}", result);
         assert!(!result.unwrap().is_empty());
@@ -810,9 +810,8 @@ mod integration_tests {
         let t: Arc<dyn Transcriber> = Arc::new(MockTranscriber);
         let orch = SessionOrchestrator::new(t, OrchestratorConfig::new(None));
 
-        orch.start_session(crate::core::recording_session::SessionId(1))
-            .unwrap();
-        let result = orch.finish_session(crate::core::recording_session::SessionId(1));
+        orch.start_session(SessionId(1)).unwrap();
+        let result = orch.finish_session(SessionId(1));
         assert!(matches!(result, Err(SessionError::NoChunks)));
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,5 @@
+//! Shared session identity for routing work across recording subsystems.
+
+/// Identifies one logical recording session across recorder and transcription components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionId(pub u64);


### PR DESCRIPTION
## Summary
- move SessionId from core::recording_session into the shared session module
- update audio, recording state, and orchestration imports without changing routing behavior
- document the neutral identity boundary

## Verification
- cargo fmt --check
- cargo test
- cargo clippy -- -D warnings
- independent Codex review: no findings