### PR TITLE
refactor(platform): hide native UI behind common interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ src/
   lib.rs                     — Crate module root and public application entry export
   application.rs             — Logging, CLI dispatch, config/local/convert workflows
   application/
-    listener.rs              — Hotkey/tray loop, session effects, transcription delivery
+    listener.rs              — Platform-action loop, session effects, transcription delivery
   runtime_config.rs          — Application-level profile and consumer config assembly
   session.rs                 — Shared SessionId value type
   text.rs                    — Shared language-aware transcription text merge
@@ -105,17 +105,20 @@ src/
     wav_file.rs              — Streaming offline WAV chunk reader
   input.rs                   — Input module entry and submodule declarations
   input/
-    hotkey.rs                — Process-lifetime rdev listener, event mapper, and filter callback
+    hotkey.rs                — Target-neutral rdev listener, event mapper, and policy contract
     typer.rs                 — TextTyper trait + MockTyper
-    tray.rs                  — TrayManager for system tray icon and recording control
-  platform.rs                — Platform selection and config directory API
+    tray.rs                  — Policy-driven TrayManager, embedded icons, and click debounce
+  platform.rs                — Compile-time backend selection and common platform facade
   platform/
-    macos.rs                 — MacTyper route selection and serialized delivery
+    backend.rs               — Private platform backend contract
+    runtime.rs               — Opaque events, semantic actions, tray/text runtime ownership
+    fallback.rs              — Unsupported-target development/test adapter
+    macos.rs                 — macOS backend policies and serialized native text delivery
     macos/
       accessibility.rs      — Focused AX selected-text insertion and secure-control rejection
       hotkey.rs             — rdev modifier normalization for the listener callback
       pasteboard.rs         — Clipboard replacement, CoreGraphics Cmd+V, and hotkey suppression
-    windows.rs               — WindowsTyper (SendInput API)
+    windows.rs               — Windows backend policies and SendInput text delivery
   transcriber.rs             — Transcriber traits, errors, and exports
   transcriber/
     api.rs                   — API-backed transcriber implementation

--- a/changelog
+++ b/changelog
@@ -39,3 +39,4 @@
 2026-08-10: Expand Hold and Toggle hotkeys from F1–F12 to named single keyboard keys, including standalone right Alt/Option, canonical aliases, platform-aware validation, and passthrough warnings
 2026-08-11: Replace fixed-rate listener polling and hand-written platform message pumps with a main-thread winit event loop, per-boundary audio readiness wakeups, and cancellable background transcription delivery
 2026-08-12: Replace macOS osascript text injection with native Accessibility selected-text insertion and an AppKit/CoreGraphics fallback that leaves the transcription on the clipboard, rejects secure controls, and suppresses its own synthetic hotkey events
+2026-08-12: Hide native hotkey, tray/icon, configuration-path, and text-delivery details behind one compile-time-selected platform runtime with opaque events and semantic actions

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,10 @@ Module-level design docs covering structs, methods, and dependencies.
 |---|---|
 | [audio.md](architecture/audio.md) | Audio recording — `AudioRecorder`, cpal stream management, live chunking, WAV output |
 | [core.md](architecture/core.md) | Strict v2 config persistence, runtime assembly, CLI parsing, and `SessionOrchestrator` |
-| [input.md](architecture/input.md) | Global hotkey detection, text injection (`TextTyper`), system tray (`TrayManager`) |
+| [input.md](architecture/input.md) | Target-neutral hotkey/tray drivers and the thread-safe `TextTyper` contract |
 | [local.md](architecture/local.md) | Local Gemma runtime: installer, Python FastAPI service, process lifecycle, health/status management |
 | [transcriber.md](architecture/transcriber.md) | Transcription trait, `ApiTranscriber` (OpenAI-compatible API), chunking, retry, text merging |
-| [platform.md](architecture/platform.md) | Platform text injection — native AX/paste fallback on macOS and `SendInput` on Windows |
+| [platform.md](architecture/platform.md) | Compile-time desktop interface for native input, status icons, config paths, and text delivery |
 | [postprocess.md](architecture/postprocess.md) | Post-processing — concrete processor facade, LLM integration, preheat/conservative sessions |
 
 ## Examples
@@ -56,3 +56,4 @@ Implementation plans and technical specs for each feature.
 | [27-release-path-hardening.md](plan/27-release-path-hardening.md) | Implemented | Make API-mode macOS and Windows packages reproducible, manually testable, and safe to publish |
 | [28-winit-event-loop.md](plan/28-winit-event-loop.md) | Implemented | Replace fixed listener polling with a main-thread winit event loop and non-blocking finalization |
 | [29-native-macos-text-injection.md](plan/29-native-macos-text-injection.md) | Implemented | Replace macOS osascript injection with direct AX insertion and a clipboard-replacing native paste fallback |
+| [30-compile-time-platform-interface.md](plan/30-compile-time-platform-interface.md) | Implemented | Hide native icon, hotkey, and text-delivery details behind one compile-time-selected platform interface |

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -28,7 +28,13 @@ alone returns the in-memory defaults.
 
 `runtime_config` selects the API or Local profile, constructs module-owned consumer configs, and aggregates construction errors into `ListenerConfig` or `BackendConfig`. Profile selection is consumed during assembly: `BackendConfig` stores the common transcriber and post-process values directly, plus an optional Local service, rather than duplicating common fields across enum variants. It contains no generic validator registry and no duplicated raw DTO layer.
 
-Each consumer receives a type owned by its module: `HotkeyConfig`, `AudioConfig`, `OrchestratorConfig`, `TranscriberConfig`, `PostProcessConfig`, `LocalPaths`, or `LocalServiceConfig`. Local mode uses `ApiAuth::None`; API mode uses a redacted `SecretValue` when configured and `ApiAuth::None` otherwise. `local start` selects Local for one invocation without mutating the persisted profile.
+Each consumer receives a type owned by its module: `HotkeyConfig`, `AudioConfig`,
+`OrchestratorConfig`, `TranscriberConfig`, `PostProcessConfig`, `LocalPaths`, or
+`LocalServiceConfig`. Hotkey resolution enters through `platform::validate_hotkeys`, so the
+compile-time-selected backend supplies native key availability without adding target branches to
+runtime assembly. Local mode uses `ApiAuth::None`; API mode uses a redacted `SecretValue` when
+configured and `ApiAuth::None` otherwise. `local start` selects Local for one invocation without
+mutating the persisted profile.
 
 ## CLI (`src/core/cli.rs`)
 
@@ -80,7 +86,10 @@ session or reach a newer session.
 
 ## Recording Session (`src/core/recording_session.rs`)
 
-`RecordingSessionMachine` is the sole authority for recording lifecycle transitions. The listener integration maps source-specific hotkey and tray gestures into source-free `StartRequested` and `StopRequested` events before they enter core.
+`RecordingSessionMachine` is the sole authority for recording lifecycle transitions. The selected
+platform runtime maps native hotkey and tray events into Hold/Toggle/Exit `PlatformAction` values;
+the listener integration then maps those actions into source-free `StartRequested`,
+`StopRequested`, and `ShutdownRequested` events before they enter core.
 
 ### States
 
@@ -113,13 +122,15 @@ Exit is represented as `ShutdownRequested`. It cancels recorder/orchestrator wor
 
 `application` loads one `ConfigDocument`, asks `runtime_config` for a typed workflow configuration,
 and passes each narrow value to its consumer. Listener mode then creates one main-thread winit
-`EventLoop<AppEvent>` in `ControlFlow::Wait` mode. Hotkey, tray/menu, audio-readiness, and background
-completion producers use `EventLoopProxy` to wake that loop; winit owns AppKit/Win32 dispatch and no
-window is created. CLI-only workflows do not construct the event loop.
+`EventLoop<AppEvent>` in `ControlFlow::Wait` mode. Opaque platform input, audio-readiness, and
+background completion producers use `EventLoopProxy` to wake that loop; winit owns AppKit/Win32
+dispatch and no window is created. CLI-only workflows do not construct the event loop.
 
-`src/application/listener/event_loop.rs` normalizes source events, executes state-machine effects,
-drains ready chunks, and coordinates background finalization. Winit types remain in the application
-layer. `core`, `audio`, and `input` expose only their existing domain values or narrow callbacks.
+`src/application/listener/event_loop.rs` passes opaque native payloads back through
+`NativePlatform::handle_event`, normalizes returned semantic actions, executes state-machine
+effects, drains ready chunks, and coordinates background finalization. Winit types remain in the
+application layer. `core`, `audio`, and `input` expose only domain values or narrow callbacks;
+platform-specific values remain behind `NativePlatform`.
 Finalization uses an atomic cancellation flag checked before post-processing and immediately before
 the final text injection. Exit records cancellation without waiting for an injection already in
 progress. Cancellation observed before the final check suppresses delivery, while an injection that

--- a/docs/architecture/input.md
+++ b/docs/architecture/input.md
@@ -2,7 +2,10 @@
 
 ## Purpose
 
-The `input` module (`src/input/`) handles three concerns: global hotkey detection (`hotkey.rs`), text injection into the focused window (`typer.rs`), and system tray UI (`tray.rs`). Input adapters report user intent; recording lifecycle decisions belong to `core::recording_session`.
+The `input` module (`src/input/`) provides target-neutral drivers and contracts for global hotkey
+detection (`hotkey.rs`), text delivery (`typer.rs`), and the system tray (`tray.rs`). Native policy
+is supplied by the compile-time-selected `platform` backend. Input drivers report native events;
+recording lifecycle decisions belong to `core::recording_session`.
 
 ---
 
