### PR TITLE
feat(macos): use native text injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ ViberWhisper is a local-first voice-to-text typing tool. The app lets the user t
 ### Platform
 
 This is a **cross-platform (macOS + Windows)** project:
-- **macOS**: Text injection via osascript + clipboard (requires Accessibility permission)
+- **macOS**: Native Accessibility selected-text insertion with an AppKit/CoreGraphics paste fallback that leaves the transcription on the clipboard (requires Accessibility permission)
 - **Windows**: Text injection via Win32 SendInput API
 - **Desktop UI**: System tray/status-bar integration with click-to-toggle recording
 - **Packaging**: GitHub Actions build CI plus release packaging for macOS and Windows
@@ -105,12 +105,16 @@ src/
     wav_file.rs              — Streaming offline WAV chunk reader
   input.rs                   — Input module entry and submodule declarations
   input/
-    hotkey.rs                — HotkeyManager with rdev
+    hotkey.rs                — Process-lifetime rdev listener, event mapper, and filter callback
     typer.rs                 — TextTyper trait + MockTyper
     tray.rs                  — TrayManager for system tray icon and recording control
   platform.rs                — Platform selection and config directory API
   platform/
-    macos.rs                 — MacTyper (osascript + clipboard)
+    macos.rs                 — MacTyper route selection and serialized delivery
+    macos/
+      accessibility.rs      — Focused AX selected-text insertion and secure-control rejection
+      hotkey.rs             — rdev modifier normalization for the listener callback
+      pasteboard.rs         — Clipboard replacement, CoreGraphics Cmd+V, and hotkey suppression
     windows.rs               — WindowsTyper (SendInput API)
   transcriber.rs             — Transcriber traits, errors, and exports
   transcriber/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,10 +2034,10 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data 0.2.2",
- "objc2-core-image 0.2.2",
+ "objc2-core-data",
+ "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2047,18 +2047,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.6.2",
- "libc",
  "objc2 0.6.4",
- "objc2-cloud-kit 0.3.2",
- "objc2-core-data 0.3.2",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image 0.3.2",
- "objc2-core-text",
- "objc2-core-video",
  "objc2-foundation 0.3.2",
