### PR TITLE
refactor(runtime): adopt winit event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,39 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -38,6 +67,31 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.11.0",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk 0.9.0",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anstream"
@@ -94,6 +148,24 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "atk"
@@ -177,11 +249,20 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -189,6 +270,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "bytes"
@@ -219,6 +306,32 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -263,6 +376,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clang-sys"
@@ -325,7 +444,7 @@ dependencies = [
  "block",
  "core-foundation 0.9.4",
  "core-graphics 0.21.0",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -344,6 +463,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -396,7 +524,7 @@ checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.7.0",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -408,7 +536,31 @@ checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "foreign-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -442,11 +594,11 @@ dependencies = [
  "core-foundation-sys 0.8.7",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "oboe",
  "wasm-bindgen",
@@ -478,6 +630,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "dasp_sample"
@@ -528,13 +686,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -547,6 +711,21 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -644,7 +823,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -652,6 +852,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -790,6 +996,16 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -1021,6 +1237,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hound"
@@ -1312,7 +1534,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1320,10 +1542,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -1424,7 +1695,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -1445,6 +1719,12 @@ dependencies = [
  "libc",
  "x11",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1496,6 +1776,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1560,10 +1849,10 @@ dependencies = [
  "gtk",
  "keyboard-types",
  "libxdo",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png",
  "thiserror 2.0.18",
@@ -1594,10 +1883,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.0",
+ "log",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "raw-window-handle",
  "thiserror 1.0.69",
 ]
 
@@ -1613,7 +1917,16 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -1687,6 +2000,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,23 +2026,52 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-text",
  "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1723,8 +2081,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1734,8 +2115,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1746,7 +2127,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1757,9 +2138,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1768,8 +2161,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1779,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -1791,7 +2196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -1805,14 +2210,26 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "libc",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -1823,8 +2240,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -1834,8 +2288,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1844,8 +2353,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
- "ndk",
+ "jni 0.21.1",
+ "ndk 0.8.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -1881,7 +2390,7 @@ checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -1924,6 +2433,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2483,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2521,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2537,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2067,6 +2635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "rdev"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2684,24 @@ dependencies = [
  "libc",
  "winapi",
  "x11",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2228,6 +2829,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2235,7 +2849,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2300,6 +2914,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
 ]
 
 [[package]]
@@ -2417,6 +3050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +3076,40 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.0",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2443,6 +3126,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
@@ -2471,6 +3160,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2546,7 +3246,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2597,6 +3297,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -2847,11 +3572,11 @@ dependencies = [
  "dirs 6.0.0",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png",
  "thiserror 2.0.18",
@@ -2863,6 +3588,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "unicase"
@@ -2950,10 +3681,9 @@ dependencies = [
  "cpal",
  "dirs 5.0.1",
  "hound",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-graphics",
- "objc2-foundation",
  "png",
  "rdev",
  "reqwest",
@@ -2963,6 +3693,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tray-icon",
+ "winit",
 ]
 
 [[package]]
@@ -3102,10 +3833,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3495,6 +4345,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk 0.9.0",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,6 +4519,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading 0.8.9",
+ "once_cell",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.11.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,6 +4596,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 png = "0.17"
 tray-icon = "0.21"
+winit = "0.30.13"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tempfile = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSDate", "NSRunLoop"] }
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSEvent"] }
 objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGEventSource", "CGEventTypes", "CGRemoteOperation"] }
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Rust 侧的 `LocalServiceManager` 负责启动、健康检查、PID 记录、日
 - [serde_json](https://crates.io/crates/serde_json) - JSON 序列化/反序列化
 - [clap](https://crates.io/crates/clap) - CLI 参数解析
 - [tray-icon](https://crates.io/crates/tray-icon) - 系统托盘图标
+- [winit](https://crates.io/crates/winit) - 跨平台原生事件循环
 - [tracing](https://crates.io/crates/tracing) - 结构化日志
 
 ## 开发

--- a/changelog
+++ b/changelog
@@ -37,3 +37,4 @@
 2026-08-10: Replace placeholder bundle artwork and generated tray dots with a shared five-bar V-shaped waveform icon, including native macOS template tinting and a red recording state
 2026-08-10: Harden API-mode macOS and Windows packaging with locked inputs, reviewed WiX authoring, pre-tag dry runs, validated portable/installable artifacts, checksums, provenance, and draft-first GitHub Release publication
 2026-08-10: Expand Hold and Toggle hotkeys from F1–F12 to named single keyboard keys, including standalone right Alt/Option, canonical aliases, platform-aware validation, and passthrough warnings
+2026-08-11: Replace fixed-rate listener polling and hand-written platform message pumps with a main-thread winit event loop, per-boundary audio readiness wakeups, and cancellable background transcription delivery

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Module-level design docs covering structs, methods, and dependencies.
 |---|---|
 | [audio.md](architecture/audio.md) | Audio recording — `AudioRecorder`, cpal stream management, live chunking, WAV output |
 | [core.md](architecture/core.md) | Strict v2 config persistence, runtime assembly, CLI parsing, and `SessionOrchestrator` |
-| [input.md](architecture/input.md) | Hotkey detection (`HotkeyManager`), text injection (`TextTyper`), system tray (`TrayManager`) |
+| [input.md](architecture/input.md) | Global hotkey detection, text injection (`TextTyper`), system tray (`TrayManager`) |
 | [local.md](architecture/local.md) | Local Gemma runtime: installer, Python FastAPI service, process lifecycle, health/status management |
 | [transcriber.md](architecture/transcriber.md) | Transcription trait, `ApiTranscriber` (OpenAI-compatible API), chunking, retry, text merging |
 | [platform.md](architecture/platform.md) | Platform text injection — `MacTyper` (osascript) and `WindowsTyper` (SendInput) |
@@ -54,3 +54,4 @@ Implementation plans and technical specs for each feature.
 | [25-test-suite-pruning.md](plan/25-test-suite-pruning.md) | Done | Remove redundant tests and make retained coverage deterministic, fast, and proportional to risk |
 | [26-symbol-icon-refresh.md](plan/26-symbol-icon-refresh.md) | Done | Replace placeholder bundle artwork and generated tray dots with one cross-platform voice-input symbol |
 | [27-release-path-hardening.md](plan/27-release-path-hardening.md) | Implemented | Make API-mode macOS and Windows packages reproducible, manually testable, and safe to publish |
+| [28-winit-event-loop.md](plan/28-winit-event-loop.md) | Implemented | Replace fixed listener polling with a main-thread winit event loop and non-blocking finalization |

--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -40,14 +40,25 @@ the capacity calculation independently testable; production callers pass the mod
 ## Live Recorder
 
 The cpal callback downmixes input to mono `i16`, applies microphone gain, appends PCM to the shared
-buffer, and updates the number of complete chunks. It never performs WAV encoding, channel waits,
-disk I/O, or network I/O.
+buffer, and updates the number of complete chunks. Crossing a new complete-chunk boundary also
+sends one readiness callback containing the active `SessionId`. The existing ready-chunk count
+prevents repeated notifications within the same boundary, while the fixed chunk policy keeps the
+wakeup rate independent of audio sample-buffer traffic. The callback never performs WAV encoding,
+channel waits, disk I/O, network I/O, or session transitions.
 
-The main loop polls `take_ready_chunk()`. For each ready boundary the recorder copies one complete
-PCM slice, encodes it with `hound` into a `Cursor<Vec<u8>>`, drains the encoded samples only after
-successful encoding, and returns `ReadyChunk { session_id, chunk }`. On stop, complete remaining
-slices and the final tail are encoded the same way. `RecorderStopOutcome::Stopped` therefore owns
-`Vec<WavChunk>` rather than file paths.
+The readiness callback becomes an application event that wakes winit. The event-loop handler drains
+`take_ready_chunk()` until it returns `None`. For each ready boundary the recorder copies one
+complete PCM slice, encodes it with `hound` into a `Cursor<Vec<u8>>`, drains the encoded samples only
+after successful encoding, and returns `ReadyChunk { session_id, chunk }`. The in-memory fixed-format
+encoder's error path is handled inside the recorder: it logs the failure, returns `None`, and leaves
+the PCM buffered for stop-time recovery.
+
+Each boundary notification is independent, so a boundary published while the listener is draining
+queues its own wakeup without a pending flag, re-arm protocol, or timer retry. Extra notifications
+are harmless because the listener drains until `take_ready_chunk()` returns `None`, and events
+from an old `SessionId` are ignored after stop or session replacement. On stop, complete remaining
+slices and the final tail are encoded the same way.
+`RecorderStopOutcome::Stopped` therefore owns `Vec<WavChunk>` rather than file paths.
 
 ## Local WAV Reader
 

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -100,10 +100,31 @@ The active states carry only a monotonically increasing `SessionId`; input sourc
 
 The machine consumes source-free requests plus `SessionStarted`, `SessionStartFailed`, `SessionStopped`, and `SessionStopFailed` results. It emits composite `StartSession` and `StopSession` effects instead of exposing recorder/orchestrator startup phases.
 
-`application::listener` executes `StartSession` as an all-or-nothing recorder/orchestrator acquisition with rollback. `StopSession` stops the recorder, submits tail chunks in order, finishes orchestrator convergence, and runs the existing post-processing and text-injection path. The state machine changes the tray to idle when it accepts a stop and restores the recording indicator if the recorder remains active.
+`application::listener` executes `StartSession` as an all-or-nothing recorder/orchestrator
+acquisition with rollback. `StopSession` stops the recorder and submits tail chunks in order, then
+starts a session-scoped background task for orchestrator convergence, post-processing, and text
+injection. The machine remains in `Stopping` until the matching completion event returns through
+the application event loop. The state machine changes the tray to idle when it accepts a stop and
+restores the recording indicator if the recorder remains active.
 
 Exit is represented as `ShutdownRequested`. It cancels recorder/orchestrator work, resets tray state, suppresses final text injection, and exits only after `ReadyToExit` is emitted.
 
 ## Main Integration Notes
 
-`application` loads one `ConfigDocument`, asks `runtime_config` for a typed workflow configuration, and passes each narrow value to its consumer. API and Local backends reuse the same recording/orchestration pipeline; no endpoint rewriting or persisted-document mutation occurs in the application layer. `main.rs` only delegates process startup to the library entry point.
+`application` loads one `ConfigDocument`, asks `runtime_config` for a typed workflow configuration,
+and passes each narrow value to its consumer. Listener mode then creates one main-thread winit
+`EventLoop<AppEvent>` in `ControlFlow::Wait` mode. Hotkey, tray/menu, audio-readiness, and background
+completion producers use `EventLoopProxy` to wake that loop; winit owns AppKit/Win32 dispatch and no
+window is created. CLI-only workflows do not construct the event loop.
+
+`src/application/listener/event_loop.rs` normalizes source events, executes state-machine effects,
+drains ready chunks, and coordinates background finalization. Winit types remain in the application
+layer. `core`, `audio`, and `input` expose only their existing domain values or narrow callbacks.
+Finalization uses an atomic cancellation flag checked before post-processing and immediately before
+the final text injection. Exit records cancellation without waiting for an injection already in
+progress. Cancellation observed before the final check suppresses delivery, while an injection that
+has already begun may complete.
+
+API and Local backends reuse the same recording/orchestration pipeline; no endpoint rewriting or
+persisted-document mutation occurs in the application layer. `main.rs` only delegates process
+startup to the library entry point.

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -29,15 +29,19 @@ pub enum HotkeyEvent {
 
 Note: `Released` is only emitted for `Hold` source (toggle mode uses press-only semantics).
 
-**`HotkeyManager`**
+**`start_hotkey_listener(config, notify)`**
 
 ```rust
-pub struct HotkeyManager {
-    events: Receiver<HotkeyEvent>,
-}
+pub fn start_hotkey_listener(
+    config: &HotkeyConfig,
+    notify: impl Fn(HotkeyEvent) + Send + 'static,
+);
 ```
 
-Spawns an `rdev::listen` thread that maps native events into an ordered channel. Per-binding key-down state suppresses operating-system key-repeat events so one physical toggle press produces one toggle action.
+Starts the process-lifetime `rdev::listen` thread, maps native events, and invokes the supplied
+callback. The application callback forwards each event through winit's `EventLoopProxy`, which wakes
+the main-thread event loop without polling. Per-binding key-down state suppresses operating-system
+key-repeat events so one physical toggle press produces one toggle action.
 
 **`HotkeyConfig`**
 
@@ -62,7 +66,7 @@ Because the core event carries no source, Hold release, Toggle, and tray input c
 
 ### Key Methods
 
-**`HotkeyManager::new(config: &HotkeyConfig) -> Self`**
+**`start_hotkey_listener(config, notify)`**
 
 - `HotkeyConfig::validate(&InputSection)` parses and validates both bindings before construction.
 - Empty strings disable a binding, including both bindings for tray-only control; duplicate non-empty bindings are rejected.
@@ -71,10 +75,8 @@ Because the core event carries no source, Hold release, Toggle, and tray input c
   plus right Alt by layouts that use AltGr. Validation rejects a `LEFTCTRL`/`RIGHTALT` pair so one
   physical AltGr press cannot enqueue both configured recording actions.
 - Spawns the listener thread without blocking application startup.
-
-**`check_event(&self) -> Option<HotkeyEvent>`**
-
-Non-blockingly receives the oldest pending event. Called from the main loop on each iteration; later events remain queued in their original order.
+- Delivers mapped press/release events directly to the supplied non-blocking callback; the listener
+  thread never runs recording state transitions itself.
 
 **`parse_key(s: &str) -> Option<Key>`**
 
@@ -119,12 +121,14 @@ their existing repeat suppression.
 ### `TextTyper` Trait
 
 ```rust
-pub trait TextTyper {
+pub trait TextTyper: Send + Sync {
     fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>>;
 }
 ```
 
 Platform implementations are in `src/platform/`. See [platform.md](platform.md).
+The thread-safety contract allows final transcription delivery to run outside the native event-loop
+thread.
 
 ### `MockTyper`
 
@@ -144,6 +148,7 @@ pub struct TrayManager {
     status_item: MenuItem,
     exit_item_id: MenuId,
     click_debounce: ClickDebounce,
+    handler_installed: bool,
 }
 ```
 
@@ -165,25 +170,31 @@ asset's explicit red. Windows ignores the template flag and displays the committ
 
 ### Key Methods
 
-**`TrayManager::new() -> Result<Self>`**
+**`TrayManager::new(notify) -> Result<Self>`**
 
 Decodes the embedded idle and recording PNGs, then builds the tray icon with a menu containing:
 title item, status item, separator, and exit item. Corrupt or non-RGBA assets fail tray construction
 with an error, while tests enforce the committed 32×32 dimensions and transparency. Left-click menu
 opening is disabled so left click can toggle recording; right click retains the native context menu.
+Before creating the native icon, construction installs the process-global `tray-icon` and menu
+callbacks with the supplied application callback. `tray-icon 0.21` stores those handlers in one-shot
+global cells, matching the application's single listener and process-lifetime event loop.
 
 **`set_recording(&mut self, recording: bool)`**
 
 Switches the icon, macOS template mode, tooltip, and menu status text based on recording state.
 Native icon/tooltip update failures are logged rather than silently discarded.
 
-**`check_action(&mut self) -> Option<TrayAction>`**
+**`handle_event(&mut self, event: TrayEvent) -> Option<TrayAction>`**
 
-Drains menu events before icon events so Exit has priority. A matching left-button-up event produces `ToggleRecording`; unrelated icon IDs and mouse phases are discarded. Events are drained as one batch using a shared handling timestamp.
+Filters raw events by tray/menu ID and maps a matching left-button-up event to `ToggleRecording`.
+Unrelated icon IDs and mouse phases are discarded; Exit bypasses debounce. Events are handled in
+native delivery order, and once Exit transitions the core to `ShuttingDown`, later recording input
+is rejected.
 
-**`update(&self)`**
-
-Pumps pending AppKit or Win32 events without creating a window. On macOS tray setup also enforces Accessory activation policy. This event pump is required for right-click menu and icon event delivery.
+The main-thread winit loop owns AppKit/Win32 dispatch in `ControlFlow::Wait` mode. `TrayManager` no
+longer exposes a polling receiver or a manual platform event pump. macOS tray setup still enforces
+Accessory activation policy and creates no application window.
 
 ### Click Protection
 

--- a/docs/plan/28-winit-event-loop.md
+++ b/docs/plan/28-winit-event-loop.md
@@ -1,0 +1,307 @@
+# 28 - Winit Event Loop
+
+## Status
+
+**Implemented; local automated validation complete.** The main-thread winit loop,
+callback forwarding, per-boundary audio readiness, cancellable background finalization, tests, and
+current-truth documentation are implemented on PR #98. Local tests, formatting, Clippy, and Windows
+cross-compilation pass after the simplification. Hosted checks passed before the simplification and
+must rerun on the updated PR. Final interactive tray, recording, and text injection gesture checks
+also remain before PR readiness.
+
+### Post-review simplifications
+
+`tray-icon 0.21` stores its process-global native event handlers in one-shot cells, so they cannot
+be unregistered and replaced as originally described. The initial implementation added a
+mutex-protected replaceable forwarding slot, but review confirmed that the application creates one
+listener per process. `TrayManager::new` now installs the application callback directly for the
+process lifetime.
+
+The initial audio implementation also coalesced boundary notifications behind a pending flag and
+added a re-arm/timer-retry protocol to close the resulting lost-wakeup race. Review removed that
+self-induced complexity: the recorder now sends one lightweight wakeup whenever it observes a new
+complete-chunk boundary, and the listener drains every ready chunk. The process-lifetime hotkey
+thread is likewise started by a function instead of returning an ownership-free zero-sized manager.
+Live WAV encoding stays behind `take_ready_chunk()`'s `Option` boundary because the listener cannot
+recover from an in-memory fixed-format encoder failure. The recorder logs that internal failure and
+leaves PCM buffered for stop-time recovery.
+
+Finalization cancellation now uses two `AtomicBool` checkpoints instead of holding a mutex across
+platform text injection. Shutdown therefore never waits for an injection already in progress;
+cancellation observed before the final checkpoint suppresses delivery, while an injection that has
+already started may complete.
+
+## Context
+
+The desktop listener currently owns a hand-written loop that, every 20 ms:
+
+1. pumps pending AppKit or Win32 messages;
+2. polls tray/menu receivers;
+3. polls one hotkey event;
+4. polls one ready audio chunk; and
+5. sleeps until the next iteration.
+
+This keeps the tray functional on macOS and Windows, but it has three structural costs:
+
+- an idle application wakes roughly 50 times per second even when no work exists;
+- input and audio latency is tied to the polling interval and one-item-per-iteration draining;
+- `StopSession` waits for transcription convergence, post-processes text, and injects it on the
+  listener thread, so the native tray message pump is unresponsive during finalization.
+
+`tray-icon` supports forwarding tray and menu callbacks through a winit `EventLoopProxy`. Winit can
+therefore own the required main-thread native event loop while existing producer threads wake it
+only when application work is available.
+
+## Goals
+
+1. Replace the fixed 20 ms listener loop and platform-specific message pumping with a winit event
+   loop running on the main thread in `ControlFlow::Wait` mode.
+2. Normalize hotkey, tray, audio-ready, background-completion, and shutdown notifications into one
+   application event boundary.
+3. Keep `RecordingSessionMachine` as the sole recording lifecycle authority and preserve current
+   Hold, Toggle, tray debounce, Session ID routing, rollback, and partial-result behavior.
+4. Keep the native event loop responsive while transcription converges, optional LLM cleanup runs,
+   and text is injected.
+5. Preserve the realtime audio callback boundary: it may append PCM and send a lightweight wakeup,
+   but it must not encode WAV, wait on a channel, access the network, or execute session effects.
+6. Make shutdown prevent late background work from injecting text after exit was requested.
+
+## Non-goals
+
+- Adding a visible window, settings UI, overlay, dock icon, or new user-facing recording mode.
+- Introducing Tokio or converting the blocking HTTP clients to async APIs.
+- Replacing `rdev`, `cpal`, `tray-icon`, the session state machine, or platform text injection.
+- Changing chunk size, request retry, convergence timeout, post-processing, or configuration
+  policy.
+- Making the detached `rdev::listen` thread independently stoppable; process shutdown remains its
+  lifetime boundary.
+
+## Design
+
+### 1. Make winit the main-thread lifecycle owner
+
+Add stable winit `0.30.x` as a direct dependency and build one `EventLoop<AppEvent>` for listener
+mode. The loop is created and run on the process main thread, uses `ControlFlow::Wait`, and does not
+create a window. Tray construction remains on that same thread and macOS retains Accessory
+activation policy.
+
+The listener will implement `ApplicationHandler<AppEvent>` through a small application object that
+owns the current runtime components: `RecordingSessionMachine`, `AudioRecorder`, tray manager,
+orchestrator, post-processor, typer, and any active finalization cancellation handle. Its
+`user_event` callback dispatches one event and drains any immediately generated state-machine
+events before returning control to winit.
+
+The existing `pump_platform_events()` implementations, `tray.update()`, the heartbeat counter, the
+fixed sleep, and polling loop are removed. Winit becomes the only owner of AppKit/Win32 event
+dispatch for listener mode. CLI-only workflows continue to run without constructing a desktop
+event loop.
+
+### 2. Use one application event boundary
+
+The application layer introduces a private event type along these lines:
+
+```rust
+enum AppEvent {
+    Hotkey(HotkeyEvent),
+    Tray(TrayAction),
+    AudioChunkAvailable { session_id: SessionId },
+    FinalizationFinished { session_id: SessionId },
+}
+```
+
+The exact private representation may be simplified during implementation, but every cross-thread
+producer must ultimately call `EventLoopProxy::send_event`; shared component APIs will accept
+narrow callbacks rather than depend directly on winit. This keeps `input` and `audio` independent
+of the application framework and lets tests substitute a deterministic event collector.
+
+Application events are normalized into the existing source-free `SessionEvent` values before
+entering `RecordingSessionMachine`. Each routed event retains its `SessionId`; a completion or
+audio notification from an older session cannot mutate a newer session.
+
+Sending after event-loop shutdown is expected and harmless. Producers may discard the closed-loop
+error, but operational failures before shutdown must continue to be logged at the layer that can
+act on them.
+
+### 3. Forward hotkey and tray callbacks instead of polling
+
+`start_hotkey_listener` retains the current `rdev::listen` thread, event mapper, press/release
+ordering, repeat suppression, and platform normalization. Instead of storing an `mpsc::Receiver`
+for `check_event()`, it invokes an application callback for each mapped `HotkeyEvent`. The callback
+only forwards to the winit proxy.
+
+`TrayManager` will register `TrayIconEvent::set_event_handler` and
+`MenuEvent::set_event_handler`. Raw tray events remain filtered by tray ID and normalized through
+the existing debounce rules before producing `TrayAction`; Exit is never debounced. The one-shot
+global handlers directly retain the callback for the process lifetime, matching the single-listener
+application lifecycle.
+
+Removing batch polling also removes the old artificial rule that a queued Exit event is inspected
+before a queued icon event. Under the event loop, callbacks are handled in delivered order; once
+Exit is accepted, the existing `ShuttingDown` state rejects later recording controls.
+
+### 4. Turn audio chunk readiness into a wakeup
+
+The CPAL callback already publishes PCM before advancing its ready-chunk count. Extend that boundary
+with a lightweight notifier that fires when a new complete chunk boundary becomes available. The
+notification contains only the active `SessionId`; WAV encoding and buffer draining stay on the
+listener thread through `take_ready_chunk()`.
+
+On `AudioChunkAvailable`, the listener drains all complete chunks in order rather than taking at
+most one per loop iteration. The callback notifies only when the complete-chunk count advances, not
+for every audio sample buffer. Each advanced boundary can therefore queue an independent wakeup;
+an event published while the listener drains remains queued, and duplicate wakeups are harmless
+because every handler drains until no complete chunk remains. The final implementation keeps the
+fixed-format in-memory WAV encoder's failure internal to the recorder: it logs the failure, returns
+`None`, and leaves the affected PCM buffered for stop-time recovery.
+
+Stopping the recorder continues to synchronously detach the CPAL stream and encode the final
+complete slices/tail before those chunks are submitted in order. A readiness notification that
+arrives after stop is harmless because recorder/session routing rejects stale work.
+
+### 5. Finalize stopped sessions away from the event-loop thread
+
+After recorder stop and final chunk submission, launch one session-scoped background finalization
+task. That task performs the currently blocking sequence:
+
+```text
+SessionOrchestrator::finish_session
+  -> optional post-processing
+  -> platform text injection
+  -> AppEvent::FinalizationFinished
+```
+
+The listener remains in the existing `Stopping { session_id }` state until the matching completion
+event feeds `SessionStopped` back into the state machine. Recording controls remain ignored while
+stopping, matching current observable behavior, but tray Exit and native application events remain
+responsive.
+
+The orchestrator, post-processor, and typer will be shared with the finalization task only through
+the minimum thread-safe ownership needed by their existing contracts. This does not add an async
+runtime or a general worker pool: at most one recording session can be active, so one scoped
+finalization thread is sufficient.
+
+Each finalization task owns a cancellation/delivery gate. The task checks cancellation before
+post-processing, then holds the gate across the final text injection; `ShutdownRequested` acquires
+the same gate before marking the task cancelled. This gives shutdown and delivery a defined order:
+an injection already underway finishes before shutdown is accepted, while shutdown accepted first
+prevents later injection. Late completion events carry the old Session ID and are ignored after
+shutdown. The process is not required to wait for a blocking network request to finish in order to
+exit.
+
+Implementation deviation: the final code replaces that mutex protocol with an atomic cancellation
+flag checked before post-processing and immediately before injection. This keeps shutdown
+non-blocking even after injection begins, accepting that an already-started platform injection may
+finish.
+
+### 6. Keep event-loop glue thin and testable
+
+Split the current listener integration so platform/framework glue does not further enlarge one
+file:
+
+```text
+src/application/listener.rs
+  - configuration and component construction
+  - EventLoop/AppEventProxy setup
+  - source callback wiring
+
+src/application/listener/event_loop.rs
+  - private AppEvent and ApplicationHandler implementation
+  - application-event normalization
+  - state-machine effect execution
+  - audio draining and finalization lifecycle
+```
+
+The existing state machine remains in `core`; winit types do not cross into `core`, `audio`, or
+`input`. Small callback interfaces are preferred over a repository-wide event bus or generic actor
+abstraction.
+
+## Expected File Changes
+
+| File | Planned change |
+| --- | --- |
+| `Cargo.toml`, `Cargo.lock` | Add stable winit `0.30.x`; remove native event-pump-only dependency features where no longer needed. |
+| `src/application/listener.rs` | Construct and run the winit loop, wire producers to its proxy, and remove the fixed polling loop. |
+| `src/application/listener/event_loop.rs` | Add the private application event handler, effect executor, audio draining, cancellation, and background finalization coordination. |
+| `src/input/hotkey.rs` | Deliver mapped hotkeys through a supplied callback instead of a polled receiver. |
+| `src/input/tray.rs` | Forward native tray/menu callbacks for the process lifetime, retain debounce/filtering, and remove manual AppKit/Win32 pumping. |
+| `src/input/typer.rs` and platform typers | Express the thread-safety contract required for background delivery without changing injection behavior. |
+| `src/audio/recorder.rs` | Emit one lightweight wakeup when the complete-chunk count advances while keeping callback work realtime-safe. |
+| `docs/architecture/input.md` | Describe callback delivery, winit ownership, tray handler lifecycle, and removal of polling. |
+| `docs/architecture/audio.md` | Describe per-boundary wakeups and main-thread chunk draining. |
+| `docs/architecture/core.md` | Describe the application event boundary and non-blocking stop/finalization flow. |
+| `README.md` | Add winit to the dependency inventory; user workflow remains unchanged. |
+| `docs/README.md` | Index this plan and track its implementation status. |
+| `changelog` | Record the event-driven listener and responsive background finalization. |
+
+No configuration/example change is expected because the feature adds no user setting or schema
+change. Packaging and release documentation are unaffected because artifact names, supported
+targets, and release procedures do not change.
+
+## Test-First Implementation Order
+
+After explicit plan approval:
+
+1. Add deterministic tests for application-event normalization and forwarding, including ordered
+   Hold press/release delivery and rejection of stale Session IDs.
+2. Add recorder tests proving that each observed chunk boundary wakes the listener and draining
+   returns all ready chunks in order.
+3. Add tray reducer/handler tests proving left-click debounce, double-click suppression, unrelated
+   ID filtering, and Exit delivery without constructing a native tray.
+4. Add finalization tests with fake processor/typer behavior proving the event-loop-facing call
+   returns without waiting, matching completion reaches `Idle`, and shutdown cancellation prevents
+   late text injection.
+5. Add winit and the private application event handler, then wire the tested hotkey, tray, audio,
+   and completion producers through `EventLoopProxy`.
+6. Remove the old polling receivers, native pump code, heartbeat, and fixed sleep only after every
+   event source has an explicit wakeup path.
+7. Synchronize architecture docs, dependency inventory, plan status, index, and changelog with the
+   final implementation.
+8. Run focused tests throughout, then the full cross-platform validation set and inspect the final
+   diff for stale polling descriptions or retired native-pump symbols.
+
+Tests will use fake callbacks, channels, clocks, processors, and typers. They will not create a
+real winit loop, tray icon, microphone stream, network request, or platform input event in unit-test
+processes.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo test application::listener
+cargo test input::hotkey::tests
+cargo test input::tray::tests
+cargo test audio::recorder::tests
+cargo test
+cargo clippy -- -D warnings
+git diff --check
+```
+
+The PR must also pass the existing macOS build/test/Clippy CI and Windows build/test CI. Before PR
+readiness, perform a macOS smoke run that confirms tray left-click, right-click Exit, Hold, Toggle,
+idle waiting, chunk submission, and post-stop text injection remain functional. Windows-native
+behavior is validated by the Windows CI build/tests unless an interactive Windows runner is
+available.
+
+## Acceptance Criteria
+
+- Listener mode uses one main-thread winit event loop with `ControlFlow::Wait` and creates no
+  application window.
+- There is no fixed-rate listener sleep, tray/hotkey polling receiver, or hand-written AppKit/Win32
+  message pump.
+- Hotkey, tray/menu, audio-ready, and finalization producers wake the loop through custom events.
+- The CPAL callback performs no WAV encoding, blocking send, network access, state transition, or
+  text processing.
+- Every published ready audio chunk is drained in order without depending on periodic polling;
+  boundary notifications published during draining remain independently queued, and stale events
+  cannot mutate another session.
+- Live WAV encoding failures are logged explicitly and retain PCM for stop-time recovery rather than
+  entering a timer-driven retry loop.
+- Existing Hold, Toggle, tray debounce, startup rollback, stop failure, chunk ordering, partial
+  transcription, and Session ID routing behavior remains intact.
+- Transcription convergence, optional LLM cleanup, and text injection do not block native event
+  dispatch.
+- Exit remains responsive during finalization; cancellation observed before the injection checkpoint
+  prevents delivery, while an injection already underway may finish.
+- macOS remains an Accessory application with a functional status item; Windows retains a
+  functional tray icon and context menu.
+- Focused tests, full tests, formatting, Clippy, diff checks, and cross-platform CI pass.

--- a/src/application/listener.rs
+++ b/src/application/listener.rs
@@ -1,9 +1,13 @@
-use tracing::{debug, error, info, warn};
+use tracing::info;
 
 use super::{LocalServiceGuard, config_context, load_config, start_local_backend};
 use crate::core::config::EnvironmentSecretSource;
+use crate::core::recording_session::{RecordingState, SessionEvent};
+use crate::input::hotkey::{HotkeyEvent, HotkeySource};
 use crate::runtime_config::{self, ListenerConfig, ProfileSelection};
 use crate::{audio, core, input, postprocess, transcriber};
+
+mod event_loop;
 
 pub(super) fn run() -> Result<(), Box<dyn std::error::Error>> {
     let (store, document) = load_config()?;
@@ -18,33 +22,25 @@ pub(super) fn run() -> Result<(), Box<dyn std::error::Error>> {
     run_with_config(config)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RecordingInput {
-    HoldPressed,
-    HoldReleased,
-    TogglePressed,
-    TrayClicked,
+fn hotkey_session_event(event: HotkeyEvent, state: &RecordingState) -> Option<SessionEvent> {
+    match event {
+        HotkeyEvent::Pressed(HotkeySource::Hold) if matches!(state, RecordingState::Idle) => {
+            Some(SessionEvent::StartRequested)
+        }
+        HotkeyEvent::Released(HotkeySource::Hold)
+            if matches!(state, RecordingState::Recording { .. }) =>
+        {
+            Some(SessionEvent::StopRequested)
+        }
+        HotkeyEvent::Pressed(HotkeySource::Toggle) => toggle_session_event(state),
+        _ => None,
+    }
 }
 
-fn normalize_recording_input(
-    input: RecordingInput,
-    state: &core::recording_session::RecordingState,
-) -> Option<core::recording_session::SessionEvent> {
-    use core::recording_session::{RecordingState, SessionEvent};
-
-    match (input, state) {
-        (
-            RecordingInput::HoldPressed
-            | RecordingInput::TogglePressed
-            | RecordingInput::TrayClicked,
-            RecordingState::Idle,
-        ) => Some(SessionEvent::StartRequested),
-        (
-            RecordingInput::HoldReleased
-            | RecordingInput::TogglePressed
-            | RecordingInput::TrayClicked,
-            RecordingState::Recording { .. },
-        ) => Some(SessionEvent::StopRequested),
+fn toggle_session_event(state: &RecordingState) -> Option<SessionEvent> {
+    match state {
+        RecordingState::Idle => Some(SessionEvent::StartRequested),
+        RecordingState::Recording { .. } => Some(SessionEvent::StopRequested),
         _ => None,
     }
 }
@@ -53,14 +49,16 @@ fn normalize_recording_input(
 pub(super) fn run_with_config(
     mut config: ListenerConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::Arc;
+
     use audio::AudioRecorder;
     use core::orchestrator::SessionOrchestrator;
-    use core::recording_session::{RecordingSessionMachine, SessionEvent};
-    use input::hotkey::{HotkeyEvent, HotkeyManager, HotkeySource};
-    use input::tray::{TrayAction, TrayManager};
+    use event_loop::{AppEvent, ListenerApplication};
+    use input::hotkey::start_hotkey_listener;
+    use input::tray::TrayManager;
     use postprocess::PostProcessor;
-    use std::sync::Arc;
-    use transcriber::{ApiTranscriber, Transcriber};
+    use transcriber::ApiTranscriber;
+    use winit::event_loop::{ControlFlow, EventLoop};
 
     println!("ViberWhisper - Voice-to-Text Input");
     println!("===================================");
@@ -68,28 +66,39 @@ pub(super) fn run_with_config(
 
     let local_manager = start_local_backend(&mut config.backend)?;
     let _local_manager = LocalServiceGuard::new(local_manager);
-    let hotkey_manager = HotkeyManager::new(&config.hotkeys);
-
-    let mut recorder = AudioRecorder::with_config(&config.audio);
-
-    // Build transcriber and wrap in Arc<dyn Transcriber> for orchestrator injection.
-    let transcriber: Arc<dyn Transcriber> =
-        Arc::new(ApiTranscriber::new(config.backend.transcriber)?);
 
     let post_processor = PostProcessor::new(config.backend.post_process);
-
-    let orchestrator = SessionOrchestrator::new(Arc::clone(&transcriber), config.orchestrator);
+    let orchestrator = Arc::new(SessionOrchestrator::new(
+        Arc::new(ApiTranscriber::new(config.backend.transcriber)?),
+        config.orchestrator,
+    ));
 
     #[cfg(target_os = "macos")]
-    let typer = crate::platform::macos::MacTyper;
+    let typer = Arc::new(crate::platform::macos::MacTyper);
     #[cfg(target_os = "windows")]
-    let typer = crate::platform::windows::WindowsTyper;
+    let typer = Arc::new(crate::platform::windows::WindowsTyper);
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    let typer = input::typer::MockTyper;
+    let typer = Arc::new(input::typer::MockTyper);
 
-    let mut tray = TrayManager::new()?;
+    let event_loop = EventLoop::<AppEvent>::with_user_event().build()?;
+    event_loop.set_control_flow(ControlFlow::Wait);
+    let proxy = event_loop.create_proxy();
+
+    let hotkey_proxy = proxy.clone();
+    start_hotkey_listener(&config.hotkeys, move |event| {
+        let _ = hotkey_proxy.send_event(AppEvent::Hotkey(event));
+    });
+
+    let audio_proxy = proxy.clone();
+    let recorder = AudioRecorder::with_config(&config.audio, move |session_id| {
+        let _ = audio_proxy.send_event(AppEvent::AudioChunkAvailable { session_id });
+    });
+
+    let tray_proxy = proxy.clone();
+    let tray = TrayManager::new(move |event| {
+        let _ = tray_proxy.send_event(AppEvent::Tray(event));
+    })?;
     info!("System tray icon started");
-    let mut session_machine = RecordingSessionMachine::new();
 
     if let Some(hotkey) = config.hotkeys.hold_label.as_deref() {
         println!("Hold {hotkey} to record, release to transcribe.");
@@ -100,326 +109,21 @@ pub(super) fn run_with_config(
     println!("Press Ctrl+C to exit.");
     println!();
 
-    let mut counter = 0;
-    loop {
-        tray.update();
-
-        if let Some(action) = tray.check_action() {
-            let event = match action {
-                TrayAction::Exit => Some(SessionEvent::ShutdownRequested),
-                TrayAction::ToggleRecording => {
-                    normalize_recording_input(RecordingInput::TrayClicked, session_machine.state())
-                }
-            };
-            if let Some(event) = event
-                && drive_session(
-                    &mut session_machine,
-                    event,
-                    &mut recorder,
-                    &orchestrator,
-                    &mut tray,
-                    &post_processor,
-                    &typer,
-                )
-            {
-                break Ok(());
-            }
-        }
-
-        if let Some(event) = hotkey_manager.check_event() {
-            let input = match event {
-                HotkeyEvent::Pressed(HotkeySource::Hold) => Some(RecordingInput::HoldPressed),
-                HotkeyEvent::Released(HotkeySource::Hold) => Some(RecordingInput::HoldReleased),
-                HotkeyEvent::Pressed(HotkeySource::Toggle) => Some(RecordingInput::TogglePressed),
-                HotkeyEvent::Released(HotkeySource::Toggle) => None,
-            };
-            if let Some(event) =
-                input.and_then(|input| normalize_recording_input(input, session_machine.state()))
-            {
-                let _ = drive_session(
-                    &mut session_machine,
-                    event,
-                    &mut recorder,
-                    &orchestrator,
-                    &mut tray,
-                    &post_processor,
-                    &typer,
-                );
-            }
-        }
-
-        if let Some(chunk) = recorder.take_ready_chunk() {
-            let _ = drive_session(
-                &mut session_machine,
-                SessionEvent::ChunkReady {
-                    session_id: chunk.session_id,
-                    chunk: chunk.chunk,
-                },
-                &mut recorder,
-                &orchestrator,
-                &mut tray,
-                &post_processor,
-                &typer,
-            );
-        }
-
-        counter += 1;
-        if counter % 300 == 0 {
-            let status = format!("{:?}", session_machine.state());
-            debug!(
-                status = %status,
-                hold_hotkey = %config.hotkeys.hold_label.as_deref().unwrap_or("disabled"),
-                toggle_hotkey = %config.hotkeys.toggle_label.as_deref().unwrap_or("disabled"),
-                "Heartbeat"
-            );
-        }
-
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
-}
-
-/// Executes state-machine effects and feeds component results back into the same transition queue.
-fn drive_session(
-    machine: &mut core::recording_session::RecordingSessionMachine,
-    initial_event: core::recording_session::SessionEvent,
-    recorder: &mut audio::AudioRecorder,
-    orchestrator: &core::orchestrator::SessionOrchestrator,
-    tray: &mut input::tray::TrayManager,
-    post_processor: &postprocess::PostProcessor,
-    typer: &dyn input::typer::TextTyper,
-) -> bool {
-    use audio::{RecorderStartOutcome, RecorderStopOutcome};
-    use core::recording_session::{SessionEffect, SessionEvent};
-    use std::collections::VecDeque;
-
-    let mut events = VecDeque::from([initial_event]);
-    let mut ready_to_exit = false;
-    while let Some(event) = events.pop_front() {
-        for effect in machine.handle(event) {
-            match effect {
-                SessionEffect::StartSession { session_id } => {
-                    let event = match recorder.start_recording(session_id) {
-                        RecorderStartOutcome::Started { session_id } => {
-                            match orchestrator.start_session(session_id) {
-                                Ok(()) => SessionEvent::SessionStarted { session_id },
-                                Err(error) => {
-                                    let active_session_id = match &error {
-                                        core::orchestrator::SessionStartError::ActiveSession {
-                                            active,
-                                            ..
-                                        } => *active,
-                                    };
-                                    let cancel_outcome = recorder.cancel_recording(session_id);
-                                    debug!(
-                                        session_id = session_id.0,
-                                        ?cancel_outcome,
-                                        "Recorder startup rollback handled"
-                                    );
-                                    if let Err(abort_error) =
-                                        orchestrator.abort_session(active_session_id)
-                                    {
-                                        debug!(
-                                            session_id = active_session_id.0,
-                                            error = %abort_error,
-                                            "Orchestrator startup rollback had no matching session"
-                                        );
-                                    }
-                                    error!(
-                                        session_id = session_id.0,
-                                        error = %error,
-                                        "Failed to start recording session"
-                                    );
-                                    SessionEvent::SessionStartFailed {
-                                        session_id,
-                                        error: error.to_string(),
-                                    }
-                                }
-                            }
-                        }
-                        RecorderStartOutcome::AlreadyRecording {
-                            requested_session_id,
-                            active_session_id,
-                        } => {
-                            let cancel_outcome = recorder.cancel_recording(active_session_id);
-                            debug!(
-                                session_id = active_session_id.0,
-                                ?cancel_outcome,
-                                "Orphan recorder cleanup handled"
-                            );
-                            if let Err(error) = orchestrator.abort_session(active_session_id) {
-                                debug!(
-                                    session_id = active_session_id.0,
-                                    error = %error,
-                                    "Orphan orchestrator cleanup had no matching session"
-                                );
-                            }
-                            let error = format!(
-                                "recorder session {} is already active",
-                                active_session_id.0
-                            );
-                            error!(
-                                requested_session_id = requested_session_id.0,
-                                active_session_id = active_session_id.0,
-                                "Failed to start recording session"
-                            );
-                            SessionEvent::SessionStartFailed {
-                                session_id: requested_session_id,
-                                error,
-                            }
-                        }
-                        RecorderStartOutcome::Failed { session_id, error } => {
-                            error!(
-                                session_id = session_id.0,
-                                error, "Failed to start recording session"
-                            );
-                            SessionEvent::SessionStartFailed { session_id, error }
-                        }
-                    };
-                    events.push_back(event);
-                }
-                SessionEffect::StopSession { session_id } => {
-                    let event = match recorder.stop_recording(session_id) {
-                        RecorderStopOutcome::Stopped {
-                            session_id,
-                            chunks,
-                            warning,
-                        } => {
-                            if let Some(warning) = warning.as_deref() {
-                                warn!(
-                                    session_id = session_id.0,
-                                    warning, "Recorder stopped with a warning"
-                                );
-                            }
-                            for chunk in chunks {
-                                if let Err(error) = orchestrator.on_chunk_ready(session_id, chunk) {
-                                    warn!(session_id = session_id.0, error = %error, "Stop-time chunk was rejected");
-                                }
-                            }
-                            finish_transcription(
-                                orchestrator.finish_session(session_id),
-                                post_processor,
-                                typer,
-                            );
-                            SessionEvent::SessionStopped { session_id }
-                        }
-                        RecorderStopOutcome::StillRecording { session_id, error } => {
-                            error!(session_id = session_id.0, error, "Failed to stop recorder");
-                            SessionEvent::SessionStopFailed { session_id, error }
-                        }
-                        RecorderStopOutcome::NotRecording {
-                            requested_session_id,
-                        } => {
-                            finish_transcription(
-                                orchestrator.finish_session(requested_session_id),
-                                post_processor,
-                                typer,
-                            );
-                            SessionEvent::SessionStopped {
-                                session_id: requested_session_id,
-                            }
-                        }
-                    };
-                    events.push_back(event);
-                }
-                SessionEffect::SubmitChunk { session_id, chunk } => {
-                    if let Err(error) = orchestrator.on_chunk_ready(session_id, chunk) {
-                        warn!(session_id = session_id.0, error = %error, "Chunk was rejected");
-                    }
-                }
-                SessionEffect::CancelRecorder { session_id } => {
-                    let outcome = recorder.cancel_recording(session_id);
-                    debug!(
-                        session_id = session_id.0,
-                        ?outcome,
-                        "Recorder cancellation handled"
-                    );
-                }
-                SessionEffect::AbortOrchestrator { session_id } => {
-                    if let Err(error) = orchestrator.abort_session(session_id) {
-                        debug!(session_id = session_id.0, error = %error, "No matching orchestrator session to abort");
-                    }
-                }
-                SessionEffect::SetTrayRecording(recording) => tray.set_recording(recording),
-                SessionEffect::ReadyToExit => ready_to_exit = true,
-            }
-        }
-    }
-    ready_to_exit
-}
-
-fn finish_transcription(
-    result: Result<String, core::orchestrator::SessionError>,
-    post_processor: &postprocess::PostProcessor,
-    typer: &dyn input::typer::TextTyper,
-) {
-    use core::orchestrator::SessionError;
-
-    match result {
-        Ok(stt_text) => {
-            if stt_text.is_empty() {
-                info!("Transcription returned empty text");
-                return;
-            }
-            let text = {
-                let mut session = post_processor.start_session();
-                session.push_stable_chunk(&stt_text);
-                match session.finish() {
-                    Ok(processed) if !processed.is_empty() => processed,
-                    Ok(_) => {
-                        warn!("Post-processing returned empty text, using original STT text");
-                        stt_text
-                    }
-                    Err(error) => {
-                        warn!(error = %error, "Post-processing failed, using original STT text");
-                        stt_text
-                    }
-                }
-            };
-            info!(text = %text, "Typing transcribed text");
-            if let Err(error) = typer.type_text(&text) {
-                error!(error = %error, "Failed to type text");
-            }
-        }
-        Err(SessionError::NoChunks) => warn!("No audio chunks to transcribe"),
-        Err(SessionError::Routing(error)) => {
-            error!(error = %error, "Session routing failed while finalizing")
-        }
-        Err(SessionError::PartialFailure {
-            errors,
-            partial_text,
-        }) => {
-            error!(
-                failed_chunks = errors.len(),
-                "Partial transcription failure"
-            );
-            if !partial_text.is_empty()
-                && let Err(error) = typer.type_text(&partial_text)
-            {
-                error!(error = %error, "Failed to type partial text");
-            }
-        }
-        Err(SessionError::ConvergenceTimeout {
-            pending_count,
-            partial_text,
-        }) => {
-            warn!(pending_count, "Convergence timeout");
-            if !partial_text.is_empty()
-                && let Err(error) = typer.type_text(&partial_text)
-            {
-                error!(error = %error, "Failed to type partial text");
-            }
-        }
-    }
+    let mut application =
+        ListenerApplication::new(recorder, orchestrator, tray, post_processor, typer, proxy);
+    event_loop.run_app(&mut application)?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RecordingInput, normalize_recording_input};
+    use super::{hotkey_session_event, toggle_session_event};
     use crate::core::recording_session::{RecordingState, SessionEvent};
+    use crate::input::hotkey::{HotkeyEvent, HotkeySource};
     use crate::session::SessionId;
 
     #[test]
-    fn input_normalization_is_source_free_and_state_aware() {
+    fn hotkey_and_toggle_requests_are_state_aware() {
         let idle = RecordingState::Idle;
         let recording = RecordingState::Recording {
             session_id: SessionId(1),
@@ -429,41 +133,42 @@ mod tests {
         };
 
         assert_eq!(
-            normalize_recording_input(RecordingInput::HoldPressed, &idle),
+            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Hold), &idle),
             Some(SessionEvent::StartRequested)
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::HoldReleased, &recording),
+            hotkey_session_event(HotkeyEvent::Released(HotkeySource::Hold), &recording),
             Some(SessionEvent::StopRequested)
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::TogglePressed, &idle),
+            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Toggle), &idle),
             Some(SessionEvent::StartRequested)
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::TogglePressed, &recording),
+            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Toggle), &recording),
             Some(SessionEvent::StopRequested)
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::TrayClicked, &idle),
+            toggle_session_event(&idle),
             Some(SessionEvent::StartRequested)
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::TrayClicked, &recording),
+            toggle_session_event(&recording),
             Some(SessionEvent::StopRequested)
         );
 
         assert_eq!(
-            normalize_recording_input(RecordingInput::HoldPressed, &recording),
+            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Hold), &recording),
             None
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::HoldReleased, &idle),
+            hotkey_session_event(HotkeyEvent::Released(HotkeySource::Hold), &idle),
             None
         );
         assert_eq!(
-            normalize_recording_input(RecordingInput::TogglePressed, &starting),
+            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Toggle), &starting),
             None
         );
+        assert_eq!(toggle_session_event(&starting), None);
     }
 }

--- a/src/application/listener/event_loop.rs
+++ b/src/application/listener/event_loop.rs
@@ -1,0 +1,599 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+use tracing::{debug, error, info, warn};
+use winit::application::ApplicationHandler;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
+use winit::window::WindowId;
+
+use super::{hotkey_session_event, toggle_session_event};
+use crate::audio::{AudioRecorder, RecorderStartOutcome, RecorderStopOutcome};
+use crate::core::orchestrator::{SessionError, SessionOrchestrator};
+use crate::core::recording_session::{
+    RecordingSessionMachine, RecordingState, SessionEffect, SessionEvent,
+};
+use crate::input::hotkey::HotkeyEvent;
+use crate::input::tray::{TrayAction, TrayEvent, TrayManager};
+use crate::input::typer::TextTyper;
+use crate::postprocess::{PostProcessor, PostProcessorSession};
+use crate::session::SessionId;
+
+#[derive(Debug, Clone)]
+pub(super) enum AppEvent {
+    Hotkey(HotkeyEvent),
+    Tray(TrayEvent),
+    AudioChunkAvailable { session_id: SessionId },
+    FinalizationFinished { session_id: SessionId },
+}
+
+struct FinalizationTask {
+    session_id: SessionId,
+    gate: Arc<FinalizationGate>,
+}
+
+struct FinalizationGate(AtomicBool);
+
+impl FinalizationGate {
+    fn new() -> Self {
+        Self(AtomicBool::new(false))
+    }
+
+    fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+
+    fn type_text_if_active(
+        &self,
+        typer: &dyn TextTyper,
+        text: &str,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        if self.is_cancelled() {
+            return Ok(false);
+        }
+        typer.type_text(text)?;
+        Ok(true)
+    }
+}
+
+fn finalization_completion_event(
+    finalization: &mut Option<FinalizationTask>,
+    session_id: SessionId,
+) -> SessionEvent {
+    if finalization
+        .as_ref()
+        .is_some_and(|task| task.session_id == session_id)
+    {
+        *finalization = None;
+    }
+    SessionEvent::SessionStopped { session_id }
+}
+
+fn spawn_finalization_worker(
+    session_id: SessionId,
+    finish: impl FnOnce() + Send + 'static,
+    notify: impl FnOnce(SessionId) + Send + 'static,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        finish();
+        notify(session_id);
+    })
+}
+
+pub(super) struct ListenerApplication {
+    machine: RecordingSessionMachine,
+    recorder: AudioRecorder,
+    orchestrator: Arc<SessionOrchestrator>,
+    tray: TrayManager,
+    post_processor: PostProcessor,
+    typer: Arc<dyn TextTyper>,
+    proxy: EventLoopProxy<AppEvent>,
+    finalization: Option<FinalizationTask>,
+}
+
+impl ListenerApplication {
+    pub(super) fn new(
+        recorder: AudioRecorder,
+        orchestrator: Arc<SessionOrchestrator>,
+        tray: TrayManager,
+        post_processor: PostProcessor,
+        typer: Arc<dyn TextTyper>,
+        proxy: EventLoopProxy<AppEvent>,
+    ) -> Self {
+        Self {
+            machine: RecordingSessionMachine::new(),
+            recorder,
+            orchestrator,
+            tray,
+            post_processor,
+            typer,
+            proxy,
+            finalization: None,
+        }
+    }
+
+    fn handle_app_event(&mut self, event_loop: &ActiveEventLoop, event: AppEvent) {
+        match event {
+            AppEvent::Hotkey(event) => {
+                if let Some(event) = hotkey_session_event(event, self.machine.state()) {
+                    self.drive_session(event_loop, event);
+                }
+            }
+            AppEvent::Tray(event) => {
+                if let Some(action) = self.tray.handle_event(event) {
+                    let event = match action {
+                        TrayAction::Exit => Some(SessionEvent::ShutdownRequested),
+                        TrayAction::ToggleRecording => toggle_session_event(self.machine.state()),
+                    };
+                    if let Some(event) = event {
+                        self.drive_session(event_loop, event);
+                    }
+                }
+            }
+            AppEvent::AudioChunkAvailable { session_id } => {
+                self.drain_audio_chunks(event_loop, session_id);
+            }
+            AppEvent::FinalizationFinished { session_id } => {
+                let event = finalization_completion_event(&mut self.finalization, session_id);
+                self.drive_session(event_loop, event);
+            }
+        }
+    }
+
+    fn drain_audio_chunks(&mut self, event_loop: &ActiveEventLoop, session_id: SessionId) {
+        if !matches!(
+            self.machine.state(),
+            RecordingState::Recording { session_id: active } if *active == session_id
+        ) {
+            return;
+        }
+
+        while let Some(chunk) = self.recorder.take_ready_chunk() {
+            self.drive_session(
+                event_loop,
+                SessionEvent::ChunkReady {
+                    session_id: chunk.session_id,
+                    chunk: chunk.chunk,
+                },
+            );
+        }
+    }
+
+    fn drive_session(&mut self, event_loop: &ActiveEventLoop, initial_event: SessionEvent) {
+        if matches!(initial_event, SessionEvent::ShutdownRequested) {
+            self.cancel_finalization();
+        }
+
+        let mut events = VecDeque::from([initial_event]);
+        while let Some(event) = events.pop_front() {
+            for effect in self.machine.handle(event) {
+                match effect {
+                    SessionEffect::StartSession { session_id } => {
+                        events.push_back(self.start_session(session_id));
+                    }
+                    SessionEffect::StopSession { session_id } => {
+                        if let Some(event) = self.stop_session(session_id) {
+                            events.push_back(event);
+                        }
+                    }
+                    SessionEffect::SubmitChunk { session_id, chunk } => {
+                        if let Err(error) = self.orchestrator.on_chunk_ready(session_id, chunk) {
+                            warn!(session_id = session_id.0, error = %error, "Chunk was rejected");
+                        }
+                    }
+                    SessionEffect::CancelRecorder { session_id } => {
+                        let outcome = self.recorder.cancel_recording(session_id);
+                        debug!(
+                            session_id = session_id.0,
+                            ?outcome,
+                            "Recorder cancellation handled"
+                        );
+                    }
+                    SessionEffect::AbortOrchestrator { session_id } => {
+                        if let Err(error) = self.orchestrator.abort_session(session_id) {
+                            debug!(session_id = session_id.0, error = %error, "No matching orchestrator session to abort");
+                        }
+                    }
+                    SessionEffect::SetTrayRecording(recording) => {
+                        self.tray.set_recording(recording);
+                    }
+                    SessionEffect::ReadyToExit => event_loop.exit(),
+                }
+            }
+        }
+    }
+
+    fn start_session(&mut self, session_id: SessionId) -> SessionEvent {
+        match self.recorder.start_recording(session_id) {
+            RecorderStartOutcome::Started { session_id } => {
+                match self.orchestrator.start_session(session_id) {
+                    Ok(()) => SessionEvent::SessionStarted { session_id },
+                    Err(error) => {
+                        let active_session_id = match &error {
+                            crate::core::orchestrator::SessionStartError::ActiveSession {
+                                active,
+                                ..
+                            } => *active,
+                        };
+                        let cancel_outcome = self.recorder.cancel_recording(session_id);
+                        debug!(
+                            session_id = session_id.0,
+                            ?cancel_outcome,
+                            "Recorder startup rollback handled"
+                        );
+                        if let Err(abort_error) = self.orchestrator.abort_session(active_session_id)
+                        {
+                            debug!(
+                                session_id = active_session_id.0,
+                                error = %abort_error,
+                                "Orchestrator startup rollback had no matching session"
+                            );
+                        }
+                        error!(
+                            session_id = session_id.0,
+                            error = %error,
+                            "Failed to start recording session"
+                        );
+                        SessionEvent::SessionStartFailed {
+                            session_id,
+                            error: error.to_string(),
+                        }
+                    }
+                }
+            }
+            RecorderStartOutcome::AlreadyRecording {
+                requested_session_id,
+                active_session_id,
+            } => {
+                let cancel_outcome = self.recorder.cancel_recording(active_session_id);
+                debug!(
+                    session_id = active_session_id.0,
+                    ?cancel_outcome,
+                    "Orphan recorder cleanup handled"
+                );
+                if let Err(error) = self.orchestrator.abort_session(active_session_id) {
+                    debug!(
+                        session_id = active_session_id.0,
+                        error = %error,
+                        "Orphan orchestrator cleanup had no matching session"
+                    );
+                }
+                let error = format!("recorder session {} is already active", active_session_id.0);
+                error!(
+                    requested_session_id = requested_session_id.0,
+                    active_session_id = active_session_id.0,
+                    "Failed to start recording session"
+                );
+                SessionEvent::SessionStartFailed {
+                    session_id: requested_session_id,
+                    error,
+                }
+            }
+            RecorderStartOutcome::Failed { session_id, error } => {
+                error!(
+                    session_id = session_id.0,
+                    error, "Failed to start recording session"
+                );
+                SessionEvent::SessionStartFailed { session_id, error }
+            }
+        }
+    }
+
+    /// Stop the recorder immediately and leave the state machine in `Stopping`
+    /// while convergence, cleanup, and delivery run away from the native event loop.
+    fn stop_session(&mut self, session_id: SessionId) -> Option<SessionEvent> {
+        match self.recorder.stop_recording(session_id) {
+            RecorderStopOutcome::Stopped {
+                session_id,
+                chunks,
+                warning,
+            } => {
+                if let Some(warning) = warning.as_deref() {
+                    warn!(
+                        session_id = session_id.0,
+                        warning, "Recorder stopped with a warning"
+                    );
+                }
+                for chunk in chunks {
+                    if let Err(error) = self.orchestrator.on_chunk_ready(session_id, chunk) {
+                        warn!(session_id = session_id.0, error = %error, "Stop-time chunk was rejected");
+                    }
+                }
+                self.spawn_finalization(session_id);
+                None
+            }
+            RecorderStopOutcome::StillRecording { session_id, error } => {
+                error!(session_id = session_id.0, error, "Failed to stop recorder");
+                Some(SessionEvent::SessionStopFailed { session_id, error })
+            }
+            RecorderStopOutcome::NotRecording {
+                requested_session_id,
+            } => {
+                self.spawn_finalization(requested_session_id);
+                None
+            }
+        }
+    }
+
+    fn spawn_finalization(&mut self, session_id: SessionId) {
+        let gate = Arc::new(FinalizationGate::new());
+        self.finalization = Some(FinalizationTask {
+            session_id,
+            gate: Arc::clone(&gate),
+        });
+
+        let orchestrator = Arc::clone(&self.orchestrator);
+        let mut post_processor = self.post_processor.start_session();
+        let typer = Arc::clone(&self.typer);
+        let proxy = self.proxy.clone();
+        spawn_finalization_worker(
+            session_id,
+            move || {
+                finish_transcription(
+                    orchestrator.finish_session(session_id),
+                    &mut post_processor,
+                    typer.as_ref(),
+                    gate.as_ref(),
+                );
+            },
+            move |session_id| {
+                let _ = proxy.send_event(AppEvent::FinalizationFinished { session_id });
+            },
+        );
+    }
+
+    fn cancel_finalization(&mut self) {
+        if let Some(task) = &self.finalization {
+            task.gate.cancel();
+        }
+    }
+}
+
+impl ApplicationHandler<AppEvent> for ListenerApplication {
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
+
+    fn window_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        _event: WindowEvent,
+    ) {
+    }
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: AppEvent) {
+        self.handle_app_event(event_loop, event);
+    }
+
+    fn exiting(&mut self, _event_loop: &ActiveEventLoop) {
+        self.cancel_finalization();
+    }
+}
+
+fn finish_transcription(
+    result: Result<String, SessionError>,
+    post_processor: &mut PostProcessorSession,
+    typer: &dyn TextTyper,
+    gate: &FinalizationGate,
+) {
+    if gate.is_cancelled() {
+        return;
+    }
+
+    match result {
+        Ok(stt_text) => {
+            if stt_text.is_empty() {
+                info!("Transcription returned empty text");
+                return;
+            }
+            post_processor.push_stable_chunk(&stt_text);
+            let text = match post_processor.finish() {
+                Ok(processed) if !processed.is_empty() => processed,
+                Ok(_) => {
+                    warn!("Post-processing returned empty text, using original STT text");
+                    stt_text
+                }
+                Err(error) => {
+                    warn!(error = %error, "Post-processing failed, using original STT text");
+                    stt_text
+                }
+            };
+            info!(text = %text, "Typing transcribed text");
+            if let Err(error) = gate.type_text_if_active(typer, &text) {
+                error!(error = %error, "Failed to type text");
+            }
+        }
+        Err(SessionError::NoChunks) => warn!("No audio chunks to transcribe"),
+        Err(SessionError::Routing(error)) => {
+            error!(error = %error, "Session routing failed while finalizing")
+        }
+        Err(SessionError::PartialFailure {
+            errors,
+            partial_text,
+        }) => {
+            error!(
+                failed_chunks = errors.len(),
+                "Partial transcription failure"
+            );
+            if !partial_text.is_empty()
+                && let Err(error) = gate.type_text_if_active(typer, &partial_text)
+            {
+                error!(error = %error, "Failed to type partial text");
+            }
+        }
+        Err(SessionError::ConvergenceTimeout {
+            pending_count,
+            partial_text,
+        }) => {
+            warn!(pending_count, "Convergence timeout");
+            if !partial_text.is_empty()
+                && let Err(error) = gate.type_text_if_active(typer, &partial_text)
+            {
+                error!(error = %error, "Failed to type partial text");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    use crate::core::recording_session::{RecordingSessionMachine, RecordingState, SessionEvent};
+    use crate::input::typer::TextTyper;
+    use crate::session::SessionId;
+
+    use super::{
+        FinalizationGate, FinalizationTask, finalization_completion_event,
+        spawn_finalization_worker,
+    };
+
+    struct CountingTyper(AtomicUsize);
+
+    impl TextTyper for CountingTyper {
+        fn type_text(&self, _text: &str) -> Result<(), Box<dyn std::error::Error>> {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn shutdown_cancellation_prevents_late_text_injection() {
+        // A finalization worker may finish after the user exits; that stale result must
+        // never paste into whichever application has focus by then.
+        let gate = FinalizationGate::new();
+        gate.cancel();
+        let typer = CountingTyper(AtomicUsize::new(0));
+
+        let delivered = gate.type_text_if_active(&typer, "late result").unwrap();
+
+        assert!(!delivered);
+        assert_eq!(typer.0.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn active_finalization_injects_text_once() {
+        let gate = FinalizationGate::new();
+        let typer = CountingTyper(AtomicUsize::new(0));
+
+        let delivered = gate.type_text_if_active(&typer, "ready result").unwrap();
+
+        assert!(delivered);
+        assert_eq!(typer.0.load(Ordering::Relaxed), 1);
+    }
+
+    struct BlockingTyper {
+        entered: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl TextTyper for BlockingTyper {
+        fn type_text(&self, _text: &str) -> Result<(), Box<dyn std::error::Error>> {
+            self.entered.wait();
+            self.release.wait();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn shutdown_does_not_wait_for_in_flight_text_delivery() {
+        // Platform injection may already be in progress when the user exits. Cancellation
+        // must return promptly while preventing any later delivery attempt.
+        let gate = Arc::new(FinalizationGate::new());
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let typer = Arc::new(BlockingTyper {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+        });
+
+        let delivery_gate = Arc::clone(&gate);
+        let delivery = thread::spawn(move || {
+            delivery_gate
+                .type_text_if_active(typer.as_ref(), "ready result")
+                .unwrap()
+        });
+        entered.wait();
+
+        let cancel_gate = Arc::clone(&gate);
+        let (cancelled_tx, cancelled_rx) = mpsc::channel();
+        let cancellation = thread::spawn(move || {
+            cancel_gate.cancel();
+            cancelled_tx.send(()).unwrap();
+        });
+        let cancellation_completed = cancelled_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+
+        release.wait();
+        assert!(delivery.join().unwrap());
+        cancellation.join().unwrap();
+        assert!(cancellation_completed);
+
+        let late_typer = CountingTyper(AtomicUsize::new(0));
+        assert!(
+            !gate
+                .type_text_if_active(&late_typer, "late result")
+                .unwrap()
+        );
+        assert_eq!(late_typer.0.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn finalization_worker_returns_before_completion_and_delivers_session_id() {
+        let session_id = SessionId(11);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = mpsc::channel();
+
+        let worker = spawn_finalization_worker(
+            session_id,
+            move || {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            },
+            move |finished_session_id| finished_tx.send(finished_session_id).unwrap(),
+        );
+
+        started_rx.recv().unwrap();
+        assert_eq!(finished_rx.try_recv(), Err(mpsc::TryRecvError::Empty));
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            finished_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            session_id
+        );
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn matching_finalization_completion_reaches_idle_and_stale_completion_is_rejected() {
+        let session_id = SessionId(1);
+        let stale_session_id = SessionId(2);
+        let mut machine = RecordingSessionMachine::new();
+        machine.handle(SessionEvent::StartRequested);
+        machine.handle(SessionEvent::SessionStarted { session_id });
+        machine.handle(SessionEvent::StopRequested);
+        assert_eq!(machine.state(), &RecordingState::Stopping { session_id });
+
+        let mut finalization = Some(FinalizationTask {
+            session_id,
+            gate: Arc::new(FinalizationGate::new()),
+        });
+        let stale_event = finalization_completion_event(&mut finalization, stale_session_id);
+        machine.handle(stale_event);
+        assert!(finalization.is_some());
+        assert_eq!(machine.state(), &RecordingState::Stopping { session_id });
+
+        let matching_event = finalization_completion_event(&mut finalization, session_id);
+        machine.handle(matching_event);
+        assert!(finalization.is_none());
+        assert_eq!(machine.state(), &RecordingState::Idle);
+    }
+}

--- a/src/audio/recorder.rs
+++ b/src/audio/recorder.rs
@@ -91,6 +91,7 @@ pub struct AudioRecorder {
     flushed_samples: usize,
     /// Number of complete chunks observed by the audio callback.
     ready_chunk_count: Arc<AtomicUsize>,
+    chunk_notifier: Arc<dyn Fn(SessionId) + Send + Sync>,
     /// Maximum mono frames per chunk. `None` means unlimited and `Some(0)` suppresses output.
     chunk_max_samples: Option<usize>,
     /// Production policy: max chunk duration in seconds.
@@ -99,8 +100,8 @@ pub struct AudioRecorder {
     max_chunk_size_bytes: u64,
 }
 
-/// Shared logic for both I16 and F32 audio callbacks: append mono samples to the
-/// buffer and signal a flush when the chunk threshold is crossed.
+/// Shared logic for both I16 and F32 audio callbacks: append mono samples and
+/// report whether the callback crossed a new chunk boundary.
 fn push_mono_chunk(
     mono: Vec<i16>,
     buffer: &Mutex<Vec<i16>>,
@@ -108,7 +109,7 @@ fn push_mono_chunk(
     ready_chunk_count: &AtomicUsize,
     sample_rate: u32,
     chunk_max_samples: usize,
-) {
+) -> bool {
     let len = mono.len();
     buffer.lock().unwrap().extend_from_slice(&mono);
     let total = sample_count.fetch_add(len, Ordering::Relaxed) + len;
@@ -120,13 +121,18 @@ fn push_mono_chunk(
         );
     }
     if let Some(ready_chunks) = total.checked_div(chunk_max_samples) {
-        ready_chunk_count.store(ready_chunks, Ordering::Release);
+        let previous = ready_chunk_count.swap(ready_chunks, Ordering::AcqRel);
+        return ready_chunks > previous;
     }
+    false
 }
 
 impl AudioRecorder {
     /// Create a recorder with the module-owned production chunk policy.
-    pub fn with_config(config: &AudioConfig) -> Self {
+    pub fn with_config(
+        config: &AudioConfig,
+        chunk_notifier: impl Fn(SessionId) + Send + Sync + 'static,
+    ) -> Self {
         let gain = config.mic_gain;
         let max_chunk_duration_secs = config.max_chunk_duration_secs;
         let max_chunk_size_bytes = config.max_chunk_size_bytes;
@@ -163,6 +169,7 @@ impl AudioRecorder {
             sample_rate: 44100,
             flushed_samples: 0,
             ready_chunk_count: Arc::new(AtomicUsize::new(0)),
+            chunk_notifier: Arc::new(chunk_notifier),
             chunk_max_samples: None,
             max_chunk_duration_secs,
             max_chunk_size_bytes,
@@ -221,6 +228,7 @@ impl AudioRecorder {
         let buffer = Arc::clone(&self.buffer);
         let sample_count = Arc::clone(&self.sample_count);
         let ready_chunk_count = Arc::clone(&self.ready_chunk_count);
+        let chunk_notifier = Arc::clone(&self.chunk_notifier);
         let chunk_max_samples = self.chunk_max_samples.unwrap_or(0);
         let gain = self.gain;
 
@@ -240,14 +248,16 @@ impl AudioRecorder {
                                 (avg * gain).clamp(i16::MIN as f32, i16::MAX as f32) as i16
                             })
                             .collect();
-                        push_mono_chunk(
+                        if push_mono_chunk(
                             mono,
                             &buffer,
                             &sample_count,
                             &ready_chunk_count,
                             sample_rate,
                             chunk_max_samples,
-                        );
+                        ) {
+                            chunk_notifier(session_id);
+                        }
                     }
                 },
                 move |err| error!(error = %err, "Stream error"),
@@ -265,14 +275,16 @@ impl AudioRecorder {
                             })
                             .map(|s| s as i16)
                             .collect();
-                        push_mono_chunk(
+                        if push_mono_chunk(
                             mono,
                             &buffer,
                             &sample_count,
                             &ready_chunk_count,
                             sample_rate,
                             chunk_max_samples,
-                        );
+                        ) {
+                            chunk_notifier(session_id);
+                        }
                     }
                 },
                 move |err| error!(error = %err, "Stream error"),
@@ -300,9 +312,10 @@ impl AudioRecorder {
 
     /// Encode and return the next complete in-memory chunk, if one is ready.
     pub fn take_ready_chunk(&mut self) -> Option<ReadyChunk> {
-        if !self.recording.load(Ordering::Relaxed) || self.active_session_id.is_none() {
+        if !self.recording.load(Ordering::Relaxed) {
             return None;
         }
+        let session_id = self.active_session_id?;
         let chunk_max_samples = self.chunk_max_samples.filter(|&samples| samples > 0)?;
 
         let flushed_chunk_count = self.flushed_samples / chunk_max_samples;
@@ -319,27 +332,26 @@ impl AudioRecorder {
                 debug!(
                     total_samples = total_samples,
                     chunk_size = chunk_max_samples,
-                    "Chunk count is ahead of buffered samples; retrying later"
+                    "Chunk count is ahead of buffered samples; leaving readiness pending"
                 );
                 return None;
             }
             buffer[..chunk_max_samples].to_vec()
         };
 
-        match encode_i16_wav(&chunk_samples, self.sample_rate) {
-            Ok(chunk) => {
-                self.buffer.lock().unwrap().drain(..chunk_max_samples);
-                self.flushed_samples = chunk_end;
-                Some(ReadyChunk {
-                    session_id: self.active_session_id?,
-                    chunk,
-                })
+        let chunk = match encode_i16_wav(&chunk_samples, self.sample_rate) {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "Failed to encode in-recording chunk; retaining PCM until stop"
+                );
+                return None;
             }
-            Err(e) => {
-                warn!(error = %e, "Failed to encode in-recording chunk; will retry next cycle");
-                None
-            }
-        }
+        };
+        self.buffer.lock().unwrap().drain(..chunk_max_samples);
+        self.flushed_samples = chunk_end;
+        Some(ReadyChunk { session_id, chunk })
     }
 
     #[instrument(skip(self))]
@@ -519,6 +531,7 @@ mod tests {
             sample_rate: 16000,
             flushed_samples: 0,
             ready_chunk_count: Arc::new(AtomicUsize::new(0)),
+            chunk_notifier: Arc::new(|_| {}),
             chunk_max_samples: Some(chunk_max_samples),
             max_chunk_duration_secs: 0,
             max_chunk_size_bytes: 0,
@@ -549,6 +562,40 @@ mod tests {
         for ready in [first, second, third].into_iter().flatten() {
             assert!(hound::WavReader::new(std::io::Cursor::new(ready.chunk.bytes())).is_ok());
         }
+    }
+
+    #[test]
+    fn each_new_chunk_boundary_is_reported_to_the_callback() {
+        let buffer = Mutex::new(Vec::new());
+        let sample_count = AtomicUsize::new(0);
+        let ready_chunk_count = AtomicUsize::new(0);
+
+        assert!(!push_mono_chunk(
+            vec![1; 5],
+            &buffer,
+            &sample_count,
+            &ready_chunk_count,
+            10,
+            10,
+        ));
+        assert!(push_mono_chunk(
+            vec![1; 5],
+            &buffer,
+            &sample_count,
+            &ready_chunk_count,
+            10,
+            10,
+        ));
+        assert!(push_mono_chunk(
+            vec![2; 10],
+            &buffer,
+            &sample_count,
+            &ready_chunk_count,
+            10,
+            10,
+        ));
+
+        assert_eq!(ready_chunk_count.load(Ordering::Acquire), 2);
     }
 
     #[test]

--- a/src/input/hotkey.rs
+++ b/src/input/hotkey.rs
@@ -1,4 +1,3 @@
-use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -413,37 +412,27 @@ impl EventMapper {
     }
 }
 
-pub struct HotkeyManager {
-    events: Receiver<HotkeyEvent>,
-}
+/// Start the process-lifetime global hotkey listener.
+///
+/// The detached `rdev` thread cannot be stopped independently; process shutdown is its lifetime
+/// boundary.
+pub fn start_hotkey_listener(config: &HotkeyConfig, notify: impl Fn(HotkeyEvent) + Send + 'static) {
+    let hold_key = config.hold_key;
+    let toggle_key = config.toggle_key;
+    spawn_listener(EventMapper::new(hold_key, toggle_key), notify);
 
-impl HotkeyManager {
-    pub fn new(config: &HotkeyConfig) -> Self {
-        let hold_key = config.hold_key;
-        let toggle_key = config.toggle_key;
-        let (sender, events) = mpsc::channel();
-        spawn_listener(EventMapper::new(hold_key, toggle_key), sender);
+    log_binding_warnings("hold", hold_key, config.hold_label.as_deref());
+    log_binding_warnings("toggle", toggle_key, config.toggle_label.as_deref());
 
-        log_binding_warnings("hold", hold_key, config.hold_label.as_deref());
-        log_binding_warnings("toggle", toggle_key, config.toggle_label.as_deref());
-
-        if let Some(label) = config.hold_label.as_deref() {
-            info!(hotkey = %label, "hold hotkey registered");
-        }
-        if let Some(label) = config.toggle_label.as_deref() {
-            info!(hotkey = %label, "toggle hotkey registered");
-        }
-
-        Self { events }
+    if let Some(label) = config.hold_label.as_deref() {
+        info!(hotkey = %label, "hold hotkey registered");
     }
-
-    /// Return the oldest pending event without losing later events.
-    pub fn check_event(&self) -> Option<HotkeyEvent> {
-        self.events.try_recv().ok()
+    if let Some(label) = config.toggle_label.as_deref() {
+        info!(hotkey = %label, "toggle hotkey registered");
     }
 }
 
-fn spawn_listener(mapper: EventMapper, sender: Sender<HotkeyEvent>) {
+fn spawn_listener(mapper: EventMapper, notify: impl Fn(HotkeyEvent) + Send + 'static) {
     thread::spawn(move || {
         debug!("rdev listener thread started");
         let mapper = Arc::new(Mutex::new(mapper));
@@ -460,7 +449,7 @@ fn spawn_listener(mapper: EventMapper, sender: Sender<HotkeyEvent>) {
                 Err(poisoned) => poisoned.into_inner().map(&event_type),
             };
             if let Some(event) = mapped {
-                let _ = sender.send(event);
+                notify(event);
             }
         };
 
@@ -477,7 +466,7 @@ mod tests {
     use crate::core::config::{ConfigKey, InputSection};
 
     #[test]
-    fn validates_hotkey_section_before_manager_construction() {
+    fn validates_default_disabled_and_invalid_hotkey_sections() {
         let config = HotkeyConfig::validate(&InputSection::default()).unwrap();
         assert_eq!(config.hold_key, Some(Key::F8));
         assert_eq!(config.toggle_key, Some(Key::F9));

--- a/src/input/tray.rs
+++ b/src/input/tray.rs
@@ -1,12 +1,16 @@
 use std::io::Cursor;
+#[cfg(not(test))]
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[cfg(not(test))]
 use tracing::warn;
 #[cfg(not(test))]
-use tray_icon::menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{Menu, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{MenuEvent, MenuId};
 #[cfg(not(test))]
-use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
+use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
+use tray_icon::{MouseButton, MouseButtonState, TrayIconEvent, TrayIconId};
 
 const MIN_DEBOUNCE_WINDOW: Duration = Duration::from_millis(300);
 const STATUS_IDLE_PNG: &[u8] = include_bytes!("../../assets/status-idle.png");
@@ -17,6 +21,13 @@ const STATUS_RECORDING_PNG: &[u8] = include_bytes!("../../assets/status-recordin
 pub enum TrayAction {
     ToggleRecording,
     Exit,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(test, allow(dead_code))]
+pub enum TrayEvent {
+    Icon(TrayIconEvent),
+    Menu(MenuEvent),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +78,28 @@ impl ClickDebounce {
     }
 }
 
+fn classify_icon_event(tray_icon_id: &TrayIconId, event: &TrayIconEvent) -> ClickPhase {
+    if event.id() != tray_icon_id {
+        return ClickPhase::Other;
+    }
+    match event {
+        TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        } => ClickPhase::LeftUp,
+        TrayIconEvent::DoubleClick {
+            button: MouseButton::Left,
+            ..
+        } => ClickPhase::LeftDouble,
+        _ => ClickPhase::Other,
+    }
+}
+
+fn is_exit_menu_event(exit_item_id: &MenuId, event: &MenuEvent) -> bool {
+    event.id == *exit_item_id
+}
+
 fn effective_debounce_window(platform_interval: Option<Duration>) -> Duration {
     platform_interval
         .unwrap_or(MIN_DEBOUNCE_WINDOW)
@@ -91,7 +124,13 @@ pub struct TrayManager;
 
 #[cfg(not(test))]
 impl TrayManager {
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    /// Construct the process's single tray manager and install its process-lifetime event handlers.
+    ///
+    /// `tray-icon` stores handlers in one-shot global cells, so another manager in the same process
+    /// cannot replace the callback.
+    pub fn new(
+        notify: impl Fn(TrayEvent) + Send + Sync + 'static,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         prepare_platform_application()?;
         let (idle_source, idle_is_template) = status_icon_source(false);
         let (recording_source, _) = status_icon_source(true);
@@ -110,6 +149,9 @@ impl TrayManager {
         menu.append(&separator)?;
         menu.append(&exit_item)?;
 
+        // tray-icon stores its handler choice in one-shot global cells. Install the
+        // process-lifetime callbacks before the native icon can emit the first event.
+        install_native_handlers(notify);
         let tray_icon = TrayIconBuilder::new()
             .with_menu(Box::new(menu))
             .with_menu_on_left_click(false)
@@ -155,40 +197,31 @@ impl TrayManager {
         }
     }
 
-    pub fn check_action(&mut self) -> Option<TrayAction> {
-        while let Ok(event) = MenuEvent::receiver().try_recv() {
-            if event.id == self.exit_item_id {
-                return Some(TrayAction::Exit);
+    pub fn handle_event(&mut self, event: TrayEvent) -> Option<TrayAction> {
+        match event {
+            TrayEvent::Menu(event) => {
+                is_exit_menu_event(&self.exit_item_id, &event).then_some(TrayAction::Exit)
+            }
+            TrayEvent::Icon(event) => {
+                let phase = classify_icon_event(self.tray_icon.id(), &event);
+                self.click_debounce
+                    .accept(phase, Instant::now())
+                    .then_some(TrayAction::ToggleRecording)
             }
         }
-
-        let now = Instant::now();
-        let mut toggle = false;
-        while let Ok(event) = TrayIconEvent::receiver().try_recv() {
-            if event.id() != self.tray_icon.id() {
-                continue;
-            }
-            let phase = match event {
-                TrayIconEvent::Click {
-                    button: MouseButton::Left,
-                    button_state: MouseButtonState::Up,
-                    ..
-                } => ClickPhase::LeftUp,
-                TrayIconEvent::DoubleClick {
-                    button: MouseButton::Left,
-                    ..
-                } => ClickPhase::LeftDouble,
-                _ => ClickPhase::Other,
-            };
-            toggle |= self.click_debounce.accept(phase, now);
-        }
-
-        toggle.then_some(TrayAction::ToggleRecording)
     }
+}
 
-    pub fn update(&self) {
-        pump_platform_events();
-    }
+#[cfg(not(test))]
+fn install_native_handlers(notify: impl Fn(TrayEvent) + Send + Sync + 'static) {
+    let notify = Arc::new(notify);
+    let icon_notify = Arc::clone(&notify);
+    TrayIconEvent::set_event_handler(Some(move |event| {
+        icon_notify(TrayEvent::Icon(event));
+    }));
+    MenuEvent::set_event_handler(Some(move |event| {
+        notify(TrayEvent::Menu(event));
+    }));
 }
 
 #[cfg(all(target_os = "macos", not(test)))]
@@ -208,17 +241,17 @@ fn prepare_platform_application() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 impl TrayManager {
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(
+        _notify: impl Fn(TrayEvent) + Send + Sync + 'static,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(TrayManager)
     }
 
     pub fn set_recording(&mut self, _recording: bool) {}
 
-    pub fn check_action(&mut self) -> Option<TrayAction> {
+    pub fn handle_event(&mut self, _event: TrayEvent) -> Option<TrayAction> {
         None
     }
-
-    pub fn update(&self) {}
 }
 
 #[cfg(all(target_os = "macos", not(test)))]
@@ -243,98 +276,14 @@ fn platform_double_click_interval() -> Option<Duration> {
     None
 }
 
-#[cfg(all(target_os = "macos", not(test)))]
-fn pump_platform_events() {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSApp, NSEventMask};
-    use objc2_foundation::{NSDate, NSDefaultRunLoopMode};
-
-    let Some(mtm) = MainThreadMarker::new() else {
-        return;
-    };
-    let app = NSApp(mtm);
-    loop {
-        let event = app.nextEventMatchingMask_untilDate_inMode_dequeue(
-            NSEventMask::all(),
-            None::<&NSDate>,
-            unsafe { NSDefaultRunLoopMode },
-            true,
-        );
-        let Some(event) = event else { break };
-        app.sendEvent(&event);
-    }
-}
-
-#[cfg(all(target_os = "windows", not(test)))]
-fn pump_platform_events() {
-    use std::mem::MaybeUninit;
-    use std::ptr;
-
-    unsafe {
-        let mut msg = MaybeUninit::<windows_event_loop::MSG>::zeroed();
-        while windows_event_loop::PeekMessageW(
-            msg.as_mut_ptr(),
-            ptr::null_mut(),
-            0,
-            0,
-            windows_event_loop::PM_REMOVE,
-        ) != 0
-        {
-            let msg = msg.assume_init();
-            windows_event_loop::TranslateMessage(&msg);
-            windows_event_loop::DispatchMessageW(&msg);
-        }
-    }
-}
-
-#[cfg(all(not(any(target_os = "macos", target_os = "windows")), not(test)))]
-fn pump_platform_events() {}
-
 #[cfg(all(target_os = "windows", not(test)))]
 #[allow(non_snake_case, clippy::upper_case_acronyms)]
 mod windows_event_loop {
-    use std::ffi::c_void;
-
-    pub type BOOL = i32;
-    pub type HWND = *mut c_void;
     pub type UINT = u32;
-    pub type WPARAM = usize;
-    pub type LPARAM = isize;
-    pub type LRESULT = isize;
-
-    #[repr(C)]
-    #[derive(Clone, Copy)]
-    pub struct POINT {
-        pub x: i32,
-        pub y: i32,
-    }
-
-    #[repr(C)]
-    #[derive(Clone, Copy)]
-    pub struct MSG {
-        pub hwnd: HWND,
-        pub message: UINT,
-        pub wParam: WPARAM,
-        pub lParam: LPARAM,
-        pub time: u32,
-        pub pt: POINT,
-        pub lPrivate: u32,
-    }
-
-    pub const PM_REMOVE: UINT = 0x0001;
 
     #[link(name = "user32")]
     unsafe extern "system" {
-        pub fn DispatchMessageW(msg: *const MSG) -> LRESULT;
         pub fn GetDoubleClickTime() -> UINT;
-        pub fn PeekMessageW(
-            msg: *mut MSG,
-            hwnd: HWND,
-            min_filter: UINT,
-            max_filter: UINT,
-            remove: UINT,
-        ) -> BOOL;
-        pub fn TranslateMessage(msg: *const MSG) -> BOOL;
     }
 }
 
@@ -383,6 +332,19 @@ fn set_native_icon(tray_icon: &TrayIcon, icon: Icon, _is_template: bool) -> tray
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tray_icon::dpi::PhysicalPosition;
+    use tray_icon::menu::MenuId;
+    use tray_icon::{Rect, TrayIconId};
+
+    fn left_up(id: &str) -> TrayIconEvent {
+        TrayIconEvent::Click {
+            id: TrayIconId::new(id),
+            position: PhysicalPosition::new(0.0, 0.0),
+            rect: Rect::default(),
+            button: tray_icon::MouseButton::Left,
+            button_state: tray_icon::MouseButtonState::Up,
+        }
+    }
 
     #[test]
     fn embedded_status_icons_are_32px_rgba_with_transparency() {
@@ -434,5 +396,31 @@ mod tests {
         assert!(!debounce.accept(ClickPhase::LeftDouble, base + Duration::from_millis(400)));
         assert!(!debounce.accept(ClickPhase::LeftUp, base + Duration::from_millis(401)));
         assert!(debounce.accept(ClickPhase::LeftUp, base + Duration::from_millis(402)));
+    }
+
+    #[test]
+    fn native_events_are_filtered_by_the_owning_tray_and_menu_ids() {
+        assert_eq!(
+            classify_icon_event(&TrayIconId::new("ours"), &left_up("ours")),
+            ClickPhase::LeftUp
+        );
+        assert_eq!(
+            classify_icon_event(&TrayIconId::new("ours"), &left_up("other")),
+            ClickPhase::Other
+        );
+
+        let exit_id = MenuId::new("exit");
+        assert!(is_exit_menu_event(
+            &exit_id,
+            &MenuEvent {
+                id: exit_id.clone()
+            }
+        ));
+        assert!(!is_exit_menu_event(
+            &exit_id,
+            &MenuEvent {
+                id: MenuId::new("status")
+            }
+        ));
     }
 }

--- a/src/input/typer.rs
+++ b/src/input/typer.rs
@@ -1,6 +1,6 @@
 use tracing::info;
 
-pub trait TextTyper {
+pub trait TextTyper: Send + Sync {
     fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>>;
 }
 


### PR DESCRIPTION
## Summary

- replace the fixed-rate listener loop and hand-written platform pumps with a main-thread winit event loop
- forward hotkey, tray/menu, coalesced audio readiness, and finalization completion through typed application events
- keep transcription convergence, post-processing, and text delivery off the native loop, with serialized shutdown cancellation
- preserve current recording state-machine behavior and update architecture docs, plan index, README, and changelog

## Validation

- `cargo test --locked` (110 passed)
- `cargo clippy --locked -- -D warnings`
- `cargo fmt --check`
- `cargo build --locked`
- `cargo check --locked --target x86_64-pc-windows-msvc`
- `git diff --check`
- `cargo run -- config check`
- native macOS no-window startup smoke test (event loop remained alive; tray initialized)
- required independent review gate: no actionable findings after concurrency fixes

## Notes

- no configuration schema or user-facing hotkey behavior changed
- final interactive tray/recording gesture smoke testing remains before merge