@@ -32,22 +35,22 @@ Note: `Released` is only emitted for `Hold` source (toggle mode uses press-only 
 **`start_hotkey_listener(config, filter, notify)`**
 
 ```rust
-pub(crate) fn start_hotkey_listener<F>(
+pub(crate) fn start_hotkey_listener<P, F>(
     config: &HotkeyConfig,
     filter: F,
     notify: impl Fn(HotkeyEvent) + Send + 'static,
 ) where
+    P: HotkeyPolicy,
     F: Fn(EventType) -> Option<EventType> + Send + 'static;
 ```
 
 Starts the process-lifetime `rdev::listen` thread, maps native events, and invokes the supplied
-callback. The application callback forwards each event through winit's `EventLoopProxy`, which wakes
-the main-thread event loop without polling. Per-binding key-down state suppresses operating-system
-key-repeat events so one physical toggle press produces one toggle action. The supplied closure is
-the only platform hook: `Some(event)` reaches `EventMapper`, while `None` drops the event from
-ViberWhisper's mapper and resets its key-down bookkeeping. Non-macOS platforms use `Some` directly;
-macOS supplies a pasteboard-owned callback that normalizes modifier direction and returns `None`
-while the native fallback posts synthetic Cmd+V and its generated events can reach the listener.
+callback. `platform::PlatformRuntime` wraps the event in an opaque `PlatformEvent` and forwards it
+through winit's `EventLoopProxy`, which wakes the main-thread event loop without polling.
+Per-binding key-down state suppresses operating-system key repeat so one physical Toggle press
+produces one action. `P` supplies target validation/warning policy. The filter is constructed by the
+same selected backend that constructs the text writer: `Some(event)` reaches `EventMapper`, while
+`None` drops the event and resets its key-down bookkeeping.
 
 **`HotkeyConfig`**
 
@@ -59,7 +62,9 @@ canonical runtime label.
 
 ### Recording Input Normalization
 
-Hotkey and tray source details stop at the listener integration boundary in `application::listener`. The integration reads the session machine's current state without mutating it and publishes only source-free core requests:
+Hotkey and tray source details stop at `platform::PlatformRuntime`. It converts opaque native
+payloads into Hold/Toggle/Exit `PlatformAction` values. `application::listener` then reads the
+session machine's current state without mutating it and publishes only source-free core requests:
 
 | Raw gesture | Idle | Recording | Transitional/shutdown state |
 |---|---|---|---|
@@ -68,13 +73,17 @@ Hotkey and tray source details stop at the listener integration boundary in `app
 | Toggle press | `StartRequested` | `StopRequested` | ignored |
 | Tray left click | `StartRequested` | `StopRequested` | ignored |
 
-Because the core event carries no source, Hold release, Toggle, and tray input can stop a current session regardless of which input started it. Input modules continue to own native classification, key-repeat suppression, and click debounce; they do not own or copy recording state.
+Because the core event carries no source, Hold release, Toggle, and tray input can stop a current
+session regardless of which input started it. Input drivers and platform policies own native
+classification, key-repeat suppression, and click debounce; they do not own or copy recording
+state.
 
 ### Key Methods
 
 **`start_hotkey_listener(config, filter, notify)`**
 
-- `HotkeyConfig::validate(&InputSection)` parses and validates both bindings before construction.
+- `HotkeyConfig::validate::<P>(&InputSection)` parses and validates both bindings before
+  construction; `platform::validate_hotkeys` supplies the selected `P` to `runtime_config`.
 - Empty strings disable a binding, including both bindings for tray-only control; duplicate non-empty bindings are rejected.
 - Non-function bindings log that `rdev::listen` observes rather than suppresses their native input.
 - On Windows, a `LEFTCTRL` binding logs an additional warning because AltGr is reported as left Ctrl
@@ -83,8 +92,8 @@ Because the core event carries no source, Hold release, Toggle, and tray input c
 - Spawns the listener thread without blocking application startup.
 - Delivers mapped press/release events directly to the supplied non-blocking callback; the listener
   thread never runs recording state transitions itself.
-- Moves the supplied filter closure into the listener thread. macOS obtains its closure together
-  with `MacTyper`; other platforms pass the `Some` constructor as a stateless pass-through callback.
+- Moves the backend-supplied filter closure into the listener thread. macOS constructs it together
+  with `MacTyper`; Windows and the fallback use `Some` as a stateless pass-through callback.
 
 **`parse_key(s: &str) -> Option<Key>`**
 
@@ -94,8 +103,8 @@ locks/system keys, punctuation, and numeric-keypad keys. Explicit aliases normal
 `ALTGR` and `RIGHTOPTION` map to canonical `RIGHTALT`/`Key::AltGr`; `ALT` and `OPTION` map to
 `LEFTALT`/`Key::Alt`.
 
-`parse_key` recognizes the shared vocabulary independently of platform. `HotkeyConfig::validate`
-then returns `hotkey.unsupported` when the current `rdev 0.5.3` backend cannot emit the named
+`parse_key` recognizes the shared vocabulary independently of platform. The selected
+`HotkeyPolicy` then returns `hotkey.unsupported` when the current `rdev 0.5.3` backend cannot emit the named
 variant. On macOS this includes Caps Lock (a status change rather than a press/release pair), right
 Ctrl, forward Delete/Insert/navigation-cluster keys, several lock/system keys, international
 backslash, and numeric-keypad names. On Windows it includes right Meta, Function, and the numeric
@@ -130,8 +139,9 @@ The native paste fallback posts a fixed left-Command/V sequence through CoreGrap
 shared boundary, `rdev` could interpret those synthetic events as configured `V`, `LEFTMETA`, or
 `RIGHTMETA` recording hotkeys.
 
-`src/platform/macos/pasteboard.rs` owns an atomic suppression flag shared only with the closure it
-returns during `MacTyper` construction. The paste transaction raises that flag immediately before
+`MacBackend` constructs `MacTyper` and the filter returned by
+`src/platform/macos/pasteboard.rs` together, so their atomic suppression flag never leaves the
+platform boundary. The paste transaction raises that flag immediately before
 constructing and posting Cmd+V and keeps it raised through a fixed 100 ms synthetic-event filter
 grace. The closure returns `None` for every event observed in that short scope, so the synthetic sequence and
 any interleaved physical input still reach macOS and the focused application but do not enter
@@ -156,13 +166,15 @@ pub trait TextTyper: Send + Sync {
 }
 ```
 
-Platform implementations are in `src/platform/`. See [platform.md](platform.md).
+Platform implementations are in `src/platform/`. `NativePlatform::text_typer` returns the selected
+thread-safe handle without exposing its concrete type. See [platform.md](platform.md).
 The thread-safety contract allows final transcription delivery to run outside the native event-loop
 thread.
 
 ### `MockTyper`
 
-A no-op implementation used in tests and non-GUI environments. Logs the text at `INFO` level instead of injecting it.
+A no-op implementation selected by the explicit fallback backend on unsupported development/test
+targets. It logs text at `INFO` instead of injecting it.
 
 ---
 
@@ -171,14 +183,14 @@ A no-op implementation used in tests and non-GUI environments. Logs the text at 
 ### `TrayManager`
 
 ```rust
-pub struct TrayManager {
+pub struct TrayManager<P: TrayPolicy> {
     tray_icon: TrayIcon,
     icon_idle: Icon,
     icon_recording: Icon,
     status_item: MenuItem,
     exit_item_id: MenuId,
     click_debounce: ClickDebounce,
-    handler_installed: bool,
+    policy: PhantomData<P>,
 }
 ```
 
@@ -194,42 +206,44 @@ RGBA PNGs are embedded in the executable and decoded during tray construction, s
 does not depend on the current directory. Bundle icons use the same geometry from
 `assets/icon-source.svg` on a solid gray-blue `#282c34` rounded-square field.
 
-macOS treats the idle icon as an AppKit template so the system selects a legible menu-bar color for
-light and dark appearances. Recording switches the icon and template flag together, preserving the
-asset's explicit red. Windows ignores the template flag and displays the committed colors.
+`MacTray` treats the idle icon as an AppKit template so the system selects a legible menu-bar color
+for light and dark appearances. Recording switches the icon and template flag together, preserving
+the asset's explicit red. `WindowsTray` uses the committed colors directly.
 
 ### Key Methods
 
-**`TrayManager::new(notify) -> Result<Self>`**
+**`TrayManager::<P>::new(notify) -> Result<Self>`**
 
 Decodes the embedded idle and recording PNGs, then builds the tray icon with a menu containing:
 title item, status item, separator, and exit item. Corrupt or non-RGBA assets fail tray construction
 with an error, while tests enforce the committed 32×32 dimensions and transparency. Left-click menu
 opening is disabled so left click can toggle recording; right click retains the native context menu.
-Before creating the native icon, construction installs the process-global `tray-icon` and menu
-callbacks with the supplied application callback. `tray-icon 0.21` stores those handlers in one-shot
+Before creating the native icon, `P` prepares the native application and construction installs the
+process-global `tray-icon` and menu callbacks with the platform runtime's event callback.
+`tray-icon 0.21` stores those handlers in one-shot
 global cells, matching the application's single listener and process-lifetime event loop.
 
 **`set_recording(&mut self, recording: bool)`**
 
-Switches the icon, macOS template mode, tooltip, and menu status text based on recording state.
-Native icon/tooltip update failures are logged rather than silently discarded.
+Switches the icon, backend-selected template/color mode, tooltip, and menu status text based on
+recording state. Native icon/tooltip update failures are logged rather than silently discarded.
 
 **`handle_event(&mut self, event: TrayEvent) -> Option<TrayAction>`**
 
 Filters raw events by tray/menu ID and maps a matching left-button-up event to `ToggleRecording`.
-Unrelated icon IDs and mouse phases are discarded; Exit bypasses debounce. Events are handled in
-native delivery order, and once Exit transitions the core to `ShuttingDown`, later recording input
-is rejected.
+Unrelated icon IDs and mouse phases are discarded; Exit bypasses debounce. `TrayEvent` and
+`TrayAction` stay behind the opaque platform boundary; `PlatformRuntime::handle_event` returns the
+corresponding semantic `PlatformAction`. Events are handled in native delivery order, and once Exit
+transitions the core to `ShuttingDown`, later recording input is rejected.
 
 The main-thread winit loop owns AppKit/Win32 dispatch in `ControlFlow::Wait` mode. `TrayManager` no
-longer exposes a polling receiver or a manual platform event pump. macOS tray setup still enforces
+longer exposes a polling receiver or a manual platform event pump. `MacTray` still enforces
 Accessory activation policy and creates no application window.
 
 ### Click Protection
 
 - effective debounce window is `max(300 ms, platform double-click interval)`
-- macOS reads `NSEvent::doubleClickInterval()`
-- Windows reads `GetDoubleClickTime()` and suppresses the button-up following a native `DoubleClick`
+- `MacTray` reads `NSEvent::doubleClickInterval()`
+- `WindowsTray` reads `GetDoubleClickTime()` and suppresses the button-up following a native `DoubleClick`
 - the suppression is one-shot; ordinary ignored clicks do not extend the window
 - debounce applies only to tray recording toggles, never Exit or hotkeys

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -2,109 +2,188 @@
 
 ## Purpose
 
-The `platform` module provides platform-specific text injection and the platform-specific application configuration directory. Implementations are selected at compile time via `#[cfg(target_os)]`.
+The `platform` module is the compile-time boundary for native desktop capabilities. It provides
+one application-facing runtime for:
 
-## Configuration directory
+- global hotkey and tray input;
+- status icon creation and recording-state updates;
+- final text delivery to the focused control;
+- platform-aware hotkey validation; and
+- configuration-directory discovery.
 
-`platform::config_dir()` delegates to the current OS module. macOS appends `com.b1indsight.viberwhisper`; Windows appends `ViberWhisper`. `core::config::ConfigStore` alone appends `config.json`, so platform code does not depend on config schema or errors.
+Application and shared input code do not select an operating system, construct native writers, or
+handle `rdev`/`tray-icon` payload types.
 
----
+## Compile-Time Selection
 
-## macOS: `MacTyper` (`src/platform/macos.rs`)
+`src/platform.rs` is the only desktop target-selection point:
 
 ```rust
-pub struct MacTyper {
-    paste: NativePasteWriter,
-    delivery: Mutex<()>,
+#[cfg(target_os = "macos")]
+use macos::MacBackend as SelectedBackend;
+
+#[cfg(target_os = "windows")]
+use windows::WindowsBackend as SelectedBackend;
+
+pub(crate) type NativePlatform = PlatformRuntime<SelectedBackend>;
+```
+
+Unsupported development targets select `FallbackBackend`, which retains the existing mock text
+delivery and generic tray behavior without being a supported release platform. Target-specific
+native dependencies remain selected by Cargo target dependency tables.
+
+`platform/backend.rs` defines the private `PlatformBackend` contract. Each backend supplies:
+
+- a `HotkeyPolicy` implementation;
+- a `TrayPolicy` implementation;
+- its configuration directory; and
+- one text writer paired with its native hotkey filter.
+
+The compiler checks the selected backend's associated policies. There is no runtime OS enum,
+feature flag, or OS-name match in the application layer.
+
+## Application Interface
+
+`platform/runtime.rs` implements the common `PlatformInterface`:
+
+```rust
+pub(crate) trait PlatformInterface: Sized {
+    fn start(hotkeys, notify) -> Result<Self, Box<dyn Error>>;
+    fn handle_event(&mut self, event: PlatformEvent) -> Option<PlatformAction>;
+    fn set_recording(&mut self, recording: bool);
+    fn text_typer(&self) -> Arc<dyn TextTyper>;
 }
 ```
 
-### `type_text` Implementation
+`NativePlatform::start` constructs the selected text writer/filter pair, starts the
+process-lifetime `rdev` listener, creates the tray, and installs the native callbacks. The listener
+application stores this single runtime instead of storing a tray and text writer separately.
 
-`MacTyper` serializes non-empty deliveries and sleeps 100 ms so the target window can regain focus.
-It then enters an Objective-C autorelease pool and uses two native routes:
+`PlatformEvent` is an opaque wrapper around private hotkey or tray events. Native callbacks enqueue
+it through winit, and the main-thread listener passes it back to `handle_event`. The runtime returns
+only these semantic actions:
 
-1. `macos/accessibility.rs` resolves the system-wide focused AX element, rejects
-   `AXSecureTextField`, checks whether `AXSelectedText` is settable, and assigns the transcription
-   to that selected-text attribute. An empty selection inserts at the caret; a non-empty selection
-   is replaced. This success path does not read the clipboard or emit keyboard events.
+```rust
+pub(crate) enum PlatformAction {
+    HoldPressed,
+    HoldReleased,
+    ToggleRecording,
+    ExitRequested,
+}
+```
+
+Toggle hotkey releases, key repeats, unrelated tray/menu IDs, rejected clicks, and native
+double-click tails produce no action. Recording-state decisions remain in
+`application::listener`; platform actions are mapped there to source-free `SessionEvent` values.
+
+## Ownership and Event Flow
+
+```text
+rdev callback ─┐
+               ├─> opaque PlatformEvent ─> winit AppEvent::Platform
+tray callback ─┘                                  │
+                                                 v
+                                  NativePlatform::handle_event
+                                                 │
+                                      optional PlatformAction
+                                                 │
+                                                 v
+                                   RecordingSessionMachine
+
+SessionEffect::SetTrayRecording ─> NativePlatform::set_recording
+final transcription              ─> NativePlatform::text_typer ─> worker
+```
+
+`NativePlatform` and its tray stay on the winit/main thread. `text_typer()` clones only the
+`Send + Sync` text writer handle for a finalization worker. AppKit/Win32 tray values never cross to
+that worker, and text delivery never blocks the native event loop.
+
+Raw tray events must return through winit before they are classified because click debounce and
+own-ID filtering mutate the main-thread-owned `TrayManager`. Native callback threads only enqueue
+events and never run recording transitions.
+
+## Hotkey Policy
+
+`platform::validate_hotkeys` resolves persisted names through the selected backend policy before a
+listener starts. Shared parsing, aliases, duplicates, repeat suppression, and stable validation
+codes remain in `input::hotkey`. Backends own the native differences:
+
+- macOS rejects key variants the current `rdev` backend cannot emit and normalizes modifier
+  direction with Core Graphics physical key state;
+- Windows rejects `RIGHTMETA`, `FUNCTION`, and keypad Enter, rejects a
+  `LEFTCTRL`/`RIGHTALT` pair as `hotkey.altgr_conflict`, and warns that AltGr can emit left Ctrl;
+- macOS supplies the synthetic-paste suppression filter paired with `MacTyper`;
+- Windows and the fallback backend supply an identity event filter.
+
+Non-function pass-through warnings remain shared because passive `rdev` observation does not stop
+the key from reaching the focused application or operating system.
+
+## Tray and Status Icon Policy
+
+`input::tray::TrayManager<P>` retains the common icon decoding, menu construction, callback
+installation, own-ID filtering, click debounce, tooltip, and menu status behavior. The selected
+`TrayPolicy` supplies only native differences:
+
+| Capability | macOS | Windows |
+|---|---|---|
+| application preparation | AppKit Accessory activation on main thread | no-op |
+| idle icon | template image | committed explicit color |
+| recording icon | committed explicit red | committed explicit red |
+| double-click interval | `NSEvent::doubleClickInterval` | `GetDoubleClickTime` |
+| icon update | `set_icon_with_as_template` | `set_icon` |
+
+Both platforms retain the 300 ms minimum debounce window and embedded 32×32 RGBA icon assets.
+
+## Configuration Directory
+
+`platform::config_dir()` delegates through the selected backend. macOS appends
+`com.b1indsight.viberwhisper`; Windows appends `ViberWhisper`; the fallback appends
+`viberwhisper`. `ConfigStore` alone appends `config.json`, so platform code does not know the
+configuration schema or persistence errors.
+
+## macOS Text Delivery
+
+`MacBackend` constructs `MacTyper` together with the filter returned by its
+`NativePasteWriter`. That shared suppression state is private to the platform boundary.
+
+`MacTyper` serializes non-empty deliveries, sleeps 100 ms so the target can regain focus, enters an
+Objective-C autorelease pool, and uses two native routes:
+
+1. `macos/accessibility.rs` resolves the focused AX element, rejects `AXSecureTextField`, checks
+   whether `AXSelectedText` is settable, and assigns the transcription to that attribute. An empty
+   selection inserts at the caret; a non-empty selection is replaced. This path does not touch the
+   clipboard or emit keyboard events.
 2. A present, non-secure control that explicitly lacks settable selected text uses the native paste
    fallback. Missing Accessibility trust, no focused element, secure controls, invalid AX objects,
    type mismatches, and messaging failures are hard errors and do not paste into an unknown target.
 
-The implementation never reads or writes `AXValue`, does not construct AppleScript, and does not
-launch a subprocess. Text is carried as `CFString`/`NSString`, so multiline content, quotes,
-backslashes, CJK, and emoji require no shell escaping.
+The implementation never reads/writes `AXValue`, builds AppleScript, or launches a subprocess.
+Text uses `CFString`/`NSString`, preserving multiline content, quotes, backslashes, CJK, and emoji.
 
 ### Native paste fallback
 
-`macos/pasteboard.rs` clears the general pasteboard and writes the transcription as
-`NSPasteboardTypeString`. It intentionally leaves that text on the clipboard after delivery; the
-fallback does not read, snapshot, or restore the previous contents. This avoids materializing
-arbitrary pasteboard representations in process memory and avoids racing a later clipboard owner.
+`macos/pasteboard.rs` clears the general pasteboard, writes the transcription as
+`NSPasteboardTypeString`, and intentionally leaves it on the clipboard. It posts left Command down,
+V down, V up, and left Command up through a HID-system Core Graphics event source.
 
-The same module creates one HID-system `CGEventSource` and posts left Command down, V down, V up,
-and left Command up.
+An atomic RAII suppression scope filters ViberWhisper's own mapping callback across event posting
+and a fixed 100 ms asynchronous-event grace. The operating system and focused application still
+receive every event. A filtered callback resets mapper key-down state; outside the scope,
+`macos/hotkey.rs` normalizes modifier direction and passes ordinary events unchanged.
 
-`NativePasteWriter` owns an atomic flag and returns a listener filter closure together with the
-writer. A private RAII scope raises the flag across CoreGraphics posting and a fixed 100 ms
-synthetic-event filter grace; the closure returns `None` during that scope, which keeps
-ViberWhisper from treating its own Cmd+V
-as configured hotkeys. The generic listener resets mapper key-down state whenever a callback drops
-an event. Outside the paste scope, `macos/hotkey.rs` normalizes modifier direction through
-`CGEventSourceKeyState` and the callback returns the normalized event. No acknowledgement or
-sequence-matching protocol is involved. The grace only gives the asynchronous `rdev` callback time
-to observe generated events; it is not a clipboard-consumption or delivery acknowledgement.
+Accessibility permission is required. Missing permission is a hard input error and leaves the
+clipboard untouched.
 
-AppKit rejection of the transcription write and failure to construct the CoreGraphics event source
-or events are returned as paste errors. If event construction fails after the write, the
-transcription still remains on the clipboard.
+## Windows Text Delivery
 
-**Requirements:** grant Accessibility permission to the running terminal or ViberWhisper in System
-Settings → Privacy & Security → Accessibility. Missing permission is a hard input error and leaves
-the clipboard untouched.
+`WindowsBackend` constructs the zero-state `WindowsTyper`. `type_text`:
 
----
+1. sleeps 100 ms so the target can regain focus;
+2. expands the text into UTF-16 code units;
+3. creates key-down/key-up `INPUT` pairs using `KEYEVENTF_UNICODE`;
+4. calls Win32 `SendInput`; and
+5. verifies that every event was accepted.
 
-## Windows: `WindowsTyper` (`src/platform/windows.rs`)
-
-```rust
-pub struct WindowsTyper;
-```
-
-### `type_text` Implementation
-
-Uses the Win32 `SendInput` API to inject Unicode keystrokes directly:
-
-1. Sleeps 100 ms to let the target window regain focus.
-2. Encodes the text as UTF-16 code units.
-3. Creates paired `INPUT` structs (keydown + keyup) for each code unit using `KEYEVENTF_UNICODE`.
-4. Calls `SendInput` and verifies all events were sent.
-
-**FFI:** The `ffi` submodule defines the `INPUT`, `KEYBDINPUT`, and `INPUT_UNION` C structs, links against `user32.dll`, and declares `SendInput` as `unsafe extern "system"`.
-
----
-
-## Selecting an Implementation
-
-In `src/application/listener.rs`, the typer is selected conditionally:
-
-```rust
-#[cfg(target_os = "macos")]
-let (typer, hotkey_filter) = MacTyper::new();
-
-start_hotkey_listener(&config.hotkeys, hotkey_filter, notify);
-
-#[cfg(target_os = "macos")]
-let typer = Arc::new(typer);
-
-#[cfg(target_os = "windows")]
-let typer = WindowsTyper;
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-let typer = MockTyper;
-```
-
-All three types implement `TextTyper`, so the listener calls `typer.type_text(text)` uniformly.
-Only macOS receives a stateful filter callback from its paste writer; other platforms pass events
-through with `Some`, and Windows `SendInput` behavior is unchanged.
+Surrogate pairs therefore produce one down/up pair for each UTF-16 code unit. The private FFI
+module owns the C layouts, flags, `SendInput`, and `GetDoubleClickTime` declarations linked from
+`user32.dll`.

--- a/docs/plan/30-compile-time-platform-interface.md
+++ b/docs/plan/30-compile-time-platform-interface.md
@@ -1,0 +1,420 @@
+# Compile-Time Platform Interface
+
+## Status
+
+**Implemented; automated validation complete.** The common runtime, compile-time backends, opaque
+event boundary, target-neutral input drivers, listener integration, tests, and current-truth
+documentation are complete. Local checks and hosted macOS/Windows CI pass. The native
+macOS/Windows smoke matrix remains required before PR readiness.
+
+## Implementation Result
+
+The implementation follows the approved ownership and capability boundary. `NativePlatform` is a
+compile-time alias for `PlatformRuntime<SelectedBackend>`; listener code contains no target
+selection and receives only opaque `PlatformEvent` values plus semantic `PlatformAction` results.
+Hotkey and tray policies now live in their selected platform backends, while shared parsing,
+mapping, icon/menu construction, and debounce mechanics remain in `input`.
+
+Two proportional implementation refinements were made:
+
+- startup retains the existing boxed error boundary instead of adding a forwarding-only
+  `PlatformStartError` enum; and
+- an injected driver seam lets the platform-runtime contract test exercise startup callbacks,
+  opaque event routing, tray state, and text delivery without installing process-global `rdev`
+  or `tray-icon` handlers. macOS and Windows backend policy tests cover their native differences
+  directly.
+
+Local validation completed with the full 117-test macOS suite, strict Clippy, native build/check,
+an Intel `x86_64-apple-darwin` check, and strict `x86_64-pc-windows-msvc` check/Clippy. The
+source-boundary search confirms no `target_os` conditions remain in `application`, `input`, or
+`runtime_config`. Hosted macOS, Windows, and Python CI also pass on the pushed implementation.
+
+## Goal
+
+Give the application layer one platform-neutral interface for the desktop capabilities it uses:
+
+1. receive global Hold/Toggle and tray input;
+2. create and update the status icon;
+3. deliver final text to the focused control; and
+4. discover the platform configuration directory.
+
+The Rust compiler selects the macOS or Windows implementation. Application and session objects
+call only the common interface and do not contain `#[cfg(target_os)]`, name `MacTyper` or
+`WindowsTyper`, supply a native hotkey filter, or handle `rdev`/`tray-icon` event types.
+
+This is an architecture refactor. It preserves the current user-visible icon, hotkey, tray, text
+injection, configuration, event-loop, and packaging behavior.
+
+## Current Problem
+
+Compile-time selection exists, but it is incomplete and spread across layers:
+
+- `application::listener` selects `MacTyper`, `WindowsTyper`, `MockTyper`, and the macOS hotkey
+  filter with several target `cfg` blocks.
+- `input::hotkey` owns shared parsing and mapping but also embeds macOS/Windows support tables,
+  Windows AltGr rules, and platform warnings.
+- `input::tray` embeds AppKit activation, macOS template-icon updates, native double-click lookup,
+  and Win32 `GetDoubleClickTime` behind target `cfg` blocks.
+- raw `TrayEvent` and `HotkeyEvent` values enter `application::listener::AppEvent`, so the
+  application event loop knows which native input adapter produced an event.
+- macOS text injection must construct its paste writer and hotkey filter together, but the
+  application is currently responsible for preserving that platform-specific relationship.
+
+The result is a shared application workflow that calls common methods only after it has already
+made platform decisions. Adding or changing a platform capability therefore requires edits in
+application and input integration code as well as the platform implementation.
+
+## Scope
+
+### In scope
+
+- A common platform lifecycle and capability interface used by the listener application.
+- One compile-time-selected native platform type for macOS and Windows.
+- An opaque platform event envelope and platform-neutral semantic actions.
+- Platform ownership of tray/icon policy, hotkey policy/filtering, and text writer construction.
+- Removal of target-specific branches from `application`, `runtime_config`, and shared input
+  drivers.
+- Preservation of the current unsupported-target test/development fallback without claiming a
+  third supported desktop platform.
+- Tests that enforce the shared contract and retain platform-specific behavior.
+
+### Out of scope
+
+- A new window, settings UI, overlay, icon design, animation, or system notification.
+- Runtime operating-system detection, a platform setting, or feature-flag selection.
+- Replacing `winit`, `tray-icon`, `rdev`, AppKit/Accessibility/CoreGraphics, or Win32 `SendInput`.
+- Changing hotkey names, validation codes, defaults, pass-through behavior, or configuration
+  schema.
+- Changing macOS Accessibility/fallback routing, clipboard replacement policy, required
+  permissions, or Windows Unicode injection semantics.
+- Generalizing audio, transcription, post-processing, or local inference behind this interface.
+- Advertising Linux or another OS as supported.
+
+## Design
+
+### 1. Put compile-time selection in one module
+
+`src/platform.rs` will be the only production selection point:
+
+```rust
+#[cfg(target_os = "macos")]
+type SelectedBackend = macos::Backend;
+
+#[cfg(target_os = "windows")]
+type SelectedBackend = windows::Backend;
+
+pub(crate) type NativePlatform = PlatformRuntime<SelectedBackend>;
+```
+
+An explicit fallback backend will retain lightweight non-native behavior for unsupported
+development/test targets. It will not be used by either release target and will not be described
+as product support.
+
+`macos::Backend` and `windows::Backend` implement a private backend contract. The compiler checks
+the selected backend and excludes the other target's native bindings and linker symbols. There is
+no runtime platform enum and no OS-name match in application code.
+
+Target-specific Cargo dependencies remain under their existing target dependency tables.
+
+### 2. Expose one application-facing runtime interface
+
+The application-facing contract will be deliberately small:
+
+```rust
+pub(crate) trait PlatformInterface: Sized {
+    fn start(
+        hotkeys: &HotkeyConfig,
+        notify: impl Fn(PlatformEvent) + Send + Sync + 'static,
+    ) -> Result<Self, PlatformStartError>;
+
+    fn handle_event(&mut self, event: PlatformEvent) -> Option<PlatformAction>;
+    fn set_recording(&mut self, recording: bool);
+    fn text_typer(&self) -> Arc<dyn TextTyper>;
+}
+```
+
+The concrete `NativePlatform` owns the main-thread tray controller and a cloneable, thread-safe
+text writer handle. Startup also installs the process-lifetime hotkey and tray callbacks. The
+listener creates this object once, stores it in `ListenerApplication`, and invokes only these
+methods.
+
+`config_dir()` remains a common platform facade function because configuration discovery happens
+before the listener runtime is created. Hotkey resolution similarly enters through a common
+platform facade so `runtime_config` does not choose an OS policy.
+
+The exact visibility and error representation may be tightened during implementation, but the
+capability boundary and ownership model above are fixed by this plan.
+
+### 3. Keep native events opaque and return semantic actions
+
+Callbacks enqueue an opaque `PlatformEvent` through winit. Its native payload remains private to
+the platform runtime. `ListenerApplication` passes it back to `NativePlatform::handle_event` and
+receives at most one semantic action:
+
+```rust
+pub(crate) enum PlatformAction {
+    HoldPressed,
+    HoldReleased,
+    ToggleRecording,
+    ExitRequested,
+}
+```
+
+The mapping is:
+
+| Native input | Platform action |
+|---|---|
+| configured Hold press | `HoldPressed` |
+| configured Hold release | `HoldReleased` |
+| configured Toggle press | `ToggleRecording` |
+| Toggle release/key repeat | none |
+| accepted tray left-button release | `ToggleRecording` |
+| tray Exit menu item | `ExitRequested` |
+
+`AppEvent` will contain `Platform(PlatformEvent)` rather than separate hotkey and tray variants.
+The application remains responsible for mapping semantic actions against `RecordingState` into
+source-free `SessionEvent` values. Recording lifecycle decisions therefore stay outside the
+platform layer.
+
+This opaque event round-trip is intentional: raw tray input must be debounced and filtered by the
+main-thread-owned tray controller, while native callbacks must remain non-blocking and wake winit
+instead of mutating that controller from callback threads.
+
+### 4. Split shared driver mechanics from platform policy
+
+`input::hotkey` will retain only cross-platform mechanics:
+
+- canonical key parsing and shared aliases;
+- `HotkeyConfig` data;
+- repeat-safe Hold/Toggle mapping;
+- the process-lifetime `rdev` listener thread; and
+- policy-driven validation and event filtering.
+
+The private platform backend supplies:
+
+- unsupported-key decisions and messages;
+- Windows AltGr pair validation and warnings;
+- macOS physical modifier normalization;
+- the macOS synthetic-paste suppression filter; and
+- the Windows/fallback pass-through filter.
+
+`input::tray` will retain embedded PNG decoding, menu construction, own-ID filtering, click
+debounce, tooltips, and status text. Platform tray policy supplies:
+
+- AppKit Accessory activation or the Windows no-op preparation;
+- system double-click interval lookup;
+- macOS template-image versus explicit-color updates; and
+- Windows ordinary icon updates.
+
+Shared drivers depend on private policy contracts or policy values. They will contain no
+`target_os` branches and will not expose their raw native types above `platform`.
+
+### 5. Preserve text-writer coupling and thread ownership
+
+`TextTyper: Send + Sync` remains the common delivery contract used by the background finalization
+worker.
+
+The macOS backend constructs `MacTyper`, `NativePasteWriter`, and the paired hotkey filter inside
+the platform boundary. This preserves their shared suppression flag without returning a closure to
+the application. Accessibility-first insertion, secure-control rejection, paste fallback,
+modifier normalization, serialization, focus delay, and the fixed suppression grace remain
+unchanged.
+
+The Windows backend constructs the `SendInput` writer and an identity hotkey filter. UTF-16 input
+construction, full-send verification, and focus delay remain unchanged.
+
+`NativePlatform` itself stays on the winit/main thread because it owns the tray. Only the cloned
+`Arc<dyn TextTyper>` crosses to a finalization worker. No AppKit/Win32 tray object becomes `Send`,
+and text delivery does not move back onto the event-loop thread.
+
+### 6. Route hotkey validation through the selected backend
+
+The canonical string vocabulary and stable validation codes remain shared. Platform availability
+and conflict rules move behind the selected backend:
+
+- macOS retains its current unsupported `rdev` key set;
+- Windows retains `RIGHTMETA`, `FUNCTION`, and keypad-Enter limitations;
+- Windows retains `hotkey.altgr_conflict` and the `LEFTCTRL` warning; and
+- both platforms retain pass-through warnings for non-function keys.
+
+`runtime_config::resolve_listener` invokes the common platform validation entry point and receives
+the same `HotkeyConfig`/`ValidationIssue` results it uses today. Persisted configuration behavior
+does not change.
+
+## Ownership and Event Flow
+
+```text
+rdev callback ─┐
+               ├─> opaque PlatformEvent ─> winit AppEvent::Platform
+tray callback ─┘                                  │
+                                                 v
+                                  NativePlatform::handle_event
+                                                 │
+                                      optional PlatformAction
+                                                 │
+                                                 v
+                                   RecordingSessionMachine
+
+SessionEffect::SetTrayRecording ─> NativePlatform::set_recording
+final transcription              ─> NativePlatform::text_typer ─> worker
+```
+
+The platform layer owns native classification and presentation. The application owns workflow
+state. Core remains unaware of native input sources and operating systems.
+
+## File and Module Plan
+
+| File | Planned responsibility/change |
+|---|---|
+| `src/platform.rs` | Define the common facade, opaque event/action contract, and the sole target-based backend alias; retain common config-directory entry. |
+| `src/platform/backend.rs` | Add private backend, hotkey-policy, and tray-policy contracts used by the common runtime. |
+| `src/platform/runtime.rs` | Own shared startup/wiring, tray state, text-writer handle, native-event handling, and semantic action mapping. |
+| `src/platform/macos.rs` | Implement the macOS backend and keep native text coordination private. |
+| `src/platform/macos/hotkey.rs` | Retain modifier normalization and expose it only through the macOS backend policy. |
+| `src/platform/macos/pasteboard.rs` | Retain the paired paste/suppression implementation without exposing its filter to application code. |
+| `src/platform/windows.rs` | Implement the Windows backend around `SendInput`, Windows hotkey policy, and tray policy. |
+| `src/platform/fallback.rs` | Provide the explicit unsupported-target test/development adapter currently represented by `MockTyper` and no-op policy. |
+| `src/input/hotkey.rs` | Remove target branches; accept private policy/filter inputs while retaining parsing, mapping, logging, and listener mechanics. |
+| `src/input/tray.rs` | Remove target branches; accept private tray policy and keep raw tray events internal to platform wiring. |
+| `src/input/typer.rs` | Retain the thread-safe common text-delivery trait; move fallback construction behind the platform facade. |
+| `src/application/listener.rs` | Construct only `NativePlatform`; remove typer/filter/tray selection and target `cfg` blocks. |
+| `src/application/listener/event_loop.rs` | Store `NativePlatform`, handle one opaque platform event variant, call the common recording/text methods, and consume semantic actions. |
+| `src/runtime_config.rs` | Resolve hotkeys through the common selected-platform validation entry point. |
+
+File boundaries may be collapsed if an implementation unit stays small, but native code must stay
+under `src/platform/`, shared input drivers must stay target-neutral, and the application-facing
+contract must not expand to native event types.
+
+No dependency or configuration-schema change is expected.
+
+## Test Strategy
+
+### Contract and shared tests
+
+1. Add a fake backend that drives `PlatformRuntime` without native APIs.
+2. Prove hotkey and tray callback payloads remain opaque until `handle_event` runs.
+3. Prove Hold press/release, Toggle press, tray toggle, Exit, repeats, unrelated IDs, and
+   double-click suppression map to the expected semantic action or no action.
+4. Prove `set_recording` delegates the idle/recording visual state exactly once and does not alter
+   recording state itself.
+5. Prove `text_typer` returns a cloneable worker-safe handle while the platform runtime remains
+   main-thread owned.
+6. Retain key parsing, aliases, duplicate detection, mapper reset, and callback-thread tests using
+   a fake hotkey policy instead of target `cfg` blocks.
+7. Retain icon decode, dimensions/transparency, menu-ID filtering, and debounce boundary tests
+   using a fake tray policy.
+8. Update listener tests to exercise `PlatformAction` to `SessionEvent` mapping independently of
+   native input sources.
+
+### Platform tests
+
+- macOS CI retains Accessibility route, paste fallback, synthetic-event suppression, modifier
+  normalization, template-icon policy, and unsupported-key coverage.
+- Windows CI covers the AltGr conflict/warning policy, unsupported keys, icon update policy, and a
+  pure Unicode `INPUT` construction helper before the real `SendInput` boundary.
+- The fallback adapter proves it cannot be mistaken for a macOS or Windows backend.
+
+### Automated validation
+
+Run on the available native host and require both hosted target jobs:
+
+```bash
+cargo fmt --check
+cargo check --locked
+cargo test --locked
+cargo clippy --locked -- -D warnings
+cargo build --locked
+git diff --check
+```
+
+Also verify that target selection has not leaked back into consumers:
+
+```bash
+rg -n 'cfg\(.*target_os' src/application src/input src/runtime_config.rs
+```
+
+The expected result is empty. macOS and Windows GitHub Actions jobs must both pass before PR
+readiness.
+
+### Manual native verification
+
+On macOS:
+
+1. Confirm idle template tint and explicit red recording icon in light and dark menu-bar modes.
+2. Confirm Hold, Toggle, tray toggle, double-click suppression, and Exit behavior.
+3. Confirm Accessibility insertion, native paste fallback, secure-field rejection, and synthetic
+   Cmd+V hotkey suppression.
+
+On Windows:
+
+1. Confirm idle/recording icon colors, tray toggle, double-click suppression, and Exit behavior.
+2. Confirm Hold/Toggle input including a layout with AltGr where available.
+3. Confirm ASCII, multiline, CJK, emoji, and surrogate-pair text delivery through `SendInput`.
+
+## Implementation Order
+
+1. Add failing fake-backend tests for the opaque event/action contract and platform runtime
+   ownership.
+2. Introduce the private backend/policy contracts and compile-time `SelectedBackend` alias while
+   leaving behavior delegated to the existing drivers.
+3. Move hotkey target rules and filter construction behind macOS/Windows backends; make the shared
+   hotkey driver target-neutral.
+4. Move application activation, double-click lookup, and icon update policy behind the platform
+   tray contract; keep decode/menu/debounce mechanics shared.
+5. Make the runtime facade construct the selected text writer, hotkey listener, and tray together;
+   retain macOS writer/filter coupling internally.
+6. Replace listener hotkey/tray variants with opaque `PlatformEvent`, store `NativePlatform`, and
+   route only `PlatformAction` values into session requests.
+7. Route runtime hotkey validation and configuration-directory discovery through the common
+   selected-platform facade.
+8. Run focused and full checks on macOS, obtain Windows CI validation, perform the native smoke
+   matrices, and synchronize documentation with the final implementation.
+9. Run the repository's code-review gate, push implementation to this same bookmark/PR, and mark
+   the PR ready only after validation completes.
+
+## Documentation Impact
+
+During planning, add only this plan and its `docs/README.md` index entry.
+
+During implementation:
+
+- update `AGENTS.md` so the project tree and platform responsibilities match the new boundary;
+- update `docs/architecture/platform.md` with the compile-time selection, facade contract,
+  ownership, events/actions, and native backend responsibilities;
+- update `docs/architecture/input.md` so hotkey/tray are described as target-neutral drivers and
+  text delivery is obtained through the platform facade;
+- update `docs/architecture/core.md` where it describes separate hotkey/tray winit producers;
+- update the architecture descriptions and this plan's status in `docs/README.md`;
+- add a `changelog` entry because this repository records material architecture refactors; and
+- record any material deviation from this design in this plan rather than rewriting its original
+  rationale.
+
+`README.md`, `config.example.json`, user configuration reference, release instructions, and asset
+documentation should not change because the refactor adds no user-visible behavior, setting,
+artifact, or icon. If implementation changes that assumption, the documentation impact must be
+reassessed before PR readiness.
+
+## Acceptance Criteria
+
+- `application`, `runtime_config`, and shared `input` code contain no target-OS selection.
+- `src/platform.rs` selects one macOS, Windows, or explicit fallback backend at compile time.
+- Listener construction names only `NativePlatform` and uses one common startup interface.
+- `AppEvent` has one opaque platform event variant and contains no public `rdev` or `tray-icon`
+  payload type.
+- The application receives only Hold press/release, Toggle, and Exit semantic actions from the
+  platform runtime.
+- Tray/icon creation, native click handling, template/color policy, and double-click timing are
+  hidden behind the common interface.
+- Hotkey support tables, AltGr handling, macOS modifier normalization, and synthetic paste
+  suppression are hidden behind the selected backend.
+- Text delivery is requested through `TextTyper`; the application does not construct or name a
+  platform writer or hotkey filter.
+- The platform runtime remains main-thread owned while only the thread-safe text writer handle is
+  used by finalization workers.
+- macOS Accessibility/paste behavior, Windows `SendInput`, hotkey validation errors/warnings,
+  icons, tray actions, configuration paths, and recording lifecycle behavior remain unchanged.
+- Fake-backend contract tests, retained platform tests, formatting, Clippy, build, diff checks, and
+  both hosted OS CI jobs pass.
+- Manual macOS and Windows smoke-test results are recorded before the PR is marked ready.
+- Architecture docs, plan index/status, project structure guidance, and changelog match the final
+  implementation.

--- a/src/application/listener.rs
+++ b/src/application/listener.rs
@@ -3,9 +3,9 @@ use tracing::info;
 use super::{LocalServiceGuard, config_context, load_config, start_local_backend};
 use crate::core::config::EnvironmentSecretSource;
 use crate::core::recording_session::{RecordingState, SessionEvent};
-use crate::input::hotkey::{HotkeyEvent, HotkeySource};
+use crate::platform::PlatformAction;
 use crate::runtime_config::{self, ListenerConfig, ProfileSelection};
-use crate::{audio, core, input, postprocess, transcriber};
+use crate::{audio, core, postprocess, transcriber};
 
 mod event_loop;
 
@@ -22,17 +22,16 @@ pub(super) fn run() -> Result<(), Box<dyn std::error::Error>> {
     run_with_config(config)
 }
 
-fn hotkey_session_event(event: HotkeyEvent, state: &RecordingState) -> Option<SessionEvent> {
-    match event {
-        HotkeyEvent::Pressed(HotkeySource::Hold) if matches!(state, RecordingState::Idle) => {
+fn platform_session_event(action: PlatformAction, state: &RecordingState) -> Option<SessionEvent> {
+    match action {
+        PlatformAction::HoldPressed if matches!(state, RecordingState::Idle) => {
             Some(SessionEvent::StartRequested)
         }
-        HotkeyEvent::Released(HotkeySource::Hold)
-            if matches!(state, RecordingState::Recording { .. }) =>
-        {
+        PlatformAction::HoldReleased if matches!(state, RecordingState::Recording { .. }) => {
             Some(SessionEvent::StopRequested)
         }
-        HotkeyEvent::Pressed(HotkeySource::Toggle) => toggle_session_event(state),
+        PlatformAction::ToggleRecording => toggle_session_event(state),
+        PlatformAction::ExitRequested => Some(SessionEvent::ShutdownRequested),
         _ => None,
     }
 }
@@ -54,11 +53,11 @@ pub(super) fn run_with_config(
     use audio::AudioRecorder;
     use core::orchestrator::SessionOrchestrator;
     use event_loop::{AppEvent, ListenerApplication};
-    use input::hotkey::start_hotkey_listener;
-    use input::tray::TrayManager;
     use postprocess::PostProcessor;
     use transcriber::ApiTranscriber;
     use winit::event_loop::{ControlFlow, EventLoop};
+
+    use crate::platform::{NativePlatform, PlatformInterface};
 
     println!("ViberWhisper - Voice-to-Text Input");
     println!("===================================");
@@ -77,32 +76,16 @@ pub(super) fn run_with_config(
     event_loop.set_control_flow(ControlFlow::Wait);
     let proxy = event_loop.create_proxy();
 
-    #[cfg(target_os = "macos")]
-    let (typer, hotkey_filter) = crate::platform::macos::MacTyper::new();
-    #[cfg(not(target_os = "macos"))]
-    let hotkey_filter = Some;
-
-    let hotkey_proxy = proxy.clone();
-    start_hotkey_listener(&config.hotkeys, hotkey_filter, move |event| {
-        let _ = hotkey_proxy.send_event(AppEvent::Hotkey(event));
-    });
-
-    #[cfg(target_os = "macos")]
-    let typer = Arc::new(typer);
-    #[cfg(target_os = "windows")]
-    let typer = Arc::new(crate::platform::windows::WindowsTyper);
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    let typer = Arc::new(input::typer::MockTyper);
+    let platform_proxy = proxy.clone();
+    let platform = NativePlatform::start(&config.hotkeys, move |event| {
+        let _ = platform_proxy.send_event(AppEvent::Platform(event));
+    })?;
 
     let audio_proxy = proxy.clone();
     let recorder = AudioRecorder::with_config(&config.audio, move |session_id| {
         let _ = audio_proxy.send_event(AppEvent::AudioChunkAvailable { session_id });
     });
 
-    let tray_proxy = proxy.clone();
-    let tray = TrayManager::new(move |event| {
-        let _ = tray_proxy.send_event(AppEvent::Tray(event));
-    })?;
     info!("System tray icon started");
 
     if let Some(hotkey) = config.hotkeys.hold_label.as_deref() {
@@ -115,20 +98,20 @@ pub(super) fn run_with_config(
     println!();
 
     let mut application =
-        ListenerApplication::new(recorder, orchestrator, tray, post_processor, typer, proxy);
+        ListenerApplication::new(recorder, orchestrator, platform, post_processor, proxy);
     event_loop.run_app(&mut application)?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{hotkey_session_event, toggle_session_event};
+    use super::platform_session_event;
     use crate::core::recording_session::{RecordingState, SessionEvent};
-    use crate::input::hotkey::{HotkeyEvent, HotkeySource};
+    use crate::platform::PlatformAction;
     use crate::session::SessionId;
 
     #[test]
-    fn hotkey_and_toggle_requests_are_state_aware() {
+    fn platform_actions_are_state_aware() {
         let idle = RecordingState::Idle;
         let recording = RecordingState::Recording {
             session_id: SessionId(1),
@@ -138,42 +121,36 @@ mod tests {
         };
 
         assert_eq!(
-            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Hold), &idle),
+            platform_session_event(PlatformAction::HoldPressed, &idle),
             Some(SessionEvent::StartRequested)
         );
         assert_eq!(
-            hotkey_session_event(HotkeyEvent::Released(HotkeySource::Hold), &recording),
+            platform_session_event(PlatformAction::HoldReleased, &recording),
             Some(SessionEvent::StopRequested)
         );
         assert_eq!(
-            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Toggle), &idle),
+            platform_session_event(PlatformAction::ToggleRecording, &idle),
             Some(SessionEvent::StartRequested)
         );
         assert_eq!(
-            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Toggle), &recording),
+            platform_session_event(PlatformAction::ToggleRecording, &recording),
             Some(SessionEvent::StopRequested)
         );
         assert_eq!(
-            toggle_session_event(&idle),
-            Some(SessionEvent::StartRequested)
+            platform_session_event(PlatformAction::ExitRequested, &idle),
+            Some(SessionEvent::ShutdownRequested)
         );
         assert_eq!(
-            toggle_session_event(&recording),
-            Some(SessionEvent::StopRequested)
-        );
-
-        assert_eq!(
-            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Hold), &recording),
+            platform_session_event(PlatformAction::HoldPressed, &recording),
             None
         );
         assert_eq!(
-            hotkey_session_event(HotkeyEvent::Released(HotkeySource::Hold), &idle),
+            platform_session_event(PlatformAction::HoldReleased, &idle),
             None
         );
         assert_eq!(
-            hotkey_session_event(HotkeyEvent::Pressed(HotkeySource::Toggle), &starting),
+            platform_session_event(PlatformAction::ToggleRecording, &starting),
             None
         );
-        assert_eq!(toggle_session_event(&starting), None);
     }
 }

--- a/src/application/listener/event_loop.rs
+++ b/src/application/listener/event_loop.rs
@@ -9,22 +9,20 @@ use winit::event::WindowEvent;
 use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 use winit::window::WindowId;
 
-use super::{hotkey_session_event, toggle_session_event};
+use super::platform_session_event;
 use crate::audio::{AudioRecorder, RecorderStartOutcome, RecorderStopOutcome};
 use crate::core::orchestrator::{SessionError, SessionOrchestrator};
 use crate::core::recording_session::{
     RecordingSessionMachine, RecordingState, SessionEffect, SessionEvent,
 };
-use crate::input::hotkey::HotkeyEvent;
-use crate::input::tray::{TrayAction, TrayEvent, TrayManager};
 use crate::input::typer::TextTyper;
+use crate::platform::{NativePlatform, PlatformEvent, PlatformInterface};
 use crate::postprocess::{PostProcessor, PostProcessorSession};
 use crate::session::SessionId;
 
 #[derive(Debug, Clone)]
 pub(super) enum AppEvent {
-    Hotkey(HotkeyEvent),
-    Tray(TrayEvent),
+    Platform(PlatformEvent),
     AudioChunkAvailable { session_id: SessionId },
     FinalizationFinished { session_id: SessionId },
 }
@@ -90,9 +88,8 @@ pub(super) struct ListenerApplication {
     machine: RecordingSessionMachine,
     recorder: AudioRecorder,
     orchestrator: Arc<SessionOrchestrator>,
-    tray: TrayManager,
+    platform: NativePlatform,
     post_processor: PostProcessor,
-    typer: Arc<dyn TextTyper>,
     proxy: EventLoopProxy<AppEvent>,
     finalization: Option<FinalizationTask>,
 }
@@ -101,18 +98,16 @@ impl ListenerApplication {
     pub(super) fn new(
         recorder: AudioRecorder,
         orchestrator: Arc<SessionOrchestrator>,
-        tray: TrayManager,
+        platform: NativePlatform,
         post_processor: PostProcessor,
-        typer: Arc<dyn TextTyper>,
         proxy: EventLoopProxy<AppEvent>,
     ) -> Self {
         Self {
             machine: RecordingSessionMachine::new(),
             recorder,
             orchestrator,
-            tray,
+            platform,
             post_processor,
-            typer,
             proxy,
             finalization: None,
         }
@@ -120,20 +115,11 @@ impl ListenerApplication {
 
     fn handle_app_event(&mut self, event_loop: &ActiveEventLoop, event: AppEvent) {
         match event {
-            AppEvent::Hotkey(event) => {
-                if let Some(event) = hotkey_session_event(event, self.machine.state()) {
+            AppEvent::Platform(event) => {
+                if let Some(action) = self.platform.handle_event(event)
+                    && let Some(event) = platform_session_event(action, self.machine.state())
+                {
                     self.drive_session(event_loop, event);
-                }
-            }
-            AppEvent::Tray(event) => {
-                if let Some(action) = self.tray.handle_event(event) {
-                    let event = match action {
-                        TrayAction::Exit => Some(SessionEvent::ShutdownRequested),
-                        TrayAction::ToggleRecording => toggle_session_event(self.machine.state()),
-                    };
-                    if let Some(event) = event {
-                        self.drive_session(event_loop, event);
-                    }
                 }
             }
             AppEvent::AudioChunkAvailable { session_id } => {
@@ -201,7 +187,7 @@ impl ListenerApplication {
                         }
                     }
                     SessionEffect::SetTrayRecording(recording) => {
-                        self.tray.set_recording(recording);
+                        self.platform.set_recording(recording);
                     }
                     SessionEffect::ReadyToExit => event_loop.exit(),
                 }
@@ -330,7 +316,7 @@ impl ListenerApplication {
 
         let orchestrator = Arc::clone(&self.orchestrator);
         let mut post_processor = self.post_processor.start_session();
-        let typer = Arc::clone(&self.typer);
+        let typer = self.platform.text_typer();
         let proxy = self.proxy.clone();
         spawn_finalization_worker(
             session_id,

--- a/src/input/hotkey.rs
+++ b/src/input/hotkey.rs
@@ -14,6 +14,22 @@ pub struct HotkeyConfig {
     pub(crate) toggle_label: Option<String>,
 }
 
+/// Target policy used by the shared parser, validator, and listener diagnostics.
+pub(crate) trait HotkeyPolicy: Send + 'static {
+    fn unsupported_reason(key: Key) -> Option<&'static str>;
+
+    fn pair_conflict(
+        _first: Option<Key>,
+        _second: Option<Key>,
+    ) -> Option<(&'static str, &'static str)> {
+        None
+    }
+
+    fn additional_warning(_key: Key) -> Option<&'static str> {
+        None
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct NamedKey {
     key: Key,
@@ -21,14 +37,16 @@ struct NamedKey {
 }
 
 impl HotkeyConfig {
-    pub(crate) fn validate(section: &InputSection) -> Result<Self, Vec<ValidationIssue>> {
+    pub(crate) fn validate<P: HotkeyPolicy>(
+        section: &InputSection,
+    ) -> Result<Self, Vec<ValidationIssue>> {
         let mut issues = Vec::new();
-        let hold_binding = validate_binding(
+        let hold_binding = validate_binding::<P>(
             ConfigKey::InputHoldHotkey,
             &section.hold_hotkey,
             &mut issues,
         );
-        let toggle_binding = validate_binding(
+        let toggle_binding = validate_binding::<P>(
             ConfigKey::InputToggleHotkey,
             &section.toggle_hotkey,
             &mut issues,
@@ -43,15 +61,14 @@ impl HotkeyConfig {
                 "hold and toggle hotkeys must use different keys",
             ));
         }
-        #[cfg(target_os = "windows")]
-        if has_windows_altgr_binding_conflict(
+        if let Some((code, message)) = P::pair_conflict(
             hold_binding.map(|binding| binding.key),
             toggle_binding.map(|binding| binding.key),
         ) {
             issues.push(ValidationIssue::new(
                 ConfigKey::InputToggleHotkey,
-                "hotkey.altgr_conflict",
-                "LEFTCTRL and RIGHTALT cannot be used together because Windows AltGr emits both keys",
+                code,
+                message,
             ));
         }
 
@@ -67,7 +84,7 @@ impl HotkeyConfig {
     }
 }
 
-fn validate_binding(
+fn validate_binding<P: HotkeyPolicy>(
     key: ConfigKey,
     value: &str,
     issues: &mut Vec<ValidationIssue>,
@@ -86,7 +103,7 @@ fn validate_binding(
     };
     let parsed = parse_named_key(value).expect("parse_key delegates to parse_named_key");
     debug_assert_eq!(parsed.key, parsed_key);
-    if let Some(reason) = unsupported_reason(parsed.key) {
+    if let Some(reason) = P::unsupported_reason(parsed.key) {
         issues.push(ValidationIssue::new(
             key,
             "hotkey.unsupported",
@@ -96,59 +113,6 @@ fn validate_binding(
     }
 
     Some(parsed)
-}
-
-#[cfg(target_os = "macos")]
-fn unsupported_reason(key: Key) -> Option<&'static str> {
-    match key {
-        Key::CapsLock => {
-            Some("macOS reports Caps Lock as a state change, not a physical press/release pair")
-        }
-        Key::ControlRight
-        | Key::Delete
-        | Key::Insert
-        | Key::Home
-        | Key::End
-        | Key::PageUp
-        | Key::PageDown
-        | Key::NumLock
-        | Key::ScrollLock
-        | Key::PrintScreen
-        | Key::Pause
-        | Key::IntlBackslash
-        | Key::KpReturn
-        | Key::KpMinus
-        | Key::KpPlus
-        | Key::KpMultiply
-        | Key::KpDivide
-        | Key::Kp0
-        | Key::Kp1
-        | Key::Kp2
-        | Key::Kp3
-        | Key::Kp4
-        | Key::Kp5
-        | Key::Kp6
-        | Key::Kp7
-        | Key::Kp8
-        | Key::Kp9
-        | Key::KpDelete => Some("the current rdev macOS backend does not emit this named key"),
-        _ => None,
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn unsupported_reason(key: Key) -> Option<&'static str> {
-    match key {
-        Key::MetaRight => Some("the current rdev Windows backend does not emit RIGHTMETA"),
-        Key::Function => Some("Windows does not expose the Fn key to rdev"),
-        Key::KpReturn => Some("the current rdev Windows backend cannot distinguish it from ENTER"),
-        _ => None,
-    }
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-fn unsupported_reason(_key: Key) -> Option<&'static str> {
-    None
 }
 
 /// Parse a configured, named physical key. Empty strings disable a binding.
@@ -286,20 +250,11 @@ fn needs_passthrough_warning(key: Key) -> bool {
     )
 }
 
-#[cfg(any(target_os = "windows", test))]
-fn has_windows_altgr_alias_risk(key: Key) -> bool {
-    key == Key::ControlLeft
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn has_windows_altgr_binding_conflict(first: Option<Key>, second: Option<Key>) -> bool {
-    matches!(
-        (first, second),
-        (Some(Key::ControlLeft), Some(Key::AltGr)) | (Some(Key::AltGr), Some(Key::ControlLeft))
-    )
-}
-
-fn log_binding_warnings(mode: &'static str, key: Option<Key>, label: Option<&str>) {
+fn log_binding_warnings<P: HotkeyPolicy>(
+    mode: &'static str,
+    key: Option<Key>,
+    label: Option<&str>,
+) {
     let (Some(key), Some(label)) = (key, label) else {
         return;
     };
@@ -310,12 +265,11 @@ fn log_binding_warnings(mode: &'static str, key: Option<Key>, label: Option<&str
             "hotkey input is observed but not suppressed and may also affect the focused application or operating system"
         );
     }
-    #[cfg(target_os = "windows")]
-    if has_windows_altgr_alias_risk(key) {
+    if let Some(message) = P::additional_warning(key) {
         warn!(
             mode,
             hotkey = %label,
-            "LEFTCTRL may also be emitted when Windows handles RIGHTALT as AltGr"
+            "{message}"
         );
     }
 }
@@ -393,19 +347,20 @@ impl EventMapper {
 /// The detached `rdev` thread cannot be stopped independently; process shutdown is its lifetime
 /// boundary. The filter returns `Some` to map an event or `None` to drop it and reset mapper
 /// key-down bookkeeping.
-pub(crate) fn start_hotkey_listener<F>(
+pub(crate) fn start_hotkey_listener<P, F>(
     config: &HotkeyConfig,
     filter: F,
     notify: impl Fn(HotkeyEvent) + Send + 'static,
 ) where
+    P: HotkeyPolicy,
     F: Fn(EventType) -> Option<EventType> + Send + 'static,
 {
     let hold_key = config.hold_key;
     let toggle_key = config.toggle_key;
     spawn_listener(EventMapper::new(hold_key, toggle_key), filter, notify);
 
-    log_binding_warnings("hold", hold_key, config.hold_label.as_deref());
-    log_binding_warnings("toggle", toggle_key, config.toggle_label.as_deref());
+    log_binding_warnings::<P>("hold", hold_key, config.hold_label.as_deref());
+    log_binding_warnings::<P>("toggle", toggle_key, config.toggle_label.as_deref());
 
     if let Some(label) = config.hold_label.as_deref() {
         info!(hotkey = %label, "hold hotkey registered");
@@ -445,9 +400,17 @@ mod tests {
     use super::*;
     use crate::core::config::{ConfigKey, InputSection};
 
+    struct TestHotkeyPolicy;
+
+    impl HotkeyPolicy for TestHotkeyPolicy {
+        fn unsupported_reason(_key: Key) -> Option<&'static str> {
+            None
+        }
+    }
+
     #[test]
     fn validates_default_disabled_and_invalid_hotkey_sections() {
-        let config = HotkeyConfig::validate(&InputSection::default()).unwrap();
+        let config = HotkeyConfig::validate::<TestHotkeyPolicy>(&InputSection::default()).unwrap();
         assert_eq!(config.hold_key, Some(Key::F8));
         assert_eq!(config.toggle_key, Some(Key::F9));
 
@@ -455,7 +418,7 @@ mod tests {
             hold_hotkey: String::new(),
             toggle_hotkey: String::new(),
         };
-        let config = HotkeyConfig::validate(&tray_only).unwrap();
+        let config = HotkeyConfig::validate::<TestHotkeyPolicy>(&tray_only).unwrap();
         assert_eq!(config.hold_key, None);
         assert_eq!(config.toggle_key, None);
 
@@ -463,14 +426,14 @@ mod tests {
             hold_hotkey: "F13".to_string(),
             toggle_hotkey: "F13".to_string(),
         };
-        let issues = HotkeyConfig::validate(&invalid).unwrap_err();
+        let issues = HotkeyConfig::validate::<TestHotkeyPolicy>(&invalid).unwrap_err();
         assert_eq!(issues[0].key, ConfigKey::InputHoldHotkey);
 
         let duplicate = InputSection {
             hold_hotkey: "RIGHTALT".to_string(),
             toggle_hotkey: "altgr".to_string(),
         };
-        let issues = HotkeyConfig::validate(&duplicate).unwrap_err();
+        let issues = HotkeyConfig::validate::<TestHotkeyPolicy>(&duplicate).unwrap_err();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].code, "hotkey.duplicate");
     }
@@ -624,7 +587,7 @@ mod tests {
         assert_eq!(parse_key(" rightoption "), Some(Key::AltGr));
         assert_eq!(parse_key("invalid"), None);
 
-        let config = HotkeyConfig::validate(&InputSection {
+        let config = HotkeyConfig::validate::<TestHotkeyPolicy>(&InputSection {
             hold_hotkey: " rightoption ".to_string(),
             toggle_hotkey: "f9".to_string(),
         })
@@ -634,88 +597,10 @@ mod tests {
     }
 
     #[test]
-    fn classifies_passthrough_and_windows_altgr_risks() {
+    fn classifies_passthrough_risks() {
         assert!(!needs_passthrough_warning(Key::F8));
         assert!(needs_passthrough_warning(Key::KeyA));
         assert!(needs_passthrough_warning(Key::AltGr));
-        assert!(has_windows_altgr_alias_risk(Key::ControlLeft));
-        assert!(!has_windows_altgr_alias_risk(Key::AltGr));
-        assert!(has_windows_altgr_binding_conflict(
-            Some(Key::ControlLeft),
-            Some(Key::AltGr)
-        ));
-        assert!(has_windows_altgr_binding_conflict(
-            Some(Key::AltGr),
-            Some(Key::ControlLeft)
-        ));
-        assert!(!has_windows_altgr_binding_conflict(
-            Some(Key::Alt),
-            Some(Key::ControlLeft)
-        ));
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn rejects_left_ctrl_and_right_alt_as_a_windows_binding_pair() {
-        let issues = HotkeyConfig::validate(&InputSection {
-            hold_hotkey: "LEFTCTRL".to_string(),
-            toggle_hotkey: "RIGHTALT".to_string(),
-        })
-        .unwrap_err();
-
-        assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].key, ConfigKey::InputToggleHotkey);
-        assert_eq!(issues[0].code, "hotkey.altgr_conflict");
-    }
-
-    #[test]
-    fn rejects_named_keys_the_current_platform_backend_cannot_emit() {
-        #[cfg(target_os = "macos")]
-        let unsupported = [
-            "CAPSLOCK",
-            "RIGHTCTRL",
-            "DELETE",
-            "INSERT",
-            "HOME",
-            "END",
-            "PAGEUP",
-            "PAGEDOWN",
-            "NUMLOCK",
-            "SCROLLLOCK",
-            "PRINTSCREEN",
-            "PAUSE",
-            "INTLBACKSLASH",
-            "NUMPAD0",
-            "NUMPAD1",
-            "NUMPAD2",
-            "NUMPAD3",
-            "NUMPAD4",
-            "NUMPAD5",
-            "NUMPAD6",
-            "NUMPAD7",
-            "NUMPAD8",
-            "NUMPAD9",
-            "NUMPADENTER",
-            "NUMPADMINUS",
-            "NUMPADPLUS",
-            "NUMPADMULTIPLY",
-            "NUMPADDIVIDE",
-            "NUMPADDELETE",
-        ];
-        #[cfg(target_os = "windows")]
-        let unsupported = ["RIGHTMETA", "FUNCTION", "NUMPADENTER"];
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        let unsupported: [&str; 0] = [];
-
-        for name in unsupported {
-            let issues = HotkeyConfig::validate(&InputSection {
-                hold_hotkey: name.to_string(),
-                toggle_hotkey: String::new(),
-            })
-            .unwrap_err();
-            assert_eq!(issues.len(), 1, "name: {name}");
-            assert_eq!(issues[0].code, "hotkey.unsupported", "name: {name}");
-        }
     }
 
     #[test]

--- a/src/input/tray.rs
+++ b/src/input/tray.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::marker::PhantomData;
 #[cfg(not(test))]
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -28,6 +29,20 @@ pub enum TrayAction {
 pub enum TrayEvent {
     Icon(TrayIconEvent),
     Menu(MenuEvent),
+}
+
+/// Target policy for native application setup, timing, and icon presentation.
+pub(crate) trait TrayPolicy: 'static {
+    fn idle_icon_is_template() -> bool;
+
+    #[cfg(not(test))]
+    fn prepare_application() -> Result<(), Box<dyn std::error::Error>>;
+
+    #[cfg(not(test))]
+    fn double_click_interval() -> Option<Duration>;
+
+    #[cfg(not(test))]
+    fn set_icon(tray_icon: &TrayIcon, icon: Icon, is_template: bool) -> tray_icon::Result<()>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,23 +122,23 @@ fn effective_debounce_window(platform_interval: Option<Duration>) -> Duration {
 }
 
 #[cfg(not(test))]
-pub struct TrayManager {
+pub struct TrayManager<P: TrayPolicy> {
     tray_icon: TrayIcon,
     icon_idle: Icon,
     icon_recording: Icon,
     status_item: MenuItem,
     exit_item_id: tray_icon::menu::MenuId,
     click_debounce: ClickDebounce,
+    policy: PhantomData<P>,
 }
 
-// Keep test builds away from the native tray backend on Windows.
-// The real `tray_icon` path is exercised in app runs, while tests only need
-// a lightweight stand-in so CI can validate higher-level logic safely.
+// Keep tests away from the process-global native tray backend. App runs and native smoke tests
+// exercise that path; unit tests use deterministic policy and event-classification seams.
 #[cfg(test)]
-pub struct TrayManager;
+pub struct TrayManager<P: TrayPolicy>(PhantomData<P>);
 
 #[cfg(not(test))]
-impl TrayManager {
+impl<P: TrayPolicy> TrayManager<P> {
     /// Construct the process's single tray manager and install its process-lifetime event handlers.
     ///
     /// `tray-icon` stores handlers in one-shot global cells, so another manager in the same process
@@ -131,9 +146,9 @@ impl TrayManager {
     pub fn new(
         notify: impl Fn(TrayEvent) + Send + Sync + 'static,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        prepare_platform_application()?;
-        let (idle_source, idle_is_template) = status_icon_source(false);
-        let (recording_source, _) = status_icon_source(true);
+        P::prepare_application()?;
+        let (idle_source, idle_is_template) = status_icon_source::<P>(false);
+        let (recording_source, _) = status_icon_source::<P>(true);
         let icon_idle = create_icon(idle_source)?;
         let icon_recording = create_icon(recording_source)?;
 
@@ -167,16 +182,17 @@ impl TrayManager {
             status_item,
             exit_item_id: exit_id,
             click_debounce: ClickDebounce::new(effective_debounce_window(
-                platform_double_click_interval(),
+                P::double_click_interval(),
             )),
+            policy: PhantomData,
         })
     }
 
     pub fn set_recording(&mut self, recording: bool) {
         let (icon, is_template) = if recording {
-            (&self.icon_recording, status_icon_source(true).1)
+            (&self.icon_recording, status_icon_source::<P>(true).1)
         } else {
-            (&self.icon_idle, status_icon_source(false).1)
+            (&self.icon_idle, status_icon_source::<P>(false).1)
         };
         let tooltip = if recording {
             "ViberWhisper - 录音中"
@@ -189,7 +205,7 @@ impl TrayManager {
         } else {
             "状态：空闲"
         });
-        if let Err(err) = set_native_icon(&self.tray_icon, icon.clone(), is_template) {
+        if let Err(err) = P::set_icon(&self.tray_icon, icon.clone(), is_template) {
             warn!(error = ?err, "failed to update tray icon");
         }
         if let Err(err) = self.tray_icon.set_tooltip(Some(tooltip)) {
@@ -224,27 +240,12 @@ fn install_native_handlers(notify: impl Fn(TrayEvent) + Send + Sync + 'static) {
     }));
 }
 
-#[cfg(all(target_os = "macos", not(test)))]
-fn prepare_platform_application() -> Result<(), Box<dyn std::error::Error>> {
-    use objc2::MainThreadMarker;
-    use objc2_app_kit::{NSApp, NSApplicationActivationPolicy};
-
-    let mtm = MainThreadMarker::new().ok_or("tray must be created on the main thread")?;
-    let _ = NSApp(mtm).setActivationPolicy(NSApplicationActivationPolicy::Accessory);
-    Ok(())
-}
-
-#[cfg(all(not(target_os = "macos"), not(test)))]
-fn prepare_platform_application() -> Result<(), Box<dyn std::error::Error>> {
-    Ok(())
-}
-
 #[cfg(test)]
-impl TrayManager {
+impl<P: TrayPolicy> TrayManager<P> {
     pub fn new(
         _notify: impl Fn(TrayEvent) + Send + Sync + 'static,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(TrayManager)
+        Ok(TrayManager(PhantomData))
     }
 
     pub fn set_recording(&mut self, _recording: bool) {}
@@ -254,44 +255,11 @@ impl TrayManager {
     }
 }
 
-#[cfg(all(target_os = "macos", not(test)))]
-fn platform_double_click_interval() -> Option<Duration> {
-    use objc2_app_kit::NSEvent;
-
-    let seconds = NSEvent::doubleClickInterval();
-    seconds
-        .is_finite()
-        .then(|| Duration::from_secs_f64(seconds))
-}
-
-#[cfg(all(target_os = "windows", not(test)))]
-fn platform_double_click_interval() -> Option<Duration> {
-    Some(Duration::from_millis(
-        unsafe { windows_event_loop::GetDoubleClickTime() } as u64,
-    ))
-}
-
-#[cfg(all(not(any(target_os = "macos", target_os = "windows")), not(test)))]
-fn platform_double_click_interval() -> Option<Duration> {
-    None
-}
-
-#[cfg(all(target_os = "windows", not(test)))]
-#[allow(non_snake_case, clippy::upper_case_acronyms)]
-mod windows_event_loop {
-    pub type UINT = u32;
-
-    #[link(name = "user32")]
-    unsafe extern "system" {
-        pub fn GetDoubleClickTime() -> UINT;
-    }
-}
-
-fn status_icon_source(recording: bool) -> (&'static [u8], bool) {
+fn status_icon_source<P: TrayPolicy>(recording: bool) -> (&'static [u8], bool) {
     if recording {
         (STATUS_RECORDING_PNG, false)
     } else {
-        (STATUS_IDLE_PNG, true)
+        (STATUS_IDLE_PNG, P::idle_icon_is_template())
     }
 }
 
@@ -319,22 +287,20 @@ fn decode_icon_png(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32), Box<dyn std::err
     Ok((rgba, info.width, info.height))
 }
 
-#[cfg(all(target_os = "macos", not(test)))]
-fn set_native_icon(tray_icon: &TrayIcon, icon: Icon, is_template: bool) -> tray_icon::Result<()> {
-    tray_icon.set_icon_with_as_template(Some(icon), is_template)
-}
-
-#[cfg(all(not(target_os = "macos"), not(test)))]
-fn set_native_icon(tray_icon: &TrayIcon, icon: Icon, _is_template: bool) -> tray_icon::Result<()> {
-    tray_icon.set_icon(Some(icon))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use tray_icon::dpi::PhysicalPosition;
     use tray_icon::menu::MenuId;
     use tray_icon::{Rect, TrayIconId};
+
+    struct TemplateTrayPolicy;
+
+    impl TrayPolicy for TemplateTrayPolicy {
+        fn idle_icon_is_template() -> bool {
+            true
+        }
+    }
 
     fn left_up(id: &str) -> TrayIconEvent {
         TrayIconEvent::Click {
@@ -360,8 +326,8 @@ mod tests {
 
     #[test]
     fn idle_uses_template_rendering_and_recording_keeps_explicit_color() {
-        assert!(status_icon_source(false).1);
-        assert!(!status_icon_source(true).1);
+        assert!(status_icon_source::<TemplateTrayPolicy>(false).1);
+        assert!(!status_icon_source::<TemplateTrayPolicy>(true).1);
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,18 +1,37 @@
+mod backend;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod fallback;
 #[cfg(target_os = "macos")]
-pub mod macos;
+mod macos;
+mod runtime;
 #[cfg(target_os = "windows")]
-pub mod windows;
+mod windows;
 
 use std::path::PathBuf;
 
-/// Returns the platform-specific application configuration directory.
+use crate::core::config::{InputSection, ValidationIssue};
+use crate::input::hotkey::HotkeyConfig;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+use fallback::FallbackBackend as SelectedBackend;
+#[cfg(target_os = "macos")]
+use macos::MacBackend as SelectedBackend;
+#[cfg(target_os = "windows")]
+use windows::WindowsBackend as SelectedBackend;
+
+use backend::PlatformBackend;
+pub(crate) use runtime::{PlatformAction, PlatformEvent, PlatformInterface};
+
+pub(crate) type NativePlatform = runtime::PlatformRuntime<SelectedBackend>;
+
+/// Returns the current target's application configuration directory.
 pub(crate) fn config_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "macos")]
-    return macos::config_dir();
+    SelectedBackend::config_dir()
+}
 
-    #[cfg(target_os = "windows")]
-    return windows::config_dir();
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    dirs::config_dir().map(|base| base.join("viberwhisper"))
+/// Resolves persisted hotkey names with the policy selected for this build target.
+pub(crate) fn validate_hotkeys(
+    section: &InputSection,
+) -> Result<HotkeyConfig, Vec<ValidationIssue>> {
+    HotkeyConfig::validate::<<SelectedBackend as PlatformBackend>::Hotkeys>(section)
 }

--- a/src/platform/backend.rs
+++ b/src/platform/backend.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rdev::EventType;
+
+use crate::input::hotkey::HotkeyPolicy;
+use crate::input::tray::TrayPolicy;
+use crate::input::typer::TextTyper;
+
+pub(crate) type HotkeyFilter = Box<dyn Fn(EventType) -> Option<EventType> + Send + 'static>;
+
+/// Private contract implemented by the one backend selected for the build target.
+pub(crate) trait PlatformBackend: 'static {
+    type Hotkeys: HotkeyPolicy;
+    type Tray: TrayPolicy;
+
+    fn config_dir() -> Option<PathBuf>;
+    fn text_typer_and_hotkey_filter() -> (Arc<dyn TextTyper>, HotkeyFilter);
+}

--- a/src/platform/fallback.rs
+++ b/src/platform/fallback.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rdev::Key;
+
+use super::backend::{HotkeyFilter, PlatformBackend};
+use crate::input::hotkey::HotkeyPolicy;
+use crate::input::tray::TrayPolicy;
+use crate::input::typer::{MockTyper, TextTyper};
+
+pub(crate) struct FallbackBackend;
+pub(crate) struct FallbackHotkeys;
+pub(crate) struct FallbackTray;
+
+impl PlatformBackend for FallbackBackend {
+    type Hotkeys = FallbackHotkeys;
+    type Tray = FallbackTray;
+
+    fn config_dir() -> Option<PathBuf> {
+        dirs::config_dir().map(|base| base.join("viberwhisper"))
+    }
+
+    fn text_typer_and_hotkey_filter() -> (Arc<dyn TextTyper>, HotkeyFilter) {
+        (Arc::new(MockTyper), Box::new(Some))
+    }
+}
+
+impl HotkeyPolicy for FallbackHotkeys {
+    fn unsupported_reason(_key: Key) -> Option<&'static str> {
+        None
+    }
+}
+
+impl TrayPolicy for FallbackTray {
+    fn idle_icon_is_template() -> bool {
+        false
+    }
+
+    #[cfg(not(test))]
+    fn prepare_application() -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn double_click_interval() -> Option<std::time::Duration> {
+        None
+    }
+
+    #[cfg(not(test))]
+    fn set_icon(
+        tray_icon: &tray_icon::TrayIcon,
+        icon: tray_icon::Icon,
+        _is_template: bool,
+    ) -> tray_icon::Result<()> {
+        tray_icon.set_icon(Some(icon))
+    }
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,12 +1,109 @@
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
+use rdev::Key;
+
+use super::backend::{HotkeyFilter, PlatformBackend};
+use crate::input::hotkey::HotkeyPolicy;
+use crate::input::tray::TrayPolicy;
 use crate::input::typer::TextTyper;
 use tracing::{debug, info};
 
 mod accessibility;
 mod hotkey;
 mod pasteboard;
+
+pub(crate) struct MacBackend;
+pub(crate) struct MacHotkeys;
+pub(crate) struct MacTray;
+
+impl PlatformBackend for MacBackend {
+    type Hotkeys = MacHotkeys;
+    type Tray = MacTray;
+
+    fn config_dir() -> Option<PathBuf> {
+        dirs::config_dir().map(|base| base.join("com.b1indsight.viberwhisper"))
+    }
+
+    fn text_typer_and_hotkey_filter() -> (Arc<dyn TextTyper>, HotkeyFilter) {
+        let (typer, filter) = MacTyper::new();
+        (Arc::new(typer), Box::new(filter))
+    }
+}
+
+impl HotkeyPolicy for MacHotkeys {
+    fn unsupported_reason(key: Key) -> Option<&'static str> {
+        match key {
+            Key::CapsLock => {
+                Some("macOS reports Caps Lock as a state change, not a physical press/release pair")
+            }
+            Key::ControlRight
+            | Key::Delete
+            | Key::Insert
+            | Key::Home
+            | Key::End
+            | Key::PageUp
+            | Key::PageDown
+            | Key::NumLock
+            | Key::ScrollLock
+            | Key::PrintScreen
+            | Key::Pause
+            | Key::IntlBackslash
+            | Key::KpReturn
+            | Key::KpMinus
+            | Key::KpPlus
+            | Key::KpMultiply
+            | Key::KpDivide
+            | Key::Kp0
+            | Key::Kp1
+            | Key::Kp2
+            | Key::Kp3
+            | Key::Kp4
+            | Key::Kp5
+            | Key::Kp6
+            | Key::Kp7
+            | Key::Kp8
+            | Key::Kp9
+            | Key::KpDelete => Some("the current rdev macOS backend does not emit this named key"),
+            _ => None,
+        }
+    }
+}
+
+impl TrayPolicy for MacTray {
+    fn idle_icon_is_template() -> bool {
+        true
+    }
+
+    #[cfg(not(test))]
+    fn prepare_application() -> Result<(), Box<dyn std::error::Error>> {
+        use objc2::MainThreadMarker;
+        use objc2_app_kit::{NSApp, NSApplicationActivationPolicy};
+
+        let mtm = MainThreadMarker::new().ok_or("tray must be created on the main thread")?;
+        let _ = NSApp(mtm).setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn double_click_interval() -> Option<Duration> {
+        let seconds = objc2_app_kit::NSEvent::doubleClickInterval();
+        seconds
+            .is_finite()
+            .then(|| Duration::from_secs_f64(seconds))
+    }
+
+    #[cfg(not(test))]
+    fn set_icon(
+        tray_icon: &tray_icon::TrayIcon,
+        icon: tray_icon::Icon,
+        is_template: bool,
+    ) -> tray_icon::Result<()> {
+        tray_icon.set_icon_with_as_template(Some(icon), is_template)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AccessibilityInsert {
@@ -125,7 +222,7 @@ fn route_injection(
 
 /// Native macOS text delivery using focused AX selection first and a clipboard-replacing paste
 /// fallback only when the focused control does not support selected-text assignment.
-pub struct MacTyper {
+struct MacTyper {
     paste: pasteboard::NativePasteWriter,
     delivery: Mutex<()>,
 }
@@ -181,17 +278,50 @@ impl TextTyper for MacTyper {
         Ok(())
     }
 }
-use std::path::PathBuf;
-
-pub(crate) fn config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|base| base.join("com.b1indsight.viberwhisper"))
-}
-
 #[cfg(test)]
 mod tests {
     use std::cell::{Cell, RefCell};
 
     use super::*;
+
+    #[test]
+    fn macos_policy_owns_native_hotkey_and_icon_rules() {
+        assert!(MacTray::idle_icon_is_template());
+        for key in [
+            Key::CapsLock,
+            Key::ControlRight,
+            Key::Delete,
+            Key::Insert,
+            Key::Home,
+            Key::End,
+            Key::PageUp,
+            Key::PageDown,
+            Key::NumLock,
+            Key::ScrollLock,
+            Key::PrintScreen,
+            Key::Pause,
+            Key::IntlBackslash,
+            Key::KpReturn,
+            Key::KpMinus,
+            Key::KpPlus,
+            Key::KpMultiply,
+            Key::KpDivide,
+            Key::Kp0,
+            Key::Kp1,
+            Key::Kp2,
+            Key::Kp3,
+            Key::Kp4,
+            Key::Kp5,
+            Key::Kp6,
+            Key::Kp7,
+            Key::Kp8,
+            Key::Kp9,
+            Key::KpDelete,
+        ] {
+            assert!(MacHotkeys::unsupported_reason(key).is_some(), "{key:?}");
+        }
+        assert_eq!(MacHotkeys::unsupported_reason(Key::F8), None);
+    }
 
     struct FakeAccessibility {
         result: RefCell<Option<Result<AccessibilityInsert, AccessibilityError>>>,

--- a/src/platform/runtime.rs
+++ b/src/platform/runtime.rs
@@ -1,0 +1,345 @@
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use super::backend::PlatformBackend;
+use crate::input::hotkey::{HotkeyConfig, HotkeyEvent, HotkeySource, start_hotkey_listener};
+use crate::input::tray::{TrayAction, TrayEvent, TrayManager};
+use crate::input::typer::TextTyper;
+
+type HotkeyNotify = Arc<dyn Fn(HotkeyEvent) + Send + Sync>;
+type TrayNotify = Arc<dyn Fn(TrayEvent) + Send + Sync>;
+
+/// Native callback payload whose representation is private to the platform runtime.
+#[derive(Debug, Clone)]
+pub(crate) struct PlatformEvent(PlatformEventKind);
+
+#[derive(Debug, Clone)]
+enum PlatformEventKind {
+    Hotkey(HotkeyEvent),
+    Tray(TrayEvent),
+}
+
+impl PlatformEvent {
+    fn hotkey(event: HotkeyEvent) -> Self {
+        Self(PlatformEventKind::Hotkey(event))
+    }
+
+    fn tray(event: TrayEvent) -> Self {
+        Self(PlatformEventKind::Tray(event))
+    }
+}
+
+/// Platform-neutral user intent returned to the listener application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlatformAction {
+    HoldPressed,
+    HoldReleased,
+    ToggleRecording,
+    ExitRequested,
+}
+
+/// The only native desktop capability surface consumed by the listener application.
+///
+/// The runtime is created and retained on the winit main thread because it owns native tray
+/// state. `start` installs process-lifetime callbacks; only the cloned `TextTyper` handle returned
+/// by `text_typer` may cross to a finalization worker.
+pub(crate) trait PlatformInterface: Sized {
+    fn start(
+        hotkeys: &HotkeyConfig,
+        notify: impl Fn(PlatformEvent) + Send + Sync + 'static,
+    ) -> Result<Self, Box<dyn std::error::Error>>;
+
+    fn handle_event(&mut self, event: PlatformEvent) -> Option<PlatformAction>;
+    fn set_recording(&mut self, recording: bool);
+    fn text_typer(&self) -> Arc<dyn TextTyper>;
+}
+
+/// Main-thread platform owner parameterized by the backend selected in `platform.rs`.
+pub(crate) struct PlatformRuntime<B, D = NativeDrivers>
+where
+    B: PlatformBackend,
+    D: RuntimeDrivers<B>,
+{
+    tray: D::Tray,
+    typer: Arc<dyn TextTyper>,
+    _backend: PhantomData<B>,
+}
+
+pub(crate) trait PlatformTray {
+    fn handle_event(&mut self, event: TrayEvent) -> Option<TrayAction>;
+    fn set_recording(&mut self, recording: bool);
+}
+
+impl<P: crate::input::tray::TrayPolicy> PlatformTray for TrayManager<P> {
+    fn handle_event(&mut self, event: TrayEvent) -> Option<TrayAction> {
+        TrayManager::handle_event(self, event)
+    }
+
+    fn set_recording(&mut self, recording: bool) {
+        TrayManager::set_recording(self, recording);
+    }
+}
+
+/// Injectable native-driver seam used to verify runtime wiring without installing global hooks.
+pub(crate) trait RuntimeDrivers<B: PlatformBackend>: 'static {
+    type Tray: PlatformTray;
+
+    fn start_hotkeys(
+        config: &HotkeyConfig,
+        filter: super::backend::HotkeyFilter,
+        notify: HotkeyNotify,
+    );
+    fn start_tray(notify: TrayNotify) -> Result<Self::Tray, Box<dyn std::error::Error>>;
+}
+
+pub(crate) struct NativeDrivers;
+
+impl<B: PlatformBackend> RuntimeDrivers<B> for NativeDrivers {
+    type Tray = TrayManager<B::Tray>;
+
+    fn start_hotkeys(
+        config: &HotkeyConfig,
+        filter: super::backend::HotkeyFilter,
+        notify: HotkeyNotify,
+    ) {
+        start_hotkey_listener::<B::Hotkeys, _>(config, filter, move |event| notify(event));
+    }
+
+    fn start_tray(notify: TrayNotify) -> Result<Self::Tray, Box<dyn std::error::Error>> {
+        TrayManager::<B::Tray>::new(move |event| notify(event))
+    }
+}
+
+impl<B, D> PlatformInterface for PlatformRuntime<B, D>
+where
+    B: PlatformBackend,
+    D: RuntimeDrivers<B>,
+{
+    fn start(
+        hotkeys: &HotkeyConfig,
+        notify: impl Fn(PlatformEvent) + Send + Sync + 'static,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let notify = Arc::new(notify);
+        let (typer, hotkey_filter) = B::text_typer_and_hotkey_filter();
+
+        let hotkey_notify = Arc::clone(&notify);
+        D::start_hotkeys(
+            hotkeys,
+            hotkey_filter,
+            Arc::new(move |event| hotkey_notify(PlatformEvent::hotkey(event))),
+        );
+
+        let tray_notify = Arc::clone(&notify);
+        let tray = D::start_tray(Arc::new(move |event| {
+            tray_notify(PlatformEvent::tray(event));
+        }))?;
+
+        Ok(Self {
+            tray,
+            typer,
+            _backend: PhantomData,
+        })
+    }
+
+    fn handle_event(&mut self, event: PlatformEvent) -> Option<PlatformAction> {
+        match event.0 {
+            PlatformEventKind::Hotkey(event) => action_from_hotkey(event),
+            PlatformEventKind::Tray(event) => self.tray.handle_event(event).map(action_from_tray),
+        }
+    }
+
+    fn set_recording(&mut self, recording: bool) {
+        self.tray.set_recording(recording);
+    }
+
+    fn text_typer(&self) -> Arc<dyn TextTyper> {
+        Arc::clone(&self.typer)
+    }
+}
+
+fn action_from_hotkey(event: HotkeyEvent) -> Option<PlatformAction> {
+    match event {
+        HotkeyEvent::Pressed(HotkeySource::Hold) => Some(PlatformAction::HoldPressed),
+        HotkeyEvent::Released(HotkeySource::Hold) => Some(PlatformAction::HoldReleased),
+        HotkeyEvent::Pressed(HotkeySource::Toggle) => Some(PlatformAction::ToggleRecording),
+        HotkeyEvent::Released(HotkeySource::Toggle) => None,
+    }
+}
+
+fn action_from_tray(action: TrayAction) -> PlatformAction {
+    match action {
+        TrayAction::ToggleRecording => PlatformAction::ToggleRecording,
+        TrayAction::Exit => PlatformAction::ExitRequested,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use rdev::{EventType, Key};
+    use tray_icon::menu::{MenuEvent, MenuId};
+
+    use crate::core::config::InputSection;
+    use crate::input::hotkey::HotkeyPolicy;
+    use crate::input::tray::TrayPolicy;
+
+    static RECORDING: AtomicBool = AtomicBool::new(false);
+    static TYPED_TEXT: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    struct FakeHotkeys;
+
+    impl HotkeyPolicy for FakeHotkeys {
+        fn unsupported_reason(_key: Key) -> Option<&'static str> {
+            None
+        }
+    }
+
+    struct FakeTrayPolicy;
+
+    impl TrayPolicy for FakeTrayPolicy {
+        fn idle_icon_is_template() -> bool {
+            false
+        }
+    }
+
+    struct RecordingTyper;
+
+    impl TextTyper for RecordingTyper {
+        fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>> {
+            TYPED_TEXT
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(text.to_string());
+            Ok(())
+        }
+    }
+
+    struct FakeBackend;
+
+    impl PlatformBackend for FakeBackend {
+        type Hotkeys = FakeHotkeys;
+        type Tray = FakeTrayPolicy;
+
+        fn config_dir() -> Option<PathBuf> {
+            None
+        }
+
+        fn text_typer_and_hotkey_filter()
+        -> (Arc<dyn TextTyper>, super::super::backend::HotkeyFilter) {
+            (Arc::new(RecordingTyper), Box::new(Some))
+        }
+    }
+
+    struct FakeTray;
+
+    impl PlatformTray for FakeTray {
+        fn handle_event(&mut self, event: TrayEvent) -> Option<TrayAction> {
+            match event {
+                TrayEvent::Menu(_) => Some(TrayAction::Exit),
+                TrayEvent::Icon(_) => Some(TrayAction::ToggleRecording),
+            }
+        }
+
+        fn set_recording(&mut self, recording: bool) {
+            RECORDING.store(recording, Ordering::SeqCst);
+        }
+    }
+
+    struct FakeDrivers;
+
+    impl RuntimeDrivers<FakeBackend> for FakeDrivers {
+        type Tray = FakeTray;
+
+        fn start_hotkeys(
+            _config: &HotkeyConfig,
+            filter: super::super::backend::HotkeyFilter,
+            notify: HotkeyNotify,
+        ) {
+            if filter(EventType::KeyPress(Key::F8)).is_some() {
+                notify(HotkeyEvent::Pressed(HotkeySource::Hold));
+            }
+        }
+
+        fn start_tray(notify: TrayNotify) -> Result<Self::Tray, Box<dyn std::error::Error>> {
+            notify(TrayEvent::Menu(MenuEvent {
+                id: MenuId::new("exit"),
+            }));
+            Ok(FakeTray)
+        }
+    }
+
+    #[test]
+    fn runtime_wires_drivers_events_state_and_text_delivery() {
+        RECORDING.store(false, Ordering::SeqCst);
+        TYPED_TEXT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+
+        let hotkeys = HotkeyConfig::validate::<FakeHotkeys>(&InputSection::default()).unwrap();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let received = Arc::clone(&events);
+        let mut runtime =
+            PlatformRuntime::<FakeBackend, FakeDrivers>::start(&hotkeys, move |event| {
+                received
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(event);
+            })
+            .unwrap();
+
+        let actions: Vec<_> = events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain(..)
+            .filter_map(|event| runtime.handle_event(event))
+            .collect();
+        assert_eq!(
+            actions,
+            [PlatformAction::HoldPressed, PlatformAction::ExitRequested]
+        );
+
+        runtime.set_recording(true);
+        assert!(RECORDING.load(Ordering::SeqCst));
+
+        runtime.text_typer().type_text("hello").unwrap();
+        assert_eq!(
+            *TYPED_TEXT
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            ["hello"]
+        );
+    }
+
+    #[test]
+    fn native_input_maps_to_platform_neutral_actions() {
+        assert_eq!(
+            action_from_hotkey(HotkeyEvent::Pressed(HotkeySource::Hold)),
+            Some(PlatformAction::HoldPressed)
+        );
+        assert_eq!(
+            action_from_hotkey(HotkeyEvent::Released(HotkeySource::Hold)),
+            Some(PlatformAction::HoldReleased)
+        );
+        assert_eq!(
+            action_from_hotkey(HotkeyEvent::Pressed(HotkeySource::Toggle)),
+            Some(PlatformAction::ToggleRecording)
+        );
+        assert_eq!(
+            action_from_hotkey(HotkeyEvent::Released(HotkeySource::Toggle)),
+            None
+        );
+        assert_eq!(
+            action_from_tray(TrayAction::ToggleRecording),
+            PlatformAction::ToggleRecording
+        );
+        assert_eq!(
+            action_from_tray(TrayAction::Exit),
+            PlatformAction::ExitRequested
+        );
+    }
+}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,23 +1,112 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rdev::Key;
+
+use super::backend::{HotkeyFilter, PlatformBackend};
+use crate::input::hotkey::HotkeyPolicy;
+use crate::input::tray::TrayPolicy;
 use crate::input::typer::TextTyper;
 use tracing::info;
 
-pub struct WindowsTyper;
+pub(crate) struct WindowsBackend;
+pub(crate) struct WindowsHotkeys;
+pub(crate) struct WindowsTray;
+
+struct WindowsTyper;
+
+impl PlatformBackend for WindowsBackend {
+    type Hotkeys = WindowsHotkeys;
+    type Tray = WindowsTray;
+
+    fn config_dir() -> Option<PathBuf> {
+        dirs::config_dir().map(|base| base.join("ViberWhisper"))
+    }
+
+    fn text_typer_and_hotkey_filter() -> (Arc<dyn TextTyper>, HotkeyFilter) {
+        (Arc::new(WindowsTyper), Box::new(Some))
+    }
+}
+
+impl HotkeyPolicy for WindowsHotkeys {
+    fn unsupported_reason(key: Key) -> Option<&'static str> {
+        match key {
+            Key::MetaRight => Some("the current rdev Windows backend does not emit RIGHTMETA"),
+            Key::Function => Some("Windows does not expose the Fn key to rdev"),
+            Key::KpReturn => {
+                Some("the current rdev Windows backend cannot distinguish it from ENTER")
+            }
+            _ => None,
+        }
+    }
+
+    fn pair_conflict(
+        first: Option<Key>,
+        second: Option<Key>,
+    ) -> Option<(&'static str, &'static str)> {
+        matches!(
+            (first, second),
+            (Some(Key::ControlLeft), Some(Key::AltGr)) | (Some(Key::AltGr), Some(Key::ControlLeft))
+        )
+        .then_some((
+            "hotkey.altgr_conflict",
+            "LEFTCTRL and RIGHTALT cannot be used together because Windows AltGr emits both keys",
+        ))
+    }
+
+    fn additional_warning(key: Key) -> Option<&'static str> {
+        (key == Key::ControlLeft)
+            .then_some("LEFTCTRL may also be emitted when Windows handles RIGHTALT as AltGr")
+    }
+}
+
+impl TrayPolicy for WindowsTray {
+    fn idle_icon_is_template() -> bool {
+        false
+    }
+
+    #[cfg(not(test))]
+    fn prepare_application() -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn double_click_interval() -> Option<std::time::Duration> {
+        Some(std::time::Duration::from_millis(
+            unsafe { ffi::GetDoubleClickTime() } as u64,
+        ))
+    }
+
+    #[cfg(not(test))]
+    fn set_icon(
+        tray_icon: &tray_icon::TrayIcon,
+        icon: tray_icon::Icon,
+        _is_template: bool,
+    ) -> tray_icon::Result<()> {
+        tray_icon.set_icon(Some(icon))
+    }
+}
+
+fn unicode_events(text: &str) -> Vec<(u16, bool)> {
+    text.encode_utf16()
+        .flat_map(|code_unit| [(code_unit, false), (code_unit, true)])
+        .collect()
+}
 
 impl TextTyper for WindowsTyper {
     fn type_text(&self, text: &str) -> Result<(), Box<dyn std::error::Error>> {
         // Give the target window time to regain focus
         std::thread::sleep(std::time::Duration::from_millis(100));
 
-        let utf16: Vec<u16> = text.encode_utf16().collect();
-        if utf16.is_empty() {
+        let events = unicode_events(text);
+        if events.is_empty() {
             return Ok(());
         }
 
-        let mut inputs: Vec<ffi::INPUT> = Vec::with_capacity(utf16.len() * 2);
-        for &code_unit in &utf16 {
-            inputs.push(ffi::make_key_input(code_unit, false));
-            inputs.push(ffi::make_key_input(code_unit, true));
-        }
+        let mut inputs: Vec<ffi::INPUT> = events
+            .into_iter()
+            .map(|(code_unit, key_up)| ffi::make_key_input(code_unit, key_up))
+            .collect();
 
         let sent = unsafe {
             ffi::SendInput(
@@ -70,6 +159,7 @@ mod ffi {
     #[link(name = "user32")]
     unsafe extern "system" {
         pub fn SendInput(nInputs: u32, pInputs: *mut INPUT, cbSize: i32) -> u32;
+        pub fn GetDoubleClickTime() -> u32;
     }
 
     pub fn make_key_input(scan_code: u16, key_up: bool) -> INPUT {
@@ -92,8 +182,43 @@ mod ffi {
         }
     }
 }
-use std::path::PathBuf;
 
-pub(crate) fn config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|base| base.join("ViberWhisper"))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::InputSection;
+    use crate::input::hotkey::HotkeyConfig;
+
+    #[test]
+    fn windows_policy_owns_altgr_key_and_icon_rules() {
+        let issues = HotkeyConfig::validate::<WindowsHotkeys>(&InputSection {
+            hold_hotkey: "LEFTCTRL".to_string(),
+            toggle_hotkey: "RIGHTALT".to_string(),
+        })
+        .unwrap_err();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].code, "hotkey.altgr_conflict");
+        for key in [Key::MetaRight, Key::Function, Key::KpReturn] {
+            assert!(WindowsHotkeys::unsupported_reason(key).is_some(), "{key:?}");
+        }
+        assert!(WindowsHotkeys::additional_warning(Key::ControlLeft).is_some());
+        assert_eq!(WindowsHotkeys::additional_warning(Key::AltGr), None);
+        assert!(!WindowsTray::idle_icon_is_template());
+    }
+
+    #[test]
+    fn unicode_input_pairs_each_utf16_unit_including_surrogates() {
+        assert_eq!(
+            unicode_events("A😀"),
+            vec![
+                (0x0041, false),
+                (0x0041, true),
+                (0xd83d, false),
+                (0xd83d, true),
+                (0xde00, false),
+                (0xde00, true),
+            ]
+        );
+    }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -57,7 +57,10 @@ pub fn resolve_listener(
     home_dir: &Path,
 ) -> Result<ListenerConfig, ValidationReport> {
     let mut issues = Vec::new();
-    let hotkeys = collect_issues(HotkeyConfig::validate(&document.input), &mut issues);
+    let hotkeys = collect_issues(
+        crate::platform::validate_hotkeys(&document.input),
+        &mut issues,
+    );
     let audio = AudioConfig::from_section(&document.audio);
     let orchestrator = OrchestratorConfig::new(document.transcription.language.clone());
     let backend = collect_issues(


### PR DESCRIPTION
## Summary

- implements one compile-time-selected NativePlatform runtime for macOS, Windows, and the explicit unsupported-target fallback
- hides native hotkey policy/filtering, tray/icon behavior, configuration paths, and text writer construction behind the common platform boundary
- routes opaque platform events into semantic Hold, Toggle, and Exit actions while keeping recording lifecycle decisions in the application/core layers
- adds an injected-driver runtime contract test plus platform policy and Unicode input coverage
- synchronizes architecture docs, the plan record, project structure, index, and changelog

## Validation

- cargo fmt --all --check
- cargo test --locked --quiet: 117 passed
- cargo clippy --locked -- -D warnings
- cargo build --locked
- cargo check/clippy for x86_64-pc-windows-msvc
- cargo check for x86_64-apple-darwin
- git diff --check
- no target_os branches in src/application, src/input, or src/runtime_config.rs
- hosted macOS, Windows, and Python CI passed
- independent code review gate completed with no final findings

## Status

This PR remains draft until the manual native macOS and Windows interaction smoke matrices in docs/plan/30-compile-time-platform-interface.md are recorded.