- "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-application-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2072,17 +2073,6 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags 2.11.0",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2109,17 +2099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "bitflags 2.11.0",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,10 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
- "dispatch2",
- "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -2156,16 +2132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,31 +2141,6 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.11.0",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -2229,17 +2170,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
- "objc2 0.6.4",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.11.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -2282,17 +2212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-quartz-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
-dependencies = [
- "bitflags 2.11.0",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,13 +2230,13 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit 0.2.2",
- "objc2-core-data 0.2.2",
- "objc2-core-image 0.2.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core 0.2.2",
+ "objc2-quartz-core",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -3683,7 +3602,10 @@ dependencies = [
  "hound",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-application-services",
+ "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
  "png",
  "rdev",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,11 @@ tempfile = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSEvent"] }
-objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGEventSource", "CGEventTypes", "CGRemoteOperation"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["NSApplication", "NSEvent", "NSPasteboard"] }
+objc2-application-services = { version = "0.3", default-features = false, features = ["AXError", "AXUIElement", "HIServices"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFString"] }
+objc2-core-graphics = { version = "0.3", default-features = false, features = ["CGEvent", "CGEventSource", "CGEventTypes", "CGRemoteOperation"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["NSString"] }
 
 [package.metadata.bundle]
 name = "ViberWhisper"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - **长录音自动分片**：超过时长/大小限制的录音自动切分，后台并行转写，结果智能合并
 - **LLM 文本后处理**：可选的 LLM 后处理层，自动补标点、去语气词、清理中断与重复
 - **本地推理模式**：通过内置 `local` 子命令拉起 Python FastAPI 服务，使用 Gemma 4 本地模型提供 `/v1/audio/transcriptions` 与 `/v1/chat/completions`
-- **自动文本输入**：识别结果自动输入到当前光标位置（支持中文等 Unicode 字符）
+- **自动文本输入**：识别结果自动输入到当前光标位置；macOS 优先使用原生辅助功能 API，支持中文等 Unicode 字符
 - **状态栏录音控制**：左键点击五柱 V 形声波图标即可开始或停止录音，右键打开退出菜单
 - **灵活配置**：支持自定义热键、模型、语言、API 地址、麦克风增益等
 - **自动清理**：自动保留最新 10 条录音，旧文件自动删除
@@ -19,7 +19,7 @@
 ## 系统要求
 
 - **操作系统**：macOS 或 Windows
-  - macOS：文字输入通过 System Events（osascript）实现，需在「系统设置 → 隐私与安全性 → 辅助功能」中授权终端应用
+  - macOS：优先通过辅助功能 API 写入当前选择；不支持该能力的文本框会使用原生剪贴板与 Cmd+V 兜底。需在「系统设置 → 隐私与安全性 → 辅助功能」中授权正在运行的终端或 ViberWhisper
   - Windows：使用 SendInput API，无需额外权限
 - **Rust**：仅源码构建需要支持 Rust 2024 edition 的 stable toolchain；安装发布包不需要 Rust
 - **Python**：本地模式需要 Python 3.10+；安装时优先使用 `uv`，若未安装则回退到系统 Python（用于 FastAPI + Transformers 服务）
@@ -99,7 +99,7 @@ cargo run -- local start
 5. 或按一下 **F9** 开始录音，再按一下停止（Toggle 模式）
 6. 退出：右键点击托盘图标选择「退出」，或按 **Ctrl+C**
 
-> macOS 首次运行时，系统会弹出辅助功能授权请求，需要允许才能完成文字输入。
+> macOS 需要辅助功能授权才能完成文字输入。未授权、没有焦点输入框或焦点位于密码框时，输入会明确失败且不会改动剪贴板。不支持直接写入所选文字的文本框会使用兜底粘贴：它会用转写文本替换剪贴板内容，并在粘贴后保留该文本，不恢复原内容。
 
 ## CLI 命令
 
@@ -176,6 +176,9 @@ viberwhisper config check
 warning。Windows 的 AltGr 通常表现为左 Ctrl + 右 Alt，因此 `RIGHTALT` 能正常匹配，但单独配置的
 `LEFTCTRL` 也可能被 AltGr 触发；为避免一次按键产生两个录音动作，Windows 会拒绝同时配置
 `LEFTCTRL` 和 `RIGHTALT`。
+
+macOS 的粘贴兜底会在极短的内部注入窗口暂停 ViberWhisper 自己的热键映射，避免合成的 `LEFTMETA`/`V`
+触发录音；这不是系统级按键拦截，事件仍会正常送达当前应用。注入结束后热键按下状态会重置。
 
 当前 `rdev 0.5.3` 后端还有以下明确限制，`config check` 会拒绝对应名称：
 

--- a/changelog
+++ b/changelog
@@ -38,3 +38,4 @@
 2026-08-10: Harden API-mode macOS and Windows packaging with locked inputs, reviewed WiX authoring, pre-tag dry runs, validated portable/installable artifacts, checksums, provenance, and draft-first GitHub Release publication
 2026-08-10: Expand Hold and Toggle hotkeys from F1–F12 to named single keyboard keys, including standalone right Alt/Option, canonical aliases, platform-aware validation, and passthrough warnings
 2026-08-11: Replace fixed-rate listener polling and hand-written platform message pumps with a main-thread winit event loop, per-boundary audio readiness wakeups, and cancellable background transcription delivery
+2026-08-12: Replace macOS osascript text injection with native Accessibility selected-text insertion and an AppKit/CoreGraphics fallback that leaves the transcription on the clipboard, rejects secure controls, and suppresses its own synthetic hotkey events

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Module-level design docs covering structs, methods, and dependencies.
 | [input.md](architecture/input.md) | Global hotkey detection, text injection (`TextTyper`), system tray (`TrayManager`) |
 | [local.md](architecture/local.md) | Local Gemma runtime: installer, Python FastAPI service, process lifecycle, health/status management |
 | [transcriber.md](architecture/transcriber.md) | Transcription trait, `ApiTranscriber` (OpenAI-compatible API), chunking, retry, text merging |
-| [platform.md](architecture/platform.md) | Platform text injection — `MacTyper` (osascript) and `WindowsTyper` (SendInput) |
+| [platform.md](architecture/platform.md) | Platform text injection — native AX/paste fallback on macOS and `SendInput` on Windows |
 | [postprocess.md](architecture/postprocess.md) | Post-processing — concrete processor facade, LLM integration, preheat/conservative sessions |
 
 ## Examples
@@ -55,3 +55,4 @@ Implementation plans and technical specs for each feature.
 | [26-symbol-icon-refresh.md](plan/26-symbol-icon-refresh.md) | Done | Replace placeholder bundle artwork and generated tray dots with one cross-platform voice-input symbol |
 | [27-release-path-hardening.md](plan/27-release-path-hardening.md) | Implemented | Make API-mode macOS and Windows packages reproducible, manually testable, and safe to publish |
 | [28-winit-event-loop.md](plan/28-winit-event-loop.md) | Implemented | Replace fixed listener polling with a main-thread winit event loop and non-blocking finalization |
+| [29-native-macos-text-injection.md](plan/29-native-macos-text-injection.md) | Implemented | Replace macOS osascript injection with direct AX insertion and a clipboard-replacing native paste fallback |

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -29,19 +29,25 @@ pub enum HotkeyEvent {
 
 Note: `Released` is only emitted for `Hold` source (toggle mode uses press-only semantics).
 
-**`start_hotkey_listener(config, notify)`**
+**`start_hotkey_listener(config, filter, notify)`**
 
 ```rust
-pub fn start_hotkey_listener(
+pub(crate) fn start_hotkey_listener<F>(
     config: &HotkeyConfig,
+    filter: F,
     notify: impl Fn(HotkeyEvent) + Send + 'static,
-);
+) where
+    F: Fn(EventType) -> Option<EventType> + Send + 'static;
 ```
 
 Starts the process-lifetime `rdev::listen` thread, maps native events, and invokes the supplied
 callback. The application callback forwards each event through winit's `EventLoopProxy`, which wakes
 the main-thread event loop without polling. Per-binding key-down state suppresses operating-system
-key-repeat events so one physical toggle press produces one toggle action.
+key-repeat events so one physical toggle press produces one toggle action. The supplied closure is
+the only platform hook: `Some(event)` reaches `EventMapper`, while `None` drops the event from
+ViberWhisper's mapper and resets its key-down bookkeeping. Non-macOS platforms use `Some` directly;
+macOS supplies a pasteboard-owned callback that normalizes modifier direction and returns `None`
+while the native fallback posts synthetic Cmd+V and its generated events can reach the listener.
 
 **`HotkeyConfig`**
 
@@ -66,7 +72,7 @@ Because the core event carries no source, Hold release, Toggle, and tray input c
 
 ### Key Methods
 
-**`start_hotkey_listener(config, notify)`**
+**`start_hotkey_listener(config, filter, notify)`**
 
 - `HotkeyConfig::validate(&InputSection)` parses and validates both bindings before construction.
 - Empty strings disable a binding, including both bindings for tray-only control; duplicate non-empty bindings are rejected.
@@ -77,6 +83,8 @@ Because the core event carries no source, Hold release, Toggle, and tray input c
 - Spawns the listener thread without blocking application startup.
 - Delivers mapped press/release events directly to the supplied non-blocking callback; the listener
   thread never runs recording state transitions itself.
+- Moves the supplied filter closure into the listener thread. macOS obtains its closure together
+  with `MacTyper`; other platforms pass the `Some` constructor as a stateless pass-through callback.
 
 **`parse_key(s: &str) -> Option<Key>`**
 
@@ -103,9 +111,11 @@ Key names identify `rdev::Key` values rather than produced characters. The macOS
 hardware key codes, while the Windows backend maps virtual-key values; letter and punctuation
 bindings can therefore follow the active Windows layout rather than a fixed physical QWERTY
 position. The listener is passive, so printable, editing, navigation, and modifier keys continue to
-affect the focused application or operating system. Windows AltGr also emits left Ctrl at the
-`rdev::Event` boundary, so a standalone `LEFTCTRL` binding may fire from AltGr; the retained event
-type does not contain enough native information to filter that event reliably.
+affect the focused application or operating system. The macOS internal injection window described
+below suppresses only ViberWhisper's mapping callback, not operating-system event delivery. Windows
+AltGr also emits left Ctrl at the `rdev::Event` boundary, so a standalone `LEFTCTRL` binding may
+fire from AltGr; the retained event type does not contain enough native information to filter that
+event reliably.
 
 On macOS, `rdev 0.5.3` derives modifier press/release direction from aggregate modifier flags.
 That direction can be wrong when the listener starts while a modifier is held or when both sides
@@ -113,6 +123,26 @@ of one modifier overlap. Before `EventMapper` sees a macOS modifier event, the l
 uses Core Graphics `CGEventSourceKeyState` with the physical modifier key code to normalize it to
 the current press/release state. Ordinary key events still flow directly through `rdev`, preserving
 their existing repeat suppression.
+
+### macOS Paste Filter
+
+The native paste fallback posts a fixed left-Command/V sequence through CoreGraphics. Without a
+shared boundary, `rdev` could interpret those synthetic events as configured `V`, `LEFTMETA`, or
+`RIGHTMETA` recording hotkeys.
+
+`src/platform/macos/pasteboard.rs` owns an atomic suppression flag shared only with the closure it
+returns during `MacTyper` construction. The paste transaction raises that flag immediately before
+constructing and posting Cmd+V and keeps it raised through a fixed 100 ms synthetic-event filter
+grace. The closure returns `None` for every event observed in that short scope, so the synthetic sequence and
+any interleaved physical input still reach macOS and the focused application but do not enter
+ViberWhisper's mapper. Each `None` resets Hold/Toggle key-down bookkeeping. A private RAII guard
+clears the flag after success, early error, or unwinding.
+
+Outside that scope, the callback delegates macOS modifier events to
+`src/platform/macos/hotkey.rs`, which normalizes press/release direction from physical key state,
+and passes ordinary events through unchanged. There is no sequence acknowledgement protocol: the
+filter protects ViberWhisper's mapper, while CoreGraphics posting and the target application
+determine paste delivery independently. The fallback leaves the transcription on the clipboard.
 
 ---
 

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -13,22 +13,56 @@ The `platform` module provides platform-specific text injection and the platform
 ## macOS: `MacTyper` (`src/platform/macos.rs`)
 
 ```rust
-pub struct MacTyper;
+pub struct MacTyper {
+    paste: NativePasteWriter,
+    delivery: Mutex<()>,
+}
 ```
 
 ### `type_text` Implementation
 
-Uses the clipboard-paste approach to avoid osascript keystroke length limits and special character issues:
+`MacTyper` serializes non-empty deliveries and sleeps 100 ms so the target window can regain focus.
+It then enters an Objective-C autorelease pool and uses two native routes:
 
-1. Sleeps 100 ms to let the target window regain focus.
-2. Escapes backslashes and double quotes in the text.
-3. Constructs an AppleScript that:
-   - Sets the clipboard to the escaped text.
-   - Simulates `Cmd+V` via `System Events`.
-4. Runs the script via `osascript -e`.
-5. Returns an error if the process exits non-zero.
+1. `macos/accessibility.rs` resolves the system-wide focused AX element, rejects
+   `AXSecureTextField`, checks whether `AXSelectedText` is settable, and assigns the transcription
+   to that selected-text attribute. An empty selection inserts at the caret; a non-empty selection
+   is replaced. This success path does not read the clipboard or emit keyboard events.
+2. A present, non-secure control that explicitly lacks settable selected text uses the native paste
+   fallback. Missing Accessibility trust, no focused element, secure controls, invalid AX objects,
+   type mismatches, and messaging failures are hard errors and do not paste into an unknown target.
 
-**Requirements:** macOS Accessibility permission must be granted to the running process in System Preferences → Privacy & Security → Accessibility.
+The implementation never reads or writes `AXValue`, does not construct AppleScript, and does not
+launch a subprocess. Text is carried as `CFString`/`NSString`, so multiline content, quotes,
+backslashes, CJK, and emoji require no shell escaping.
+
+### Native paste fallback
+
+`macos/pasteboard.rs` clears the general pasteboard and writes the transcription as
+`NSPasteboardTypeString`. It intentionally leaves that text on the clipboard after delivery; the
+fallback does not read, snapshot, or restore the previous contents. This avoids materializing
+arbitrary pasteboard representations in process memory and avoids racing a later clipboard owner.
+
+The same module creates one HID-system `CGEventSource` and posts left Command down, V down, V up,
+and left Command up.
+
+`NativePasteWriter` owns an atomic flag and returns a listener filter closure together with the
+writer. A private RAII scope raises the flag across CoreGraphics posting and a fixed 100 ms
+synthetic-event filter grace; the closure returns `None` during that scope, which keeps
+ViberWhisper from treating its own Cmd+V
+as configured hotkeys. The generic listener resets mapper key-down state whenever a callback drops
+an event. Outside the paste scope, `macos/hotkey.rs` normalizes modifier direction through
+`CGEventSourceKeyState` and the callback returns the normalized event. No acknowledgement or
+sequence-matching protocol is involved. The grace only gives the asynchronous `rdev` callback time
+to observe generated events; it is not a clipboard-consumption or delivery acknowledgement.
+
+AppKit rejection of the transcription write and failure to construct the CoreGraphics event source
+or events are returned as paste errors. If event construction fails after the write, the
+transcription still remains on the clipboard.
+
+**Requirements:** grant Accessibility permission to the running terminal or ViberWhisper in System
+Settings → Privacy & Security → Accessibility. Missing permission is a hard input error and leaves
+the clipboard untouched.
 
 ---
 
@@ -57,7 +91,12 @@ In `src/application/listener.rs`, the typer is selected conditionally:
 
 ```rust
 #[cfg(target_os = "macos")]
-let typer = MacTyper;
+let (typer, hotkey_filter) = MacTyper::new();
+
+start_hotkey_listener(&config.hotkeys, hotkey_filter, notify);
+
+#[cfg(target_os = "macos")]
+let typer = Arc::new(typer);
 
 #[cfg(target_os = "windows")]
 let typer = WindowsTyper;
@@ -67,3 +106,5 @@ let typer = MockTyper;
 ```
 
 All three types implement `TextTyper`, so the listener calls `typer.type_text(text)` uniformly.
+Only macOS receives a stateful filter callback from its paste writer; other platforms pass events
+through with `Some`, and Windows `SendInput` behavior is unchanged.

--- a/docs/plan/29-native-macos-text-injection.md
+++ b/docs/plan/29-native-macos-text-injection.md
@@ -1,0 +1,428 @@
+# 29 - Native macOS Text Injection
+
+## Status
+
+**Implementation revised again; local automated validation complete.** The native Accessibility route,
+AppKit and CoreGraphics fallback, callback-based hotkey suppression, clipboard-replacement policy,
+focused tests, and current-truth documentation are implemented on PR #99. Formatting, the complete
+Rust suite, checks, Clippy, build, Windows cross-check, diff validation, the native pasteboard test,
+and Python tests pass. Hosted macOS, Windows, and Python CI also pass on code-bearing revision
+`40d8d8650f94`. The interactive application matrix below remains before PR readiness.
+
+The generated `objc2-application-services` crate does not expose Apple's macro-defined AX
+attribute/subrole constants as Rust statics. The implementation therefore passes their documented
+string values through `CFString`; all functions and owned native types still use generated
+bindings, with no handwritten extern declarations.
+
+The user explicitly superseded clipboard-preservation goals 3 and 4 and the corresponding design,
+file-impact, test, and acceptance sections retained below as approved-plan history. Restoring a
+clipboard is not part of the desired paste operation. The fallback now clears the general
+pasteboard, writes the transcription as a native string, posts Cmd+V, and leaves that transcription
+on the clipboard. It never reads or materializes the previous items, uses no `changeCount`
+ownership token, and performs no restore.
+
+The approved design placed acknowledged suppression state and an RAII guard directly in
+`src/input/hotkey.rs`. The first implementation moved that protocol into platform-owned
+`hotkey.rs` and `injection.rs` helpers. After implementation review, the user approved a smaller
+boundary: `start_hotkey_listener` now accepts an `EventType -> Option<EventType>` callback, and
+`NativePasteWriter` owns the atomic flag shared with its callback. `None` drops an event from
+ViberWhisper and resets mapper bookkeeping. The fixed paste transaction raises the flag while it
+constructs and posts Cmd+V and waits through a 100 ms synthetic-event filter grace; an RAII scope
+clears it on all exits. CoreGraphics posting now lives in `pasteboard.rs`, and the forwarding delivery trait,
+standalone `keyboard.rs`, coordinator, sequence matching, generation, condition variable, and
+listener acknowledgement were removed. This intentionally trades the original acknowledgement
+error signal for a direct filter boundary: whether ViberWhisper observes its own key events does
+not determine whether the focused application received the CoreGraphics paste.
+
+## Context
+
+At planning time, `MacTyper::type_text` waited 100 ms for focus to settle, interpolated the
+transcription into AppleScript, launched `osascript`, replaced the general clipboard, and asked
+`System Events` to press Cmd+V. That path had four material problems:
+
+- the previous clipboard contents are never restored;
+- AppleScript escaping is not a safe arbitrary-text transport;
+- each transcription starts a subprocess and reports failure only after it exits; and
+- synthetic Command/V events are visible to the process-wide `rdev` listener, so single-key
+  bindings such as `V`, `LEFTMETA`, or `RIGHTMETA` can trigger ViberWhisper itself.
+
+PR #67 added named single-key hotkeys but deliberately did not add input grabbing or injection
+suppression. PR #98 then moved `TextTyper::type_text` onto a background finalization worker. This
+feature therefore needs both a native macOS injection implementation and a narrow cross-thread
+contract that lets the existing hotkey listener ignore only ViberWhisper's paste sequence without
+blocking the winit event loop.
+
+Apple documents `kAXSelectedTextAttribute` as the editable text selection attribute and exposes
+settable checks through `AXUIElementIsAttributeSettable`. `NSPasteboard.changeCount` is the
+ownership token for deciding whether clipboard contents can still be restored. The implementation
+will use the generated `objc2` framework crates for both APIs instead of adding handwritten
+Objective-C declarations.
+
+Primary API references:
+
+- [Apple: `kAXSelectedTextAttribute`](https://developer.apple.com/documentation/applicationservices/kaxselectedtextattribute)
+- [Apple: `AXUIElementSetAttributeValue`](https://developer.apple.com/documentation/applicationservices/1460434-axuielementsetattributevalue)
+- [Apple: `NSPasteboard.changeCount`](https://developer.apple.com/documentation/appkit/nspasteboard/changecount)
+- [Apple: `NSPasteboardItem`](https://developer.apple.com/documentation/appkit/nspasteboarditem)
+- [`objc2-application-services` 0.3.2 bindings](https://docs.rs/objc2-application-services/0.3.2/objc2_application_services/)
+
+## Goals
+
+1. Insert directly through the focused Accessibility element when selected text is writable.
+2. Fall back to a native pasteboard transaction plus a CoreGraphics Cmd+V sequence for controls
+   that do not support direct selected-text insertion.
+3. Preserve every pasteboard item and every eagerly readable representation when the application
+   still owns the clipboard after paste delivery.
+4. Never restore stale clipboard data over a concurrent user or application change.
+5. Prevent the fallback's synthetic `V`, `LEFTMETA`, and `RIGHTMETA` events from producing
+   ViberWhisper hotkey events or leaving the hotkey mapper in a stale key-down state.
+6. Reject secure text controls and genuine Accessibility failures without silently replacing an
+   entire field or pasting into an unknown target.
+7. Preserve the shared `TextTyper` interface, Windows `SendInput` behavior, the event-driven UI
+   loop, and current recording-session semantics.
+
+## Non-goals
+
+- Changing the Windows text injector.
+- Replacing `rdev`, introducing an input grab, or suppressing events in the focused application.
+- Using `kAXValueAttribute`, which could replace the entire control rather than its selection.
+- Implementing an InputMethodKit input source.
+- Using `CGEventKeyboardSetUnicodeString` as the primary insertion path.
+- Adding configuration fields, a selectable injection mode, or user-tunable timing knobs.
+- Claiming that every third-party editor implements the macOS Accessibility text contract
+  correctly; unsupported controls use the bounded paste fallback.
+
+## Design
+
+### 1. Keep one `MacTyper` coordinator with focused native helpers
+
+`MacTyper` will become a constructed value rather than a zero-sized type. It will own:
+
+- a cloneable handle to the hotkey suppression state shared with the `rdev` callback; and
+- a mutex that serializes access to the process-global general pasteboard if `TextTyper` is ever
+  called concurrently.
+
+The platform implementation will be split into three private helpers under `src/platform/macos/`:
+
+```text
+macos.rs                  route selection, focus delay, error policy, logging
+macos/accessibility.rs    focused AX element lookup and selected-text insertion
+macos/pasteboard.rs       deep snapshot, temporary text ownership, conditional restore
+macos/keyboard.rs         CoreGraphics Cmd+V construction and posting
+```
+
+Native Objective-C/Core Foundation values are created within the call and are not stored in
+`MacTyper`. The background finalization thread will enter an Objective-C autorelease pool around the
+native operation. `MacTyper` remains `Send + Sync`, and no AppKit object is sent through winit.
+
+`type_text("")` remains a no-op. Non-empty input retains the existing fixed 100 ms focus-settling
+delay before either AX access or hotkey suppression begins.
+
+### 2. Prefer Accessibility selected-text insertion
+
+The AX adapter will:
+
+1. require the current process to be a trusted Accessibility client;
+2. create the system-wide AX element;
+3. resolve `kAXFocusedUIElementAttribute` and require a concrete focused target;
+4. read `kAXSubroleAttribute` when available and reject
+   `kAXSecureTextFieldSubrole` as a protected destination;
+5. ask whether `kAXSelectedTextAttribute` is settable; and
+6. set that attribute to a `CFString` containing the transcription.
+
+Setting selected text gives both required direct behaviors: an empty selection inserts at the
+caret, and a non-empty selection is replaced. The implementation will not read or set
+`kAXValueAttribute`.
+
+The adapter returns a small private outcome rather than flattening all AX results into one error:
+
+```text
+Inserted
+Unsupported(reason)
+SecureControl
+Failed(ax_error)
+```
+
+Only a present, non-secure focused element whose selected-text capability is absent, explicitly
+non-settable, or returns the documented unsupported/no-value/not-implemented result selects the
+paste fallback. Failure to identify a focused target, missing Accessibility trust, invalid AX
+objects, messaging failure, illegal arguments, and type mismatches are hard Accessibility errors.
+This keeps unsupported editors usable without turning genuine AX failures into an unobservable
+paste attempt.
+
+Successful direct insertion returns immediately. It does not access the clipboard, construct
+keyboard events, or enter hotkey suppression.
+
+### 3. Deep-snapshot all pasteboard items before taking ownership
+
+The fallback must not retain and later rewrite the `NSPasteboardItem` values returned by
+`pasteboardItems`: AppKit associates those objects with the current owner and documents them as
+stale after ownership changes. Instead, the pasteboard adapter will eagerly copy a neutral snapshot:
+
+```text
+PasteboardSnapshot
+  items[]
+    representations[]
+      type identifier string
+      owned data bytes
+```
+
+For every current item, it enumerates every advertised type and calls `dataForType`. Item order,
+type order, and the exact representation bytes are preserved. If any advertised representation
+cannot be read, snapshotting fails before the pasteboard is changed; a partial snapshot is never
+used. An empty pasteboard is represented explicitly.
+
+The adapter records `changeCount` before and after snapshotting. If ownership changes during the
+snapshot, fallback aborts without writing, rather than racing a newly copied value. No automatic
+retry is needed because a user-driven clipboard change is not an internal transient failure.
+
+After a stable snapshot:
+
+1. clear the general pasteboard;
+2. write the transcription as `NSPasteboardTypeString`;
+3. verify the native write succeeded; and
+4. record the resulting `changeCount` as ViberWhisper's ownership token.
+
+Plain text, multiline content, quotes, backslashes, CJK, and emoji travel as native strings; no
+escaping or shell representation is involved.
+
+### 4. Post Cmd+V under acknowledged hotkey suppression
+
+The fallback will create one CoreGraphics event source and post this fixed virtual-key sequence to
+the HID event tap:
+
+1. left Command down (virtual key 55);
+2. V down (virtual key 9, Command flag set);
+3. V up (virtual key 9, Command flag set); and
+4. left Command up (virtual key 55).
+
+The sequence is one internal constant used by both the native poster and suppression expectation so
+the two cannot drift. Failure to create the source or any event aborts delivery and enters the same
+clipboard-restoration path as an acknowledgement failure. `CGEventPost` itself returns no status;
+failure to observe the sequence within the bounded acknowledgement window is the delivery failure
+signal.
+
+`src/input/hotkey.rs` will add a cloneable suppression handle backed by a mutex, condition variable,
+monotonic epoch, and the expected injected key sequence. Starting a paste returns an RAII guard.
+While that guard is active, the existing rdev callback will:
+
+- normalize macOS modifier direction from physical key state before inspecting the rdev event;
+- withhold all hotkey notifications during the short injection window;
+- advance only when it sees the expected Command/V sequence in order; and
+- signal the guard after the final Command-up has passed through the listener.
+
+Unrelated physical input during the window is ignored by ViberWhisper but does not advance the
+expected sequence. It still reaches the focused application because this is mapper suppression,
+not an operating-system input grab.
+
+`EventMapper` gains a narrow `reset` operation. The suppression epoch advances both when the guard
+starts and when it is released; the callback resets hold/toggle key-down bookkeeping on each
+observed transition. A release missed during suppression therefore cannot leave the next physical
+press suppressed, and an injected press cannot become remembered mapper state.
+
+After posting, the fallback waits up to a fixed internal 500 ms for rdev to acknowledge the exact
+sequence. The value is a safety bound, not configuration. Timeout is a paste-injection error. The
+guard's `Drop` releases suppression and advances the epoch on success, timeout, event-construction
+failure, or panic unwinding. Tests use direct state transitions and controlled threads rather than
+sleeping for this production timeout.
+
+Once the listener acknowledgement arrives, a fixed 100 ms background-worker grace period allows
+the target application to consume the paste before clipboard restoration. This grace is outside
+the suppression guard: only synthetic-event production and observation suppress ViberWhisper
+hotkeys. The winit UI thread remains unblocked.
+
+### 5. Restore only while ViberWhisper still owns the pasteboard
+
+After the paste-consumption grace period, the adapter compares the current `changeCount` with the
+token recorded after writing the transcription:
+
+- if they match, it creates fresh `NSPasteboardItem` objects from the snapshot, clears the board,
+  and writes the complete ordered item array;
+- if they differ, another owner won the race, so restoration is skipped and the new clipboard is
+  left untouched.
+
+The same conditional restoration runs after any failure that occurs after ViberWhisper took
+ownership. Event injection remains the primary result:
+
+- write, event, or acknowledgement failure returns a typed paste error after best-effort restore;
+- a successful paste followed by restoration failure is logged as a distinct warning and still
+  returns success, because the requested text was already delivered;
+- a concurrent ownership change is an informational skip, not a restoration error; and
+- restoration failure never triggers a second paste or overwrites a newer owner.
+
+The private error variants and log messages will distinguish Accessibility failure, secure-control
+rejection, pasteboard snapshot/write failure, CoreGraphics event-construction failure, suppression
+acknowledgement timeout, and clipboard restoration failure. The public `TextTyper` signature
+remains unchanged.
+
+### 6. Assemble one shared suppression state
+
+`start_hotkey_listener` will create the suppression state used by its callback and return a handle
+to the application assembly. On macOS, `run_with_config` moves that handle into
+`MacTyper::new(...)`; other platforms retain their current typer behavior and do not enter
+suppression because they do not synthesize this fallback sequence.
+
+The handle has real runtime state and acknowledgement semantics, so it does not reintroduce the
+ownership-free hotkey manager removed by plan 28. The recording state machine remains unaware of
+injection events. During finalization it is already in `Stopping`, and any unrelated user input
+that reaches the application boundary remains subject to the existing state transitions.
+
+## Error and Fallback Matrix
+
+| Condition | Result |
+|---|---|
+| Empty text | Success without delay or native calls |
+| Accessibility permission missing | Hard AX error; no clipboard write |
+| No focused AX element | Hard AX error; no paste into an unknown target |
+| Secure AX subrole | Hard secure-control error; no fallback |
+| Selected text unsupported, absent, or non-settable | Native paste fallback |
+| AX messaging/invalid-element/type failure | Hard AX error |
+| AX selected-text set succeeds | Success; clipboard and keyboard untouched |
+| Pasteboard snapshot is incomplete or changes while read | Paste error; clipboard untouched |
+| Temporary text write fails | Paste error; conditionally restore snapshot |
+| CoreGraphics event construction or suppression acknowledgement fails | Paste error; release guard and conditionally restore |
+| Clipboard owner unchanged after successful paste | Restore all items/representations |
+| Clipboard owner changed after write | Skip restoration and preserve new contents |
+| Paste succeeds but restoration fails | Log restoration warning; return delivery success |
+
+## File Impact
+
+| File | Planned change |
+|---|---|
+| `Cargo.toml`, `Cargo.lock` | Add narrowly featured macOS `objc2-application-services`, `objc2-core-foundation`, and `objc2-foundation` bindings; enable AppKit pasteboard item features. |
+| `src/application/listener.rs` | Share the hotkey suppression handle with constructed `MacTyper`. |
+| `src/input/hotkey.rs` | Add suppression state/guard, sequence acknowledgement, epoch reconciliation, and mapper reset tests. |
+| `src/platform/macos.rs` | Replace `osascript` with the two-tier coordinator and typed route/error logging. |
+| `src/platform/macos/accessibility.rs` | Add focused-element, secure-subrole, settable, and selected-text AX adapter. |
+| `src/platform/macos/pasteboard.rs` | Add deep snapshot, temporary text ownership, change-count validation, and fresh-item restoration. |
+| `src/platform/macos/keyboard.rs` | Add CoreGraphics Cmd+V event construction/posting. |
+| `AGENTS.md`, `README.md` | Replace current osascript/clipboard descriptions with the implemented native behavior and permission boundary. |
+| `docs/architecture/platform.md` | Document direct AX insertion, paste transaction ownership, errors, and Windows non-change. |
+| `docs/architecture/input.md` | Document shared injection suppression and mapper-state reconciliation. |
+| `docs/README.md` | Keep the plan index/status and platform-document description synchronized. |
+| `changelog` | Record native macOS insertion and clipboard preservation after implementation. |
+| `docs/plan/29-native-macos-text-injection.md` | Record implementation status and material deviations without rewriting the approved design. |
+
+No configuration schema or example changes are planned because the strategy is fixed internal
+macOS behavior. Core, audio, transcriber, post-processing, local-service, Windows platform, and
+release contracts are unchanged.
+
+## Test Strategy
+
+Implementation is test-first at each boundary. Tests should protect behavior and concurrency
+contracts rather than reproduce framework getters and setters.
+
+### Route and error policy
+
+Use private fake AX and paste adapters to prove:
+
+- direct AX success never snapshots the clipboard or emits key events;
+- unsupported/non-settable selected text chooses paste exactly once;
+- secure targets and genuine AX failures never fall back;
+- empty text is a complete no-op; and
+- text is forwarded exactly for multiline, quotes/backslashes, CJK, and emoji cases.
+
+### Hotkey suppression
+
+Drive the reducer/mapper directly to prove:
+
+- the Command-down, V-down, V-up, Command-up sequence produces no Hold/Toggle event when any of
+  `V`, `LEFTMETA`, or `RIGHTMETA` is configured;
+- unrelated events cannot falsely complete the expected injected sequence;
+- entry and exit epochs reset both hold and toggle down-state;
+- normal mapping resumes after completion; and
+- dropping the guard on every simulated error path releases suppression.
+
+Threaded acknowledgement coverage will use channels/barriers and a short injected test deadline,
+not wall-clock sleeps.
+
+### Pasteboard transaction
+
+Use a deterministic fake pasteboard containing multiple items and multiple binary representations
+to prove:
+
+- every item/type/byte payload is restored in order while ownership is unchanged;
+- a change during snapshot aborts before clear/write;
+- a change after ViberWhisper's write skips restoration;
+- snapshot, text-write, event, acknowledgement, and restore failures retain their documented
+  primary result; and
+- restoration failure after successful delivery is reported separately from delivery success.
+
+The native AppKit adapter will have a focused macOS-only test with an isolated uniquely named
+pasteboard where practical; tests will not mutate the user's general pasteboard or post real global
+keys.
+
+### Native and cross-platform validation
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check --locked
+cargo test --locked
+cargo clippy --locked -- -D warnings
+cargo build --locked
+cargo check --locked --target x86_64-pc-windows-msvc
+git diff --check
+```
+
+Hosted macOS and Windows CI must pass. Windows validation confirms that target-specific bindings and
+the constructed macOS typer do not alter `SendInput` compilation or behavior.
+
+## Manual macOS Verification
+
+With Accessibility permission granted, verify all of the following before PR readiness:
+
+1. A native AppKit `NSTextField` or equivalent controlled test field inserts at an empty caret and
+   replaces an active selection through AX, without changing the clipboard.
+2. A browser/Electron editor that lacks settable selected text uses fallback and receives the text.
+3. Terminal.app (and iTerm2 when available) receives fallback text at the active prompt.
+4. Plain text, multiline content, quotes, backslashes, CJK, and emoji arrive unchanged.
+5. A clipboard containing multiple items/representations is restored byte-for-byte after fallback.
+6. Changing the clipboard concurrently during the transaction leaves the newer contents intact.
+7. A secure/password field fails without text delivery or clipboard replacement.
+8. Separate runs with Hold/Toggle bound to `V`, `LEFTMETA`, and `RIGHTMETA` show no recording
+   transition from injected Cmd+V, and the next physical press/release still works normally.
+9. AX failure and fallback/restore outcomes are distinguishable in logs, and no `osascript` process
+   is launched.
+
+## Implementation Order
+
+1. Add failing hotkey suppression and mapper reconciliation tests, then implement the shared
+   state, RAII guard, and acknowledgement path.
+2. Add failing coordinator tests for AX success, fallback eligibility, secure rejection, and hard
+   errors; introduce the private route/result model.
+3. Add failing pasteboard transaction tests for complete restoration, concurrent ownership change,
+   and restoration failure; implement the neutral snapshot/restore policy.
+4. Add the native AX, AppKit pasteboard, and CoreGraphics adapters with narrowly enabled bindings.
+5. Construct `MacTyper` with the listener's suppression handle and remove all AppleScript/process
+   invocation code.
+6. Run focused and full automated validation, then update current-truth documentation and record
+   any implementation deviations in this plan.
+7. Perform the manual macOS matrix, run the repository's independent code-review gate, push the
+   implementation on this same bookmark/PR, and mark the PR ready only after the gate and required
+   validation complete.
+
+## Acceptance Criteria
+
+- Supported editable AX controls insert at an empty caret and replace an active selection through
+  `kAXSelectedTextAttribute`.
+- Unsupported/non-settable selected text selects native paste fallback; genuine AX and secure-field
+  failures do not.
+- No implementation path reads or writes `kAXValueAttribute`, builds AppleScript, or launches
+  `osascript`.
+- AX success neither reads/writes the clipboard nor emits keyboard events.
+- Fallback round-trips every eagerly readable item and representation while ownership is unchanged.
+- A concurrent clipboard owner is never overwritten by restoration.
+- Plain, multiline, quoted, backslashed, CJK, and emoji text is preserved.
+- Every success/failure/unwind path releases hotkey suppression and reconciles mapper state.
+- Fallback cannot emit ViberWhisper events for `V`, `LEFTMETA`, or `RIGHTMETA` bindings.
+- Paste delivery, AX failure, secure rejection, concurrent-owner skip, and restoration failure are
+  distinguishable in logs.
+- `TextTyper` and Windows `SendInput` contracts remain unchanged.
+- Focused tests, the full suite, formatting, Clippy, build, diff checks, Windows cross-check, and
+  hosted CI pass.
+- The manual AppKit, browser/Electron, terminal, clipboard, secure-field, and hotkey matrix is
+  completed before PR readiness.
+- `AGENTS.md`, README, platform/input architecture docs, plan status/index, and changelog match the
+  implemented behavior.

--- a/src/application/listener.rs
+++ b/src/application/listener.rs
@@ -73,21 +73,26 @@ pub(super) fn run_with_config(
         config.orchestrator,
     ));
 
-    #[cfg(target_os = "macos")]
-    let typer = Arc::new(crate::platform::macos::MacTyper);
-    #[cfg(target_os = "windows")]
-    let typer = Arc::new(crate::platform::windows::WindowsTyper);
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    let typer = Arc::new(input::typer::MockTyper);
-
     let event_loop = EventLoop::<AppEvent>::with_user_event().build()?;
     event_loop.set_control_flow(ControlFlow::Wait);
     let proxy = event_loop.create_proxy();
 
+    #[cfg(target_os = "macos")]
+    let (typer, hotkey_filter) = crate::platform::macos::MacTyper::new();
+    #[cfg(not(target_os = "macos"))]
+    let hotkey_filter = Some;
+
     let hotkey_proxy = proxy.clone();
-    start_hotkey_listener(&config.hotkeys, move |event| {
+    start_hotkey_listener(&config.hotkeys, hotkey_filter, move |event| {
         let _ = hotkey_proxy.send_event(AppEvent::Hotkey(event));
     });
+
+    #[cfg(target_os = "macos")]
+    let typer = Arc::new(typer);
+    #[cfg(target_os = "windows")]
+    let typer = Arc::new(crate::platform::windows::WindowsTyper);
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let typer = Arc::new(input::typer::MockTyper);
 
     let audio_proxy = proxy.clone();
     let recorder = AudioRecorder::with_config(&config.audio, move |session_id| {

--- a/src/input/hotkey.rs
+++ b/src/input/hotkey.rs
@@ -1,11 +1,8 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::thread;
 
 use rdev::{Event, EventType, Key, listen};
 use tracing::{debug, error, info, warn};
-
-#[cfg(target_os = "macos")]
-use objc2_core_graphics::{CGEventSource, CGEventSourceStateID};
 
 use crate::core::config::{ConfigKey, InputSection, ValidationIssue};
 
@@ -289,42 +286,6 @@ fn needs_passthrough_warning(key: Key) -> bool {
     )
 }
 
-#[cfg(target_os = "macos")]
-fn macos_modifier_keycode(key: Key) -> Option<u16> {
-    match key {
-        Key::MetaLeft => Some(55),
-        Key::ShiftLeft => Some(56),
-        Key::Alt => Some(58),
-        Key::ControlLeft => Some(59),
-        Key::ShiftRight => Some(60),
-        Key::AltGr => Some(61),
-        Key::ControlRight => Some(62),
-        Key::Function => Some(63),
-        Key::MetaRight => Some(54),
-        _ => None,
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn normalize_macos_modifier_event(
-    event_type: EventType,
-    key_is_pressed: impl FnOnce(u16) -> bool,
-) -> EventType {
-    let key = match &event_type {
-        EventType::KeyPress(key) | EventType::KeyRelease(key) => *key,
-        _ => return event_type,
-    };
-    let Some(keycode) = macos_modifier_keycode(key) else {
-        return event_type;
-    };
-
-    if key_is_pressed(keycode) {
-        EventType::KeyPress(key)
-    } else {
-        EventType::KeyRelease(key)
-    }
-}
-
 #[cfg(any(target_os = "windows", test))]
 fn has_windows_altgr_alias_risk(key: Key) -> bool {
     key == Key::ControlLeft
@@ -410,16 +371,38 @@ impl EventMapper {
             _ => None,
         }
     }
+
+    fn reset(&mut self) {
+        self.hold_down = false;
+        self.toggle_down = false;
+    }
+
+    fn map_filtered(&mut self, event_type: Option<EventType>) -> Option<HotkeyEvent> {
+        match event_type {
+            Some(event_type) => self.map(&event_type),
+            None => {
+                self.reset();
+                None
+            }
+        }
+    }
 }
 
 /// Start the process-lifetime global hotkey listener.
 ///
 /// The detached `rdev` thread cannot be stopped independently; process shutdown is its lifetime
-/// boundary.
-pub fn start_hotkey_listener(config: &HotkeyConfig, notify: impl Fn(HotkeyEvent) + Send + 'static) {
+/// boundary. The filter returns `Some` to map an event or `None` to drop it and reset mapper
+/// key-down bookkeeping.
+pub(crate) fn start_hotkey_listener<F>(
+    config: &HotkeyConfig,
+    filter: F,
+    notify: impl Fn(HotkeyEvent) + Send + 'static,
+) where
+    F: Fn(EventType) -> Option<EventType> + Send + 'static,
+{
     let hold_key = config.hold_key;
     let toggle_key = config.toggle_key;
-    spawn_listener(EventMapper::new(hold_key, toggle_key), notify);
+    spawn_listener(EventMapper::new(hold_key, toggle_key), filter, notify);
 
     log_binding_warnings("hold", hold_key, config.hold_label.as_deref());
     log_binding_warnings("toggle", toggle_key, config.toggle_label.as_deref());
@@ -432,23 +415,20 @@ pub fn start_hotkey_listener(config: &HotkeyConfig, notify: impl Fn(HotkeyEvent)
     }
 }
 
-fn spawn_listener(mapper: EventMapper, notify: impl Fn(HotkeyEvent) + Send + 'static) {
+fn spawn_listener<F>(mapper: EventMapper, filter: F, notify: impl Fn(HotkeyEvent) + Send + 'static)
+where
+    F: Fn(EventType) -> Option<EventType> + Send + 'static,
+{
     thread::spawn(move || {
         debug!("rdev listener thread started");
-        let mapper = Arc::new(Mutex::new(mapper));
+        let mapper = Mutex::new(mapper);
         let callback = move |event: Event| {
-            #[cfg(target_os = "macos")]
-            let event_type = normalize_macos_modifier_event(event.event_type, |keycode| {
-                CGEventSource::key_state(CGEventSourceStateID::HIDSystemState, keycode)
-            });
-            #[cfg(not(target_os = "macos"))]
-            let event_type = event.event_type;
+            let event_type = filter(event.event_type);
 
-            let mapped = match mapper.lock() {
-                Ok(mut mapper) => mapper.map(&event_type),
-                Err(poisoned) => poisoned.into_inner().map(&event_type),
-            };
-            if let Some(event) = mapped {
+            let mut mapper = mapper
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(event) = mapper.map_filtered(event_type) {
                 notify(event);
             }
         };
@@ -764,6 +744,21 @@ mod tests {
     }
 
     #[test]
+    fn callback_filter_can_drop_an_event_and_reset_mapper_state() {
+        let mut mapper = EventMapper::new(Some(Key::KeyV), Some(Key::F9));
+
+        assert_eq!(
+            mapper.map_filtered(Some(EventType::KeyPress(Key::KeyV))),
+            Some(HotkeyEvent::Pressed(HotkeySource::Hold))
+        );
+        assert_eq!(mapper.map_filtered(None), None);
+        assert_eq!(
+            mapper.map_filtered(Some(EventType::KeyPress(Key::KeyV))),
+            Some(HotkeyEvent::Pressed(HotkeySource::Hold))
+        );
+    }
+
+    #[test]
     fn maps_standalone_right_alt_hold_press_and_release() {
         let mut mapper = EventMapper::new(Some(Key::AltGr), Some(Key::F9));
 
@@ -776,48 +771,5 @@ mod tests {
             Some(HotkeyEvent::Released(HotkeySource::Hold))
         );
         assert_eq!(mapper.map(&EventType::KeyPress(Key::Alt)), None);
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn normalizes_macos_modifier_direction_from_physical_key_state() {
-        let keycodes = [
-            (Key::MetaRight, 54),
-            (Key::MetaLeft, 55),
-            (Key::ShiftLeft, 56),
-            (Key::Alt, 58),
-            (Key::ControlLeft, 59),
-            (Key::ShiftRight, 60),
-            (Key::AltGr, 61),
-            (Key::ControlRight, 62),
-            (Key::Function, 63),
-        ];
-        for (key, expected) in keycodes {
-            assert_eq!(macos_modifier_keycode(key), Some(expected));
-        }
-        assert_eq!(macos_modifier_keycode(Key::F8), None);
-
-        let mut mapper = EventMapper::new(Some(Key::AltGr), None);
-        let startup_release =
-            normalize_macos_modifier_event(EventType::KeyPress(Key::AltGr), |keycode| {
-                assert_eq!(keycode, 61);
-                false
-            });
-        assert_eq!(startup_release, EventType::KeyRelease(Key::AltGr));
-        assert_eq!(mapper.map(&startup_release), None);
-
-        assert_eq!(
-            mapper.map(&normalize_macos_modifier_event(
-                EventType::KeyRelease(Key::AltGr),
-                |_| true
-            )),
-            Some(HotkeyEvent::Pressed(HotkeySource::Hold))
-        );
-        assert_eq!(
-            normalize_macos_modifier_event(EventType::KeyPress(Key::F8), |_| {
-                panic!("ordinary keys do not require a physical-state query")
-            }),
-            EventType::KeyPress(Key::F8)
-        );
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,7 +1,150 @@
-use crate::input::typer::TextTyper;
-use tracing::info;
+use std::sync::Mutex;
+use std::time::Duration;
 
-pub struct MacTyper;
+use crate::input::typer::TextTyper;
+use tracing::{debug, info};
+
+mod accessibility;
+mod hotkey;
+mod pasteboard;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AccessibilityInsert {
+    Inserted,
+    Unsupported(&'static str),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AccessibilityError {
+    PermissionDenied,
+    NoFocusedElement,
+    SecureControl,
+    Native { operation: &'static str, code: i32 },
+    UnexpectedType { operation: &'static str },
+}
+
+impl std::fmt::Display for AccessibilityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PermissionDenied => formatter.write_str("Accessibility permission is required"),
+            Self::NoFocusedElement => formatter.write_str("no focused Accessibility element"),
+            Self::SecureControl => {
+                formatter.write_str("refusing to inject text into a secure control")
+            }
+            Self::Native { operation, code } => {
+                write!(
+                    formatter,
+                    "Accessibility {operation} failed with error {code}"
+                )
+            }
+            Self::UnexpectedType { operation } => {
+                write!(
+                    formatter,
+                    "Accessibility {operation} returned an unexpected value type"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for AccessibilityError {}
+
+trait AccessibilityWriter {
+    fn insert_selected_text(&self, text: &str) -> Result<AccessibilityInsert, AccessibilityError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PasteError {
+    Write(String),
+    Delivery(String),
+}
+
+impl std::fmt::Display for PasteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Write(message) => write!(formatter, "pasteboard write failed: {message}"),
+            Self::Delivery(message) => write!(formatter, "paste delivery failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for PasteError {}
+
+trait PasteWriter {
+    fn paste(&self, text: &str) -> Result<(), PasteError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum InjectionOutcome {
+    Noop,
+    Accessibility,
+    Paste,
+}
+
+#[derive(Debug)]
+enum MacInjectionError {
+    Accessibility(AccessibilityError),
+    Paste(PasteError),
+}
+
+impl std::fmt::Display for MacInjectionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Accessibility(error) => error.fmt(formatter),
+            Self::Paste(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for MacInjectionError {}
+
+fn route_injection(
+    text: &str,
+    accessibility: &impl AccessibilityWriter,
+    paste: &impl PasteWriter,
+) -> Result<InjectionOutcome, MacInjectionError> {
+    if text.is_empty() {
+        return Ok(InjectionOutcome::Noop);
+    }
+
+    match accessibility.insert_selected_text(text) {
+        Ok(AccessibilityInsert::Inserted) => Ok(InjectionOutcome::Accessibility),
+        Ok(AccessibilityInsert::Unsupported(reason)) => {
+            debug!(
+                reason,
+                "Accessibility selected-text insertion is unsupported; using native paste fallback"
+            );
+            paste
+                .paste(text)
+                .map(|()| InjectionOutcome::Paste)
+                .map_err(MacInjectionError::Paste)
+        }
+        Err(error) => Err(MacInjectionError::Accessibility(error)),
+    }
+}
+
+/// Native macOS text delivery using focused AX selection first and a clipboard-replacing paste
+/// fallback only when the focused control does not support selected-text assignment.
+pub struct MacTyper {
+    paste: pasteboard::NativePasteWriter,
+    delivery: Mutex<()>,
+}
+
+impl MacTyper {
+    pub(crate) fn new() -> (
+        Self,
+        impl Fn(rdev::EventType) -> Option<rdev::EventType> + Send + 'static,
+    ) {
+        let (paste, hotkey_filter) = pasteboard::NativePasteWriter::new();
+        (
+            Self {
+                paste,
+                delivery: Mutex::new(()),
+            },
+            hotkey_filter,
+        )
+    }
+}
 
 impl TextTyper for MacTyper {
     fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -9,29 +152,32 @@ impl TextTyper for MacTyper {
             return Ok(());
         }
 
-        // Give the target window time to regain focus
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        // Serializing the focus delay with delivery prevents a concurrent finalizer from shifting
+        // the focus-settling window immediately before another transaction.
+        let _delivery = self
+            .delivery
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::thread::sleep(Duration::from_millis(100));
 
-        // Use clipboard approach: set clipboard content then simulate Cmd+V paste
-        // This avoids keystroke length limits and special character issues
-        let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
-        let script = format!(
-            r#"set the clipboard to "{}"
-tell application "System Events" to keystroke "v" using command down"#,
-            escaped
-        );
-
-        let output = std::process::Command::new("osascript")
-            .arg("-e")
-            .arg(&script)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("osascript failed: {}", stderr).into());
+        let outcome = objc2::rc::autoreleasepool(|_| {
+            route_injection(text, &accessibility::NativeAccessibility, &self.paste)
+        })?;
+        match outcome {
+            InjectionOutcome::Noop => {}
+            InjectionOutcome::Accessibility => {
+                info!(
+                    text_bytes = text.len(),
+                    "text inserted through Accessibility"
+                );
+            }
+            InjectionOutcome::Paste => {
+                info!(
+                    text_bytes = text.len(),
+                    "text delivered through native paste fallback; clipboard contains transcription"
+                );
+            }
         }
-
-        info!(text = %text, "Text typed");
         Ok(())
     }
 }
@@ -39,4 +185,115 @@ use std::path::PathBuf;
 
 pub(crate) fn config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|base| base.join("com.b1indsight.viberwhisper"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+
+    use super::*;
+
+    struct FakeAccessibility {
+        result: RefCell<Option<Result<AccessibilityInsert, AccessibilityError>>>,
+        texts: RefCell<Vec<String>>,
+    }
+
+    impl FakeAccessibility {
+        fn returning(result: Result<AccessibilityInsert, AccessibilityError>) -> Self {
+            Self {
+                result: RefCell::new(Some(result)),
+                texts: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl AccessibilityWriter for FakeAccessibility {
+        fn insert_selected_text(
+            &self,
+            text: &str,
+        ) -> Result<AccessibilityInsert, AccessibilityError> {
+            self.texts.borrow_mut().push(text.to_string());
+            self.result
+                .borrow_mut()
+                .take()
+                .expect("fake Accessibility result used once")
+        }
+    }
+
+    #[derive(Default)]
+    struct FakePaste {
+        calls: Cell<usize>,
+        texts: RefCell<Vec<String>>,
+    }
+
+    impl PasteWriter for FakePaste {
+        fn paste(&self, text: &str) -> Result<(), PasteError> {
+            self.calls.set(self.calls.get() + 1);
+            self.texts.borrow_mut().push(text.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn direct_accessibility_insert_never_uses_paste_fallback() {
+        let accessibility = FakeAccessibility::returning(Ok(AccessibilityInsert::Inserted));
+        let paste = FakePaste::default();
+
+        let outcome = route_injection("hello", &accessibility, &paste).unwrap();
+
+        assert_eq!(outcome, InjectionOutcome::Accessibility);
+        assert_eq!(paste.calls.get(), 0);
+    }
+
+    #[test]
+    fn unsupported_selected_text_uses_paste_once_with_exact_text() {
+        let accessibility = FakeAccessibility::returning(Ok(AccessibilityInsert::Unsupported(
+            "selected text is not settable",
+        )));
+        let paste = FakePaste::default();
+        let text = "line 1\n\"quoted\" \\ slash 中文 😀";
+
+        let outcome = route_injection(text, &accessibility, &paste).unwrap();
+
+        assert_eq!(outcome, InjectionOutcome::Paste);
+        assert_eq!(paste.calls.get(), 1);
+        assert_eq!(paste.texts.borrow().as_slice(), [text]);
+    }
+
+    #[test]
+    fn secure_and_hard_accessibility_errors_never_fall_back() {
+        let cases = [
+            AccessibilityError::SecureControl,
+            AccessibilityError::PermissionDenied,
+            AccessibilityError::NoFocusedElement,
+            AccessibilityError::Native {
+                operation: "set selected text",
+                code: -25204,
+            },
+        ];
+
+        for error in cases {
+            let accessibility = FakeAccessibility::returning(Err(error));
+            let paste = FakePaste::default();
+
+            assert!(matches!(
+                route_injection("secret", &accessibility, &paste),
+                Err(MacInjectionError::Accessibility(_))
+            ));
+            assert_eq!(paste.calls.get(), 0);
+        }
+    }
+
+    #[test]
+    fn empty_text_is_a_complete_no_op() {
+        let accessibility = FakeAccessibility::returning(Ok(AccessibilityInsert::Inserted));
+        let paste = FakePaste::default();
+
+        assert_eq!(
+            route_injection("", &accessibility, &paste).unwrap(),
+            InjectionOutcome::Noop
+        );
+        assert!(accessibility.texts.borrow().is_empty());
+        assert_eq!(paste.calls.get(), 0);
+    }
 }

--- a/src/platform/macos/accessibility.rs
+++ b/src/platform/macos/accessibility.rs
@@ -1,0 +1,151 @@
+use std::ptr::NonNull;
+
+use objc2_application_services::{AXError, AXIsProcessTrusted, AXUIElement};
+use objc2_core_foundation::{CFRetained, CFString, CFType};
+
+use super::{AccessibilityError, AccessibilityInsert, AccessibilityWriter};
+
+const FOCUSED_UI_ELEMENT_ATTRIBUTE: &str = "AXFocusedUIElement";
+const SELECTED_TEXT_ATTRIBUTE: &str = "AXSelectedText";
+const SUBROLE_ATTRIBUTE: &str = "AXSubrole";
+const SECURE_TEXT_FIELD_SUBROLE: &str = "AXSecureTextField";
+
+pub(super) struct NativeAccessibility;
+
+fn native_error(operation: &'static str, error: AXError) -> AccessibilityError {
+    if error == AXError::APIDisabled {
+        AccessibilityError::PermissionDenied
+    } else {
+        AccessibilityError::Native {
+            operation,
+            code: error.0,
+        }
+    }
+}
+
+fn is_unsupported(error: AXError) -> bool {
+    matches!(
+        error,
+        AXError::AttributeUnsupported | AXError::NoValue | AXError::NotImplemented
+    )
+}
+
+/// Copies one AX attribute while preserving the Core Foundation create-rule ownership returned by
+/// `AXUIElementCopyAttributeValue`.
+fn copy_attribute(
+    element: &AXUIElement,
+    attribute: &CFString,
+    operation: &'static str,
+) -> Result<CFRetained<CFType>, AccessibilityError> {
+    let mut value: *const CFType = std::ptr::null();
+    // SAFETY: `value` is a valid out-pointer for the duration of the call. A successful Copy call
+    // returns a retained Core Foundation object, which is transferred into `CFRetained` below.
+    let error = unsafe { element.copy_attribute_value(attribute, NonNull::from(&mut value)) };
+    if error != AXError::Success {
+        return Err(native_error(operation, error));
+    }
+
+    let value = NonNull::new(value.cast_mut()).ok_or(AccessibilityError::Native {
+        operation,
+        code: AXError::Failure.0,
+    })?;
+    // SAFETY: The successful AX Copy call returned a non-null object with +1 retain ownership.
+    Ok(unsafe { CFRetained::from_raw(value) })
+}
+
+fn focused_element() -> Result<CFRetained<AXUIElement>, AccessibilityError> {
+    // SAFETY: This function has no pointer parameters or caller-side preconditions.
+    if !unsafe { AXIsProcessTrusted() } {
+        return Err(AccessibilityError::PermissionDenied);
+    }
+
+    // SAFETY: Creating the system-wide AX object has no caller-side preconditions.
+    let system = unsafe { AXUIElement::new_system_wide() };
+    let focused_attribute = CFString::from_static_str(FOCUSED_UI_ELEMENT_ATTRIBUTE);
+    match copy_attribute(&system, &focused_attribute, "focused element lookup") {
+        Ok(value) => {
+            value
+                .downcast::<AXUIElement>()
+                .map_err(|_| AccessibilityError::UnexpectedType {
+                    operation: "focused element lookup",
+                })
+        }
+        Err(AccessibilityError::Native { code, .. })
+            if code == AXError::NoValue.0
+                || code == AXError::AttributeUnsupported.0
+                || code == AXError::NotImplemented.0 =>
+        {
+            Err(AccessibilityError::NoFocusedElement)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn reject_secure_control(element: &AXUIElement) -> Result<(), AccessibilityError> {
+    let subrole_attribute = CFString::from_static_str(SUBROLE_ATTRIBUTE);
+    let subrole = match copy_attribute(element, &subrole_attribute, "subrole lookup") {
+        Ok(value) => {
+            value
+                .downcast::<CFString>()
+                .map_err(|_| AccessibilityError::UnexpectedType {
+                    operation: "subrole lookup",
+                })?
+        }
+        Err(AccessibilityError::Native { code, .. })
+            if code == AXError::NoValue.0
+                || code == AXError::AttributeUnsupported.0
+                || code == AXError::NotImplemented.0 =>
+        {
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
+
+    if subrole.to_string() == SECURE_TEXT_FIELD_SUBROLE {
+        Err(AccessibilityError::SecureControl)
+    } else {
+        Ok(())
+    }
+}
+
+impl AccessibilityWriter for NativeAccessibility {
+    fn insert_selected_text(&self, text: &str) -> Result<AccessibilityInsert, AccessibilityError> {
+        let focused = focused_element()?;
+        reject_secure_control(&focused)?;
+
+        let selected_text_attribute = CFString::from_static_str(SELECTED_TEXT_ATTRIBUTE);
+        let mut settable = 0;
+        // SAFETY: `settable` is a valid out-pointer for the duration of this call.
+        let error = unsafe {
+            focused.is_attribute_settable(&selected_text_attribute, NonNull::from(&mut settable))
+        };
+        if is_unsupported(error) {
+            return Ok(AccessibilityInsert::Unsupported(
+                "selected text is unsupported",
+            ));
+        }
+        if error != AXError::Success {
+            return Err(native_error("selected-text settable check", error));
+        }
+        if settable == 0 {
+            return Ok(AccessibilityInsert::Unsupported(
+                "selected text is not settable",
+            ));
+        }
+
+        let text = CFString::from_str(text);
+        // SAFETY: `CFString` is a supported AX attribute value type and both references remain
+        // valid for the duration of the synchronous call.
+        let error = unsafe { focused.set_attribute_value(&selected_text_attribute, &text) };
+        if is_unsupported(error) {
+            return Ok(AccessibilityInsert::Unsupported(
+                "selected-text assignment is unsupported",
+            ));
+        }
+        if error != AXError::Success {
+            return Err(native_error("selected-text assignment", error));
+        }
+
+        Ok(AccessibilityInsert::Inserted)
+    }
+}

--- a/src/platform/macos/hotkey.rs
+++ b/src/platform/macos/hotkey.rs
@@ -1,0 +1,84 @@
+use objc2_core_graphics::{CGEventSource, CGEventSourceStateID};
+use rdev::{EventType, Key};
+
+fn modifier_keycode(key: Key) -> Option<u16> {
+    match key {
+        Key::MetaLeft => Some(55),
+        Key::ShiftLeft => Some(56),
+        Key::Alt => Some(58),
+        Key::ControlLeft => Some(59),
+        Key::ShiftRight => Some(60),
+        Key::AltGr => Some(61),
+        Key::ControlRight => Some(62),
+        Key::Function => Some(63),
+        Key::MetaRight => Some(54),
+        _ => None,
+    }
+}
+
+fn normalize_modifier_event(
+    event_type: EventType,
+    key_is_pressed: impl FnOnce(u16) -> bool,
+) -> EventType {
+    let key = match &event_type {
+        EventType::KeyPress(key) | EventType::KeyRelease(key) => *key,
+        _ => return event_type,
+    };
+    let Some(keycode) = modifier_keycode(key) else {
+        return event_type;
+    };
+
+    if key_is_pressed(keycode) {
+        EventType::KeyPress(key)
+    } else {
+        EventType::KeyRelease(key)
+    }
+}
+
+pub(super) fn normalize_event(event_type: EventType) -> EventType {
+    normalize_modifier_event(event_type, |keycode| {
+        CGEventSource::key_state(CGEventSourceStateID::HIDSystemState, keycode)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_modifier_direction_from_physical_key_state() {
+        let keycodes = [
+            (Key::MetaRight, 54),
+            (Key::MetaLeft, 55),
+            (Key::ShiftLeft, 56),
+            (Key::Alt, 58),
+            (Key::ControlLeft, 59),
+            (Key::ShiftRight, 60),
+            (Key::AltGr, 61),
+            (Key::ControlRight, 62),
+            (Key::Function, 63),
+        ];
+        for (key, expected) in keycodes {
+            assert_eq!(modifier_keycode(key), Some(expected));
+        }
+        assert_eq!(modifier_keycode(Key::F8), None);
+
+        assert_eq!(
+            normalize_modifier_event(EventType::KeyPress(Key::AltGr), |keycode| {
+                assert_eq!(keycode, 61);
+                false
+            }),
+            EventType::KeyRelease(Key::AltGr)
+        );
+        assert_eq!(
+            normalize_modifier_event(EventType::KeyRelease(Key::AltGr), |_| true),
+            EventType::KeyPress(Key::AltGr)
+        );
+        assert_eq!(
+            normalize_modifier_event(EventType::KeyPress(Key::F8), |_| {
+                panic!("ordinary keys do not require a physical-state query")
+            }),
+            EventType::KeyPress(Key::F8)
+        );
+    }
+}

--- a/src/platform/macos/pasteboard.rs
+++ b/src/platform/macos/pasteboard.rs
@@ -1,0 +1,227 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use objc2_app_kit::{NSPasteboard, NSPasteboardTypeString};
+use objc2_core_graphics::{
+    CGEvent, CGEventFlags, CGEventSource, CGEventSourceStateID, CGEventTapLocation,
+};
+use objc2_foundation::NSString;
+use rdev::EventType;
+
+use super::{PasteError, PasteWriter};
+
+const SYNTHETIC_EVENT_FILTER_GRACE: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NativeEventSpec {
+    virtual_key: u16,
+    pressed: bool,
+    command_flag: bool,
+}
+
+const PASTE_EVENT_SPECS: [NativeEventSpec; 4] = [
+    NativeEventSpec {
+        virtual_key: 55,
+        pressed: true,
+        command_flag: true,
+    },
+    NativeEventSpec {
+        virtual_key: 9,
+        pressed: true,
+        command_flag: true,
+    },
+    NativeEventSpec {
+        virtual_key: 9,
+        pressed: false,
+        command_flag: true,
+    },
+    NativeEventSpec {
+        virtual_key: 55,
+        pressed: false,
+        command_flag: false,
+    },
+];
+
+fn replace_with_text(pasteboard: &NSPasteboard, text: &str) -> Result<(), String> {
+    pasteboard.clearContents();
+    let text = NSString::from_str(text);
+    // SAFETY: AppKit exports this process-lifetime immutable type identifier.
+    let string_type = unsafe { NSPasteboardTypeString };
+    if pasteboard.setString_forType(&text, string_type) {
+        Ok(())
+    } else {
+        Err("AppKit rejected the transcription text".to_string())
+    }
+}
+
+fn post_paste() -> Result<(), String> {
+    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState)
+        .ok_or_else(|| "could not create CoreGraphics event source".to_string())?;
+
+    let mut events = Vec::with_capacity(PASTE_EVENT_SPECS.len());
+    for spec in PASTE_EVENT_SPECS {
+        let event = CGEvent::new_keyboard_event(Some(&source), spec.virtual_key, spec.pressed)
+            .ok_or_else(|| {
+                format!(
+                    "could not create CoreGraphics keyboard event for key {}",
+                    spec.virtual_key
+                )
+            })?;
+        let flags = if spec.command_flag {
+            CGEventFlags::MaskCommand
+        } else {
+            CGEventFlags::empty()
+        };
+        CGEvent::set_flags(Some(&event), flags);
+        events.push(event);
+    }
+
+    for event in &events {
+        CGEvent::post(CGEventTapLocation::HIDEventTap, Some(event));
+    }
+    Ok(())
+}
+
+/// Keeps ViberWhisper's listener filter closed while synthetic Cmd+V events can arrive.
+/// The operating system and focused application still receive every event.
+struct HotkeySuppression<'a> {
+    active: &'a AtomicBool,
+}
+
+impl HotkeySuppression<'_> {
+    fn begin(active: &AtomicBool) -> HotkeySuppression<'_> {
+        assert!(
+            active
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok(),
+            "paste hotkey suppression must not overlap"
+        );
+        HotkeySuppression { active }
+    }
+}
+
+impl Drop for HotkeySuppression<'_> {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::Release);
+    }
+}
+
+fn paste_transaction(
+    pasteboard: &NSPasteboard,
+    writer: &NativePasteWriter,
+    text: &str,
+) -> Result<(), PasteError> {
+    replace_with_text(pasteboard, text).map_err(PasteError::Write)?;
+
+    let _suppression = writer.suppress_hotkeys();
+    post_paste().map_err(PasteError::Delivery)?;
+    // CoreGraphics posting is asynchronous. Keep the listener callback filtered briefly so it
+    // can observe the generated sequence before normal hotkey handling resumes.
+    std::thread::sleep(SYNTHETIC_EVENT_FILTER_GRACE);
+    Ok(())
+}
+
+pub(super) struct NativePasteWriter {
+    suppress_hotkeys: Arc<AtomicBool>,
+}
+
+impl NativePasteWriter {
+    /// Creates the writer and the one callback that shares its private suppression flag.
+    /// The callback must be installed in the process-lifetime hotkey listener before `paste` runs.
+    pub(super) fn new() -> (
+        Self,
+        impl Fn(EventType) -> Option<EventType> + Send + 'static,
+    ) {
+        let suppress_hotkeys = Arc::new(AtomicBool::new(false));
+        let listener_suppression = Arc::clone(&suppress_hotkeys);
+        let filter = move |event_type| {
+            if listener_suppression.load(Ordering::Acquire) {
+                None
+            } else {
+                Some(super::hotkey::normalize_event(event_type))
+            }
+        };
+        (Self { suppress_hotkeys }, filter)
+    }
+
+    fn suppress_hotkeys(&self) -> HotkeySuppression<'_> {
+        HotkeySuppression::begin(&self.suppress_hotkeys)
+    }
+}
+
+impl PasteWriter for NativePasteWriter {
+    fn paste(&self, text: &str) -> Result<(), PasteError> {
+        let pasteboard = NSPasteboard::generalPasteboard();
+        paste_transaction(&pasteboard, self, text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rdev::Key;
+
+    use super::*;
+
+    #[test]
+    fn native_paste_sequence_is_command_v() {
+        assert_eq!(
+            PASTE_EVENT_SPECS,
+            [
+                NativeEventSpec {
+                    virtual_key: 55,
+                    pressed: true,
+                    command_flag: true,
+                },
+                NativeEventSpec {
+                    virtual_key: 9,
+                    pressed: true,
+                    command_flag: true,
+                },
+                NativeEventSpec {
+                    virtual_key: 9,
+                    pressed: false,
+                    command_flag: true,
+                },
+                NativeEventSpec {
+                    virtual_key: 55,
+                    pressed: false,
+                    command_flag: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn writer_filter_only_drops_events_during_a_paste_scope() {
+        let (writer, filter) = NativePasteWriter::new();
+        let event = EventType::KeyPress(Key::KeyV);
+
+        assert_eq!(filter(event), Some(event));
+        {
+            let _suppression = writer.suppress_hotkeys();
+            assert_eq!(filter(event), None);
+        }
+        assert_eq!(filter(event), Some(event));
+    }
+
+    #[test]
+    fn native_named_pasteboard_keeps_replacement_text() {
+        objc2::rc::autoreleasepool(|_| {
+            let pasteboard = NSPasteboard::pasteboardWithUniqueName();
+            // SAFETY: AppKit exports this process-lifetime immutable type identifier.
+            let string_type = unsafe { NSPasteboardTypeString };
+            let original = NSString::from_str("original clipboard value");
+            pasteboard.clearContents();
+            assert!(pasteboard.setString_forType(&original, string_type));
+
+            replace_with_text(&pasteboard, "native 中文 😀").unwrap();
+
+            assert_eq!(
+                pasteboard.stringForType(string_type).unwrap().to_string(),
+                "native 中文 😀"
+            );
+            pasteboard.clearContents();
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- replace the macOS `osascript` path with focused Accessibility selected-text insertion
- fall back only when selected text is unsupported, replacing the general pasteboard with the transcription and leaving that text on the clipboard
- avoid reading, snapshotting, materializing, or restoring previous pasteboard items and representations
- post native CoreGraphics Cmd+V and filter the short synthetic-event window from ViberWhisper's own hotkey mapper
- keep macOS modifier normalization in the platform layer and expose only an event-filter callback to the generic listener
- keep the `TextTyper` boundary and Windows `SendInput` behavior unchanged
- synchronize README, architecture docs, plan status/deviations, AGENTS.md, and changelog

## Validation

- `cargo test` — 115 passed
- `cargo check --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `cargo check --target x86_64-pc-windows-gnu`
- `cargo fmt --check`
- `git diff --check`
- native named-pasteboard replacement test — passed
- `uv run pytest` — 18 passed, 2 skipped
- hosted macOS, Windows, and Python CI — passed on code-bearing revision `40d8d8650f94`

## Pending validation

- interactive macOS checks across AX-capable fields, paste-only controls, secure/no-focus cases, clipboard replacement, physical Command overlap, and configured V/Command hotkeys

## Independent review

The required review gate completed successfully. Its three findings are advisory and did not block this push:

- high: the fixed 100 ms filter grace cannot guarantee delayed synthetic events are suppressed
- medium: unsupported AX attributes may route a non-text focused element to paste fallback
- medium: filtering every event during the paste scope can discard physical hotkey transitions

## Plan

- `docs/plan/29-native-macos-text-injection.md`

Closes #76
