### PR TITLE
docs(plan): design STT prompt regression suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ This is a **cross-platform (macOS + Windows)** project:
 7. **Text Injection**: Output recognized text at the current cursor position on macOS and Windows
 8. **System Tray UI**: Status indicator (idle/recording), left-click recording toggle, and right-click history/exit menu
 9. **CLI Utilities**: Config management and offline WAV transcription commands
-10. **Packaging and Release Automation**: CI workflows plus app bundle / installer release support
+10. **STT Prompt Regression**: Capture paired WAV/reference datasets, rerun all ready audio with a temporary prompt, and finalize JSON metrics with coding-agent semantic review
+11. **Packaging and Release Automation**: CI workflows plus app bundle / installer release support
 
 ### User Flow
 
@@ -87,10 +88,18 @@ src/
   application.rs             — Logging, CLI dispatch, config/local/convert workflows
   application/
     listener.rs              — Platform-action loop, session effects, transcription delivery
+    prompt_lab.rs            — Dataset capture, regression, and agent-review CLI assembly
   runtime_config.rs          — Application-level profile and consumer config assembly
   session.rs                 — Shared SessionId value type
   text.rs                    — Shared language-aware transcription text merge
   history.rs                 — Bounded JSONL transcription history persistence and tail repair
+  prompt_lab.rs              — STT prompt-lab domain facade and exports
+  prompt_lab/
+    capture.rs               — Session WAV archive worker and raw-STT sample publication
+    dataset.rs               — Versioned samples, correction, validation, and scoring identity
+    metrics.rs               — Versioned WER alignment and proper-noun matching
+    regression.rs            — Fresh full-dataset STT execution and canonical JSON reports
+    review.rs                — Coding-agent review validation and final threshold gates
   core.rs                    — Core module entry and submodule declarations
   core/
     config.rs                — Config facade, errors, validation, and safe value types

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
@@ -287,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +371,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cedarwood"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -666,6 +693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +889,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1015,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1265,7 +1313,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1273,6 +1321,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1525,6 +1578,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f173716febb1ad596c16ea5637b5f1790ea32de8e627493ff82bc73b0876ce"
+dependencies = [
+ "include-flate-codegen",
+ "include-flate-compress",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7875b62a72ad3f3203cdd8950d4cf9947db036030b974b8b37ceae90c8d8c0"
+dependencies = [
+ "include-flate-compress",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fbb9c5ccb9a5b67b4afa2974c27e5507ea1bf6d22828cef418e4dfaeca51dd"
+dependencies = [
+ "libflate",
+ "zstd",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1658,30 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jieba-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c676b32a471d3cfae8dac2ad2f8334cd52e53377733cca8c1fb0a5062fec192"
+dependencies = [
+ "phf_codegen",
+]
+
+[[package]]
+name = "jieba-rs"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5dd552bbb95d578520ee68403bf8aaf0dbbb2ce55b0854d019f9350ad61040a"
+dependencies = [
+ "cedarwood",
+ "fxhash",
+ "include-flate",
+ "jieba-macros",
+ "lazy_static",
+ "phf",
+ "regex",
+]
 
 [[package]]
 name = "jni"
@@ -1716,6 +1826,30 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libflate"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libloading"
@@ -1975,6 +2109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.0",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2450,6 +2593,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,6 +2774,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2833,21 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "raw-window-handle"
@@ -2778,6 +2996,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustc-hash"
@@ -3042,6 +3266,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3311,6 +3541,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3592,6 +3837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,6 +3919,7 @@ dependencies = [
  "cpal",
  "dirs 5.0.1",
  "hound",
+ "jieba-rs",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-application-services",
@@ -3681,6 +3936,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tray-icon",
+ "unicode-normalization",
+ "unicode-segmentation",
  "winit",
 ]
 
@@ -4671,3 +4928,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +670,16 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -996,6 +1034,16 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2948,6 +2996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,6 +3574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3676,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "5.0"
 reqwest = { version = "0.12", features = ["blocking", "multipart", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 clap = { version = "4", features = ["derive"] }
 png = "0.17"
 tray-icon = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ reqwest = { version = "0.12", features = ["blocking", "multipart", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+jieba-rs = "0.7"
+unicode-normalization = "0.1"
+unicode-segmentation = "1"
 clap = { version = "4", features = ["derive"] }
 png = "0.17"
 tray-icon = "0.21"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **本地推理模式**：通过内置 `local` 子命令拉起 Python FastAPI 服务，使用 Gemma 4 本地模型提供 `/v1/audio/transcriptions` 与 `/v1/chat/completions`
 - **自动文本输入**：识别结果自动输入到当前光标位置；macOS 原生控件优先使用辅助功能 API，Chromium 浏览器使用可恢复的剪贴板粘贴，支持中文等 Unicode 字符
 - **本地识别历史**：最终用于输入的文本以 JSONL 追加到应用数据目录，右键菜单直接显示最近 5 条，点击即可复制完整原文
-- **STT Prompt 测试集采集**：专用录音模式保存完整 WAV 与原始 STT 结果，并提供逐条校正和专有名词标注命令
+- **STT Prompt 回归调试**：采集并校正 WAV 测试集，全量重跑临时候选 prompt，以 WER、代理语义评分和专有名词准确率独立把关
 - **状态栏录音控制**：左键点击五柱 V 形声波图标即可开始或停止录音，右键打开识别历史和退出菜单
 - **灵活配置**：支持自定义热键、模型、语言、API 地址、麦克风增益等
 - **自动清理**：自动保留最新 10 条录音，旧文件自动删除
@@ -158,6 +158,16 @@ viberwhisper prompt-lab sample show --dataset /path/to/my-stt-dataset <sample-id
 viberwhisper prompt-lab sample correct --dataset /path/to/my-stt-dataset <sample-id> \
   --reference-file expected.txt --proper-nouns-file proper-nouns.json
 viberwhisper prompt-lab dataset validate --dataset /path/to/my-stt-dataset
+
+# 用临时候选 prompt 全量重跑所有 ready 历史录音
+viberwhisper prompt-lab evaluate --dataset /path/to/my-stt-dataset \
+  --prompt-file candidate.txt \
+  --max-wer-percent 8 --min-llm-score 95 --min-proper-noun-percent 98
+
+# 将编码代理给出的逐样本语义复核应用到同一份报告
+viberwhisper prompt-lab report apply-review \
+  --report /path/to/my-stt-dataset/runs/<run-id>.json \
+  --review /path/to/<run-id>.agent-review.json
 ```
 
 `prompt-lab record` 只保存当前 STT profile 返回的原始结果，不执行 LLM 后处理、不写普通
@@ -170,6 +180,32 @@ WAV，并在 `samples/` 下保存同 ID 的 JSON；初始识别不是标准答�
 调试任务中，编码代理也会读取参考文本与候选结果。请只采集愿意通过这些路径处理的内容。首个版本
 要求同一数据集同一时间只由一个 `prompt-lab` 进程使用，不提供锁、原子写入或中断自动恢复；
 `dataset validate` 会报告损坏 JSON、截断 WAV、摘要不匹配和无侧车录音，需人工清理或重录。
+
+### STT Prompt 回归调试
+
+`prompt-lab evaluate` 每次都会按稳定 ID 顺序重新读取并转写全部 `ready` WAV，不复用旧 STT
+结果，也不把人工参考文本发给 STT。`--prompt-file` 的原文只覆盖本次进程内的
+`transcription.prompt`，不会修改 `config.json`；省略它会使用当前配置作为基线，`--no-prompt`
+则明确不发送 multipart prompt。`--compare-to` 可指向一份已完成且数据集、后端与评分版本兼容的
+旧报告；不兼容会在任何 STT 请求前失败。报告默认直接写入数据集的 `runs/`，只生成 JSON，
+不生成 Markdown 或网页报告。
+
+三项指标各自独立，不合成加权总分：
+
+- **词错误率（WER）**：NFKC 规范化后，中文使用固定 Jieba 词典且关闭 HMM，其他文本使用
+  Unicode 词边界；数据集值是替换、删除、插入总数除以参考词总数的微平均，可超过 100%。
+- **语义差异评分**：编码代理只依据每条人工参考文本和本次 STT 结果，按固定 rubric 给出
+  `0..=100` 整数、简短原因和结构化差异；程序不配置或调用 Judge API/model。
+- **专有名词准确率**：按 canonical/accepted 形式、大小写策略、词边界和期望出现次数计算匹配数
+  的微平均。整个 ready 集必须至少标注一次专有名词，否则回归会拒绝启动。
+
+首次评估成功后，规范报告状态为 `awaiting_agent_review`，此时只有 WER 和专有名词指标，不能判定
+通过。编码代理读取该 JSON，生成覆盖全部样本的 versioned review JSON，再执行 `apply-review`；
+程序验证 run ID、rubric、完整样本覆盖、`0..=100` 分数及差异结构后，直接改写同一份报告，计算
+语义均分和三个门禁。只有 `WER <= max`、`LLM >= min`、`专有名词 >= min` 同时成立时
+`meets_targets` 才为 `true`。若未通过，编码代理根据逐条差异修改候选 prompt 并再次全量回归，
+直到达到目标或判断 prompt 已无法继续改善。单条 STT 失败不会跳过后续样本，但报告会标记为
+`incomplete`、命令返回非零，且该报告不能接受复核或作为比较基线。
 
 ## 配置说明
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **本地推理模式**：通过内置 `local` 子命令拉起 Python FastAPI 服务，使用 Gemma 4 本地模型提供 `/v1/audio/transcriptions` 与 `/v1/chat/completions`
 - **自动文本输入**：识别结果自动输入到当前光标位置；macOS 原生控件优先使用辅助功能 API，Chromium 浏览器使用可恢复的剪贴板粘贴，支持中文等 Unicode 字符
 - **本地识别历史**：最终用于输入的文本以 JSONL 追加到应用数据目录，右键菜单直接显示最近 5 条，点击即可复制完整原文
+- **STT Prompt 测试集采集**：专用录音模式保存完整 WAV 与原始 STT 结果，并提供逐条校正和专有名词标注命令
 - **状态栏录音控制**：左键点击五柱 V 形声波图标即可开始或停止录音，右键打开识别历史和退出菜单
 - **灵活配置**：支持自定义热键、模型、语言、API 地址、麦克风增益等
 - **自动清理**：自动保留最新 10 条录音，旧文件自动删除
@@ -147,7 +148,28 @@ viberwhisper config set <key> <value>
 # 离线转写 WAV 文件
 viberwhisper convert input.wav
 viberwhisper convert input.wav --output output.txt
+
+# 采集 STT prompt 测试样本（使用现有托盘与 Hold/Toggle 热键）
+viberwhisper prompt-lab record --dataset /path/to/my-stt-dataset
+
+# 查看、校正并验证样本
+viberwhisper prompt-lab sample list --dataset /path/to/my-stt-dataset --status pending
+viberwhisper prompt-lab sample show --dataset /path/to/my-stt-dataset <sample-id>
+viberwhisper prompt-lab sample correct --dataset /path/to/my-stt-dataset <sample-id> \
+  --reference-file expected.txt --proper-nouns-file proper-nouns.json
+viberwhisper prompt-lab dataset validate --dataset /path/to/my-stt-dataset
 ```
+
+`prompt-lab record` 只保存当前 STT profile 返回的原始结果，不执行 LLM 后处理、不写普通
+`history.jsonl`，也不向当前输入框注入文字。每次完成的录音在数据集的 `audio/` 下保存一个完整
+WAV，并在 `samples/` 下保存同 ID 的 JSON；初始识别不是标准答案，必须通过 `sample correct`
+写入人工参考文本后才会成为 `ready`。专有名词文件是由 `canonical`、`accepted`、
+`case_sensitive` 和 `expected_occurrences` 组成的 JSON 数组；省略该文件表示该样本没有专有名词。
+
+数据集中的录音、初始识别和人工参考文本均为本机明文。录音会发送给当前配置的 STT 服务；在后续
+调试任务中，编码代理也会读取参考文本与候选结果。请只采集愿意通过这些路径处理的内容。首个版本
+要求同一数据集同一时间只由一个 `prompt-lab` 进程使用，不提供锁、原子写入或中断自动恢复；
+`dataset validate` 会报告损坏 JSON、截断 WAV、摘要不匹配和无侧车录音，需人工清理或重录。
 
 ## 配置说明
 

--- a/changelog
+++ b/changelog
@@ -42,3 +42,4 @@
 2026-08-12: Hide native hotkey, tray/icon, configuration-path, and text-delivery details behind one compile-time-selected platform runtime with opaque events and semantic actions
 2026-08-13: Fix macOS Chromium web-field input by routing identified browsers through native Cmd+V without activating renderer accessibility, while leaving the transcription on the clipboard for manual recovery
 2026-08-13: Add append-only JSONL transcription history with timestamp metadata, trailing-record repair, a 5 MiB cap, and the newest five Unicode-safe summaries as exact tray clipboard-copy actions
+2026-08-14: Add an STT prompt lab with paired WAV/raw-transcript capture, human reference correction, full historical regression, WER and proper-noun metrics, coding-agent semantic review, compatible-run deltas, and JSON-only reports

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,4 +59,4 @@ Implementation plans and technical specs for each feature.
 | [30-compile-time-platform-interface.md](plan/30-compile-time-platform-interface.md) | Implemented | Hide native icon, hotkey, and text-delivery details behind one compile-time-selected platform interface |
 | [31-macos-chromium-paste-fallback.md](plan/31-macos-chromium-paste-fallback.md) | Implemented | Route identified Chromium browsers through recoverable native paste without activating web accessibility |
 | [32-transcription-history.md](plan/32-transcription-history.md) | In progress | Persist a bounded transcription history and expose the newest five entries as exact clipboard-copy actions in the tray menu |
-| [33-stt-prompt-regression-suite.md](plan/33-stt-prompt-regression-suite.md) | Approved | Capture corrected audio datasets and rerun STT prompts with local metrics plus agent-reviewed LLM scoring in JSON |
+| [33-stt-prompt-regression-suite.md](plan/33-stt-prompt-regression-suite.md) | In progress | Capture corrected audio datasets and rerun STT prompts with local metrics plus agent-reviewed LLM scoring in JSON |

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,3 +59,4 @@ Implementation plans and technical specs for each feature.
 | [30-compile-time-platform-interface.md](plan/30-compile-time-platform-interface.md) | Implemented | Hide native icon, hotkey, and text-delivery details behind one compile-time-selected platform interface |
 | [31-macos-chromium-paste-fallback.md](plan/31-macos-chromium-paste-fallback.md) | Implemented | Route identified Chromium browsers through recoverable native paste without activating web accessibility |
 | [32-transcription-history.md](plan/32-transcription-history.md) | In progress | Persist a bounded transcription history and expose the newest five entries as exact clipboard-copy actions in the tray menu |
+| [33-stt-prompt-regression-suite.md](plan/33-stt-prompt-regression-suite.md) | Approved | Capture corrected audio datasets and rerun STT prompts with local metrics plus agent-reviewed LLM scoring in JSON |

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Module-level design docs covering structs, methods, and dependencies.
 | [transcriber.md](architecture/transcriber.md) | Transcription trait, `ApiTranscriber` (OpenAI-compatible API), chunking, retry, text merging |
 | [platform.md](architecture/platform.md) | Compile-time desktop interface for native input, status/history menus, config paths, text delivery, and clipboard copy |
 | [postprocess.md](architecture/postprocess.md) | Post-processing — concrete processor facade, LLM integration, preheat/conservative sessions |
+| [prompt-lab.md](architecture/prompt-lab.md) | STT prompt dataset capture, deterministic local metrics, agent review, and JSON report lifecycle |
 
 ## Examples
 
@@ -59,4 +60,4 @@ Implementation plans and technical specs for each feature.
 | [30-compile-time-platform-interface.md](plan/30-compile-time-platform-interface.md) | Implemented | Hide native icon, hotkey, and text-delivery details behind one compile-time-selected platform interface |
 | [31-macos-chromium-paste-fallback.md](plan/31-macos-chromium-paste-fallback.md) | Implemented | Route identified Chromium browsers through recoverable native paste without activating web accessibility |
 | [32-transcription-history.md](plan/32-transcription-history.md) | In progress | Persist a bounded transcription history and expose the newest five entries as exact clipboard-copy actions in the tray menu |
-| [33-stt-prompt-regression-suite.md](plan/33-stt-prompt-regression-suite.md) | In progress | Capture corrected audio datasets and rerun STT prompts with local metrics plus agent-reviewed LLM scoring in JSON |
+| [33-stt-prompt-regression-suite.md](plan/33-stt-prompt-regression-suite.md) | Implemented | Capture corrected audio datasets and rerun STT prompts with local metrics plus agent-reviewed LLM scoring in JSON |

--- a/docs/architecture/audio.md
+++ b/docs/architecture/audio.md
@@ -60,6 +60,14 @@ from an old `SessionId` are ignored after stop or session replacement. On stop, 
 slices and the final tail are encoded the same way.
 `RecorderStopOutcome::Stopped` therefore owns `Vec<WavChunk>` rather than file paths.
 
+Prompt-lab recording optionally clones these immutable chunks into a session-owned, capacity-two
+archive channel after they leave the recorder. Its worker validates one stable integer 16-bit WAV
+format, decodes the chunks in arrival order, and writes their PCM samples into one final dataset
+WAV. Stop-time chunks use the same path. The callback remains free of disk work, and normal listener
+mode does not construct the archive channel or worker. Closing a completed session finalizes the WAV
+before its digest and JSON sidecar are written; an interrupted process may leave a partial or
+unreferenced WAV for dataset validation to report.
+
 ## Local WAV Reader
 
 `WavChunkReader::open(path, duration_limit, size_limit)` opens the source once. Its `chunks()` method

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -50,6 +50,8 @@ No subcommand runs the recording listener. Other commands are:
 | `prompt-lab record` | Reuse native recording controls to archive WAV/raw-STT sample pairs |
 | `prompt-lab sample list/show/correct` | Inspect and curate human references and proper nouns |
 | `prompt-lab dataset validate` | Verify dataset schemas, WAV readability, paths, and digests |
+| `prompt-lab evaluate` | Freshly transcribe every ready WAV and write local metrics to JSON |
+| `prompt-lab report apply-review` | Validate coding-agent scores and finalize all three gates |
 
 `config set` parses the canonical field type and saves the updated document without running cross-field business validation. This permits incremental configuration; `config check` or the command that consumes a profile reports incomplete runtime configuration. Secret and schema fields are read-only. Legacy aliases are rejected.
 
@@ -149,3 +151,9 @@ already in progress.
 API and Local backends reuse the same recording/orchestration pipeline; no endpoint rewriting or
 persisted-document mutation occurs in the application layer. `main.rs` only delegates process
 startup to the library entry point.
+
+Prompt-lab evaluation is a CLI-only workflow: it does not construct winit, a post-processor,
+history, or native typing. It resolves the configured backend, replaces only the consumed
+`TranscriberConfig` prompt in memory, sequentially feeds verified historical WAVs through the
+production offline chunk reader and transcriber, and writes one JSON report. Coding-agent review is
+a separate local JSON validation/rewrite step and makes no inference request.

--- a/docs/architecture/core.md
+++ b/docs/architecture/core.md
@@ -47,6 +47,9 @@ No subcommand runs the recording listener. Other commands are:
 | `config list/get/set` | Use canonical dotted keys from the single field catalog |
 | `local install/start/stop/status` | Manage the Local runtime; stop only requires Local paths |
 | `convert <wav>` | Resolve the persisted backend and transcribe a WAV file |
+| `prompt-lab record` | Reuse native recording controls to archive WAV/raw-STT sample pairs |
+| `prompt-lab sample list/show/correct` | Inspect and curate human references and proper nouns |
+| `prompt-lab dataset validate` | Verify dataset schemas, WAV readability, paths, and digests |
 
 `config set` parses the canonical field type and saves the updated document without running cross-field business validation. This permits incremental configuration; `config check` or the command that consumes a profile reports incomplete runtime configuration. Secret and schema fields are read-only. Legacy aliases are rejected.
 
@@ -111,9 +114,12 @@ The machine consumes source-free requests plus `SessionStarted`, `SessionStartFa
 
 `application::listener` executes `StartSession` as an all-or-nothing recorder/orchestrator
 acquisition with rollback. `StopSession` stops the recorder and submits tail chunks in order, then
-starts a session-scoped background task for orchestrator convergence, post-processing, and text
-history persistence followed by injection. `HistoryTyper` emits one `HistorySaved` event after a
-successful append, and the main-thread tray prepends that text to its five-entry cache. The machine
+starts a session-scoped background task for orchestrator convergence and the selected application
+output. Normal delivery performs post-processing and text history persistence followed by
+injection. Prompt-lab capture instead finalizes its archived WAV and stores the raw merged STT
+result plus credential-free request metadata in the matching sample sidecar; it constructs no
+post-processor or history typer. `HistoryTyper` emits one `HistorySaved` event after a successful
+normal append, and the main-thread tray prepends that text to its five-entry cache. The machine
 remains in `Stopping` until the separate finalization event returns.
 
 Exit is represented as `ShutdownRequested`. It cancels recorder/orchestrator work, resets tray state, suppresses final text injection, and exits only after `ReadyToExit` is emitted.

--- a/docs/architecture/prompt-lab.md
+++ b/docs/architecture/prompt-lab.md
@@ -1,0 +1,94 @@
+# STT Prompt Lab Architecture
+
+## Purpose and Boundary
+
+Prompt lab builds a reusable, human-corrected audio dataset and evaluates the prompt sent directly
+to the configured STT endpoint. It does not construct `PostProcessor`, write normal
+`history.jsonl`, inject text, call a Judge service, or persist a candidate prompt into application
+configuration. One prompt-lab process owns a dataset at a time.
+
+## Modules
+
+```text
+src/prompt_lab.rs
+src/prompt_lab/
+  capture.rs       — session-owned archive worker and sample publication
+  dataset.rs       — strict manifests/sidecars, correction, validation, scoring digest
+  metrics.rs       — versioned WER alignment and proper-noun matching
+  regression.rs    — fresh WAV execution, report contract, comparison
+  review.rs        — coding-agent input validation and final gates
+src/application/prompt_lab.rs — CLI/config/backend assembly
+```
+
+The domain modules contain no winit or native platform types. The application layer reuses the
+existing listener only for capture controls and assembles offline regression from the resolved STT
+profile, `WavChunkReader`, `ApiTranscriber`, and the shared language-aware merge helper.
+
+## Dataset and Capture
+
+An explicit dataset root contains `dataset.json`, `audio/<sample-id>.wav`,
+`samples/<sample-id>.json`, and `runs/<run-id>.json`. The root and its three owned directories are
+canonicalized; symlink storage, path escape, unexpected fields, invalid versions, malformed WAVs,
+and digest mismatches are rejected or reported. IDs combine a Unix-millisecond timestamp and a
+process sequence.
+
+Prompt-lab listener output clones complete immutable `WavChunk` values into a bounded archive
+worker. The worker validates a stable 16-bit integer WAV format and appends decoded samples in
+session order to one final WAV. Finalization closes that writer, hashes the WAV, and directly writes
+one sidecar containing raw merged STT output and sanitized endpoint/model/language/temperature/
+prompt metadata. A valid WAV is retained even when STT is partial or failed. Only `sample correct`
+can replace the pending reference with validated human text and proper-noun annotations.
+
+Persistence is intentionally direct rather than atomic. A process interruption can leave a
+truncated WAV/JSON or an unreferenced file; `dataset validate` reports it and performs no repair.
+
+## Scoring Snapshot and Execution
+
+Evaluation first validates all sidecars and snapshots every valid `ready` sample in stable ID
+order. Its dataset digest covers only the scoring-policy version, IDs, WAV SHA-256 values, human
+references, and proper-noun annotations. Initial capture text is excluded. At least one ready sample,
+one scoreable reference token, and one expected proper-noun occurrence are required.
+
+The resolved `TranscriberConfig` is consumed by an in-memory prompt override. For each snapshot WAV,
+the runner recreates production-sized chunks, makes fresh sequential STT requests, merges ordered
+results, and computes local metrics. It continues after a sample failure so one `incomplete` report
+contains all reachable outcomes, but returns nonzero and cannot be reviewed or compared as a
+baseline. References never enter an STT request.
+
+## Metrics
+
+The scoring policy is versioned as `stt-prompt-scoring-v1`:
+
+- WER applies NFKC first. A reference containing Han characters selects the bundled Jieba
+  dictionary with HMM disabled for both sides; other references use Unicode word boundaries.
+  Punctuation is excluded, tokens are case-folded, Levenshtein backtracking records every equal,
+  substitution, deletion, and insertion, and the aggregate is a micro-average.
+- Proper-noun matching applies NFKC, canonical plus accepted forms, each annotation's case policy,
+  alphanumeric token boundaries, expected-count caps, and global longest-first overlap consumption.
+  The aggregate is matched expected occurrences divided by all expected occurrences.
+- Semantic similarity is not computed locally. The coding agent applies rubric
+  `semantic-equivalence-v1` to each reference/hypothesis pair and supplies an integer score, reason,
+  and structured differences. The aggregate is the unweighted sample mean.
+
+## Two-Phase JSON Report
+
+A successful local run directly writes schema-v1 JSON with status `awaiting_agent_review` and null
+LLM/gate fields. Agent review input must use the exact run ID and rubric, contain each sample ID once,
+use scores in `0..=100`, and provide non-empty reasons plus differences for every score below 100.
+The review module validates the entire input and unchanged report contract before any write, embeds
+the review content, calculates the mean and inclusive gates, then directly rewrites that report as
+`complete`. Invalid input leaves the report byte-for-byte unchanged.
+
+`meets_targets` is true only when WER is at or below its maximum and both 100-point metrics are at
+or above their minima. There is no combined score. Optional comparison requires a complete report
+with identical dataset identity, ready IDs, endpoint/model/language/temperature, scoring policy, and
+rubric before STT starts. Local deltas are written in phase one; semantic deltas are filled when the
+new agent review is applied.
+
+## Privacy
+
+Audio and all transcripts are plaintext. Audio is sent to the configured STT service; during an
+explicit tuning task the coding agent reads reference and hypothesis text from the local report.
+Endpoint metadata has userinfo, query, and fragment components removed, and neither dataset nor run
+JSON can contain `ApiAuth`. No external Judge request, credential, model setting, Markdown mirror,
+lock file, or automatic crash recovery exists.

--- a/docs/architecture/transcriber.md
+++ b/docs/architecture/transcriber.md
@@ -15,13 +15,20 @@ pub trait Transcriber: Send + Sync {
 
 `WavChunk` is produced by either `AudioRecorder` or `WavChunkReader`. Realtime ordered merging is
 owned by `SessionOrchestrator`; offline conversion iterates `WavChunkReader` and uses the shared
-`text::merge_texts` helper.
+`text::merge_texts` helper. Prompt-lab regression follows the same offline chunk reader and merge
+path but deliberately bypasses post-processing.
 
 ## `ApiTranscriber`
 
 `ApiTranscriber` is compatible with OpenAI-style multipart transcription endpoints. Construction
 consumes endpoint, authentication, model, language, prompt, and temperature. Retry policy is owned
 by the module; chunk duration and size limits are owned by the audio producer.
+
+`TranscriberConfig::with_prompt` consumes one already resolved config and replaces only its prompt
+in memory. Prompt-lab uses this for configured baselines, prompt files, and explicit no-prompt runs;
+the persisted config document is never mutated. `metadata()` returns endpoint/model/language/prompt/
+temperature for dataset and run JSON while removing endpoint userinfo, query, and fragment data and
+never exposing `ApiAuth`.
 
 Each request builds a multipart form containing `model`, `temperature`,
 `response_format=verbose_json`, optional `language` and `prompt`, plus an `audio.wav` file part. The

--- a/docs/plan/33-stt-prompt-regression-suite.md
+++ b/docs/plan/33-stt-prompt-regression-suite.md
@@ -1,0 +1,635 @@
+# 33 - STT Prompt Regression Suite
+
+## Status
+
+**Approved on 2026-08-14; implementation has not started.** No product or test code has been
+written for this feature yet. This document defines a local dataset-capture and regression workflow
+for the prompt sent directly to the STT endpoint. It does not evaluate or modify the existing LLM
+post-processing prompt.
+
+## Context
+
+ViberWhisper already sends `transcription.prompt` with every OpenAI-compatible multipart STT
+request, but prompt changes are currently judged from ad-hoc live recordings. There is no stable
+way to retain the audio behind an observed result, correct that result into a reference transcript,
+rerun all prior recordings with a candidate prompt, or distinguish a real improvement from a
+regression on an older sample.
+
+The requested workflow has two uses:
+
+1. Run a dedicated recording mode that saves one complete WAV and its raw STT result under one
+   sample ID. Afterwards, correct samples one by one and annotate expected proper nouns to build a
+   reusable test dataset.
+2. When prompt tuning is requested, rerun every ready historical recording through STT with a new
+   prompt, compare each result with its human reference, emit one JSON report, and let the coding
+   agent inspect that report, explain the result, revise the prompt, and repeat until all requested
+   thresholds pass or further prompt-only progress is no longer credible.
+
+Only the STT prompt changes between comparable runs. Post-processing is never invoked, old STT
+outputs are never reused as candidate results, and reference transcripts are never sent to the STT
+endpoint.
+
+## Goals
+
+1. Add a cross-platform prompt-lab recording mode that reuses the existing tray and Hold/Toggle
+   controls while saving one complete WAV and one raw STT capture record per completed session.
+2. Keep audio, initial recognition, corrected reference text, and proper-noun annotations linked by
+   a collision-safe sample ID and verifiable audio digest.
+3. Provide explicit sample list/show/correct/validate commands so a pending recording can be
+   corrected repeatedly and becomes regression-ready only after validation.
+4. Evaluate every ready sample against an in-memory candidate STT prompt without mutating the
+   persisted `transcription.prompt` setting.
+5. Calculate word error rate and proper-noun accuracy locally, then let the coding agent apply the
+   fixed rubric to every reference/result pair and supply the third metric: an LLM similarity score
+   capped at 100.
+6. Save every run as a versioned JSON report containing aggregate metrics, per-sample results,
+   structured differences, request metadata, dataset identity, thresholds, and failure details.
+7. Support an optional comparison to a compatible prior run so prompt improvements and regressions
+   are visible per sample without treating the prior STT output as a cache.
+8. Make the report and CLI deterministic enough for a coding agent to run the loop, read the JSON,
+   explain the outcome to the user, and prepare the next prompt candidate.
+9. Preserve the normal listener, transcription history, text injection, post-processing, and
+   configuration behavior outside explicit `prompt-lab` commands.
+
+## Non-goals
+
+- Automatically asking an LLM inside ViberWhisper to rewrite the STT prompt. Prompt diagnosis,
+  editing, stopping for a plateau, and final user communication remain agent-driven.
+- Evaluating or tuning `post_process.prompt`, or passing STT output through `PostProcessor` during
+  capture or regression.
+- Generating Markdown, HTML, dashboards, charts, or a GUI report. The suite writes JSON only; the
+  coding agent supplies the human-readable summary in conversation.
+- Adding built-in audio playback or a graphical annotation editor. Sample commands expose the
+  exact WAV and sidecar paths; any normal audio player can play the WAV.
+- Treating the initial capture transcript as ground truth. Only a validated human reference is
+  scored.
+- Caching a transcription across candidate prompts, embedding reference answers in an STT prompt,
+  or evaluating only the samples that failed in the preceding run.
+- Combining the three metrics into a weighted score. All configured thresholds must pass
+  independently.
+- Calling a separately configured Judge API/model, storing Judge credentials, or reusing the
+  post-processing LLM as an evaluator. The coding agent performs semantic review in the first
+  version.
+- Adding automatic train/holdout splitting, repeated reviewer voting, or concurrent STT scheduling
+  in the first version.
+- Supporting simultaneous prompt-lab processes against one dataset, filesystem locking, atomic
+  publication, or crash-safe recovery. One process owns a dataset at a time; interrupted files are
+  detected and handled manually.
+- Automatically writing the winning prompt back to `config.json`. Promotion remains an explicit
+  user decision after reviewing the result.
+
+## User Workflow
+
+### 1. Capture recordings
+
+The dataset path is always explicit so private audio is not silently placed in the repository or
+application-data directory:
+
+```text
+viberwhisper prompt-lab record --dataset /path/to/my-stt-dataset
+```
+
+This command starts the existing native tray/hotkey interaction in prompt-lab mode. Each completed
+Hold or Toggle session:
+
+1. archives the complete microphone session as one WAV;
+2. transcribes it with the current configured STT backend and prompt;
+3. stores the raw STT result and sanitized request metadata in the matching sample sidecar; and
+4. prints the sample ID plus audio/sidecar paths.
+
+Prompt-lab recording does not post-process, append normal `history.jsonl`, or inject text into the
+focused application. A partial or failed initial STT request is recorded as capture metadata rather
+than discarding a valid WAV; the user may still supply a reference and use that audio in later
+regressions.
+
+### 2. Correct and annotate samples
+
+The CLI exposes a small curation surface:
+
+```text
+viberwhisper prompt-lab sample list --dataset /path/to/my-stt-dataset --status pending
+viberwhisper prompt-lab sample show --dataset /path/to/my-stt-dataset <sample-id>
+viberwhisper prompt-lab sample correct --dataset /path/to/my-stt-dataset <sample-id> \
+  --reference-file expected.txt --proper-nouns-file proper-nouns.json
+viberwhisper prompt-lab dataset validate --dataset /path/to/my-stt-dataset
+```
+
+`correct` also accepts a short inline `--reference`; inline text and `--reference-file` are mutually
+exclusive. The optional proper-nouns file is a JSON array. Rerunning `correct` validates the full
+replacement in memory and then rewrites the same sidecar directly. A non-empty reference, valid
+annotations, an existing readable WAV, and a matching audio digest move the sample to `ready`;
+otherwise it remains `pending` or is reported as invalid. Regression never silently treats the
+captured STT output as the reference.
+
+### 3. Run a baseline or candidate prompt
+
+```text
+viberwhisper prompt-lab evaluate --dataset /path/to/my-stt-dataset \
+  --prompt-file prompts/candidate.txt \
+  --max-wer-percent 8 \
+  --min-llm-score 95 \
+  --min-proper-noun-percent 98
+```
+
+Omitting `--prompt-file` uses the configured STT prompt for a baseline. `--no-prompt` explicitly
+omits the multipart prompt field; it is mutually exclusive with `--prompt-file`. A candidate file
+must contain valid, non-empty UTF-8, and the exact content sent to STT is embedded in the report.
+The file may be edited between runs, while persisted application configuration remains unchanged.
+
+The STT backend, model, language, temperature, authentication, and fixed chunking/retry policies
+come from the same resolved profile as `convert`; only the prompt is overridden. Every invocation
+opens every ready WAV, recreates its normal chunks, and issues fresh STT requests before scoring.
+No post-processing is constructed.
+
+After fresh STT plus the two local metrics finish, the report has
+`status="awaiting_agent_review"`, contains every reference/result pair, and leaves the per-sample
+LLM review fields empty. The coding agent reads that JSON, applies the fixed rubric itself, and
+creates a small versioned review JSON containing one score, reason, and structured difference list
+for every sample. The suite then validates and incorporates it into the same run report:
+
+```text
+viberwhisper prompt-lab report apply-review \
+  --report /path/to/my-stt-dataset/runs/<run-id>.json \
+  --review /path/to/<run-id>.agent-review.json
+```
+
+`apply-review` requires the exact run ID and complete sample-ID coverage, rejects duplicates or
+scores outside `0..=100`, calculates the LLM mean plus all three gates, and rewrites the
+run to `status="complete"`. The review input is not a second generated report; it is agent-authored
+structured input and its complete content is incorporated into the canonical run JSON. No Judge
+URL, model, API key, or external Judge request exists in this version.
+
+An optional `--compare-to <prior-run.json>` adds compatible run and per-sample deltas. Compatibility
+requires the same dataset digest and ready sample IDs, STT endpoint/model/language/temperature,
+scoring-policy version, and agent-review rubric version. The prompt is expected to differ.
+The prior report must already be complete. Incompatible comparisons fail before STT calls instead
+of producing misleading deltas; LLM-score deltas are added when the new agent review is applied.
+
+The default report path is `<dataset>/runs/<run-id>.json`; `--output` may choose another JSON path.
+Progress and the final report path may be printed to the terminal, but no prose or Markdown report
+is generated.
+
+One completed recording is one scored utterance and one per-sample result. A recording may contain
+multiple grammatical sentences, but the first version does not guess sentence boundaries or align
+independently segmented sentences; its WER alignment and LLM difference list still expose the exact
+within-recording differences.
+
+### 4. Agent-driven tuning loop
+
+For each requested tuning task, the coding agent will:
+
+1. run a baseline against all ready samples with the user's three thresholds;
+2. read the awaiting-review JSON, judge each reference/result pair under the fixed 0–100 rubric,
+   apply the structured agent review, and verify the resulting three aggregate values;
+3. report failed thresholds, important sentence-level differences, and likely error classes;
+4. prepare a new STT prompt candidate without copying reference answers into it;
+5. rerun the full ready dataset, normally comparing against the current best compatible run;
+6. explain aggregate changes plus improved and regressed samples; and
+7. repeat until all three gates pass or stop when repeated candidates plateau, trade improvements
+   for material regressions, or leave errors attributable to audio/model capability rather than the
+   STT prompt.
+
+The CLI records whether thresholds pass; the agent owns the judgment that further prompt-only work
+is no longer productive.
+
+## Dataset Design
+
+### Directory layout
+
+```text
+my-stt-dataset/
+  dataset.json
+  audio/
+    <sample-id>.wav
+  samples/
+    <sample-id>.json
+  runs/
+    <run-id>.json
+```
+
+`dataset.json` contains only dataset-level schema/version metadata. One sidecar per sample avoids
+rewriting an ever-growing manifest during correction and makes the WAV/metadata relationship
+obvious. All paths stored in dataset files are relative and must remain underneath the canonical
+dataset root; absolute paths, `..` traversal, symlink escape, duplicate IDs, and duplicate audio
+ownership are rejected.
+
+The sample sidecar has this logical shape (exact field naming may be refined without changing the
+contract):
+
+```json
+{
+  "schema_version": 1,
+  "id": "sample-1786612345678-1",
+  "audio": {
+    "path": "audio/sample-1786612345678-1.wav",
+    "sha256": "..."
+  },
+  "capture": {
+    "created_at_unix_ms": 1786612345678,
+    "transcription": {
+      "status": "success",
+      "text": "初次识别结果",
+      "model": "whisper-large-v3-turbo",
+      "language": "zh",
+      "temperature": 0,
+      "prompt": "采集时使用的 STT prompt"
+    }
+  },
+  "reference": {
+    "status": "ready",
+    "text": "人工校正结果",
+    "proper_nouns": [
+      {
+        "canonical": "ViberWhisper",
+        "accepted": ["Viber Whisper"],
+        "case_sensitive": false,
+        "expected_occurrences": 1
+      }
+    ]
+  }
+}
+```
+
+The canonical form is always accepted and need not be repeated in `accepted`. Expected occurrence
+counts are explicit so repeated names have an unambiguous denominator. Validation also verifies
+that the canonical/accepted forms occur that many times in the reference. It rejects empty or
+duplicate accepted forms, zero/mismatched expected counts, ambiguous duplicate forms within one
+sample, empty ready references, missing/mismatched audio, non-finite numeric metadata, and unknown
+schema fields.
+
+Audio and text are deliberately plaintext. Documentation will state that the configured STT service
+receives audio and that the coding agent reads reference/candidate text from the local JSON while
+performing the requested task. No additional Judge service is contacted. The dataset must contain
+only material the user is willing to expose through those two paths. STT endpoint metadata is
+sanitized before persistence by removing userinfo, query, and fragment components.
+
+### Single-process persistence and interruption behavior
+
+The first version assumes exactly one prompt-lab process owns a dataset at a time. Recording,
+correction, evaluation, and review application must not overlap with another process using the same
+root. The suite does not add a lock file, reader/writer coordination, generation checks, or atomic
+replace protocol. This is an explicit operational contract rather than best-effort concurrency.
+
+Prompt-lab mode adds an optional session archive beside the existing live `WavChunk` path. The
+audio callback remains free of disk I/O and network work. As complete chunks leave the recorder,
+shared immutable chunk bytes are sent to a session-owned archive worker, which validates a stable
+WAV format and appends samples directly to the sample's final WAV path. The stop-time tail follows
+the same path. Finalization closes the writer, computes the digest, and writes/updates the matching
+sample sidecar directly.
+
+Capture state is keyed by `SessionId`; stale chunks and stale finalization cannot attach to another
+sample. A process interruption may leave a truncated WAV, malformed JSON, an unreferenced WAV, or a
+sidecar whose digest no longer matches. `dataset validate` reports these conditions without repair;
+they can never become `ready` or enter regression until the user deletes the damaged sample or
+records/corrects it again. Normal listener mode does not construct the archive worker and keeps its
+current in-memory behavior and cost.
+
+## Scoring Contract
+
+### 1. Word error rate
+
+Each ready sample is normalized and tokenized by one versioned, deterministic policy:
+
+- Unicode compatibility normalization is applied first;
+- punctuation and whitespace separate tokens but do not become scored words;
+- a reference containing Han characters uses a fixed bundled Jieba dictionary with HMM disabled;
+- other text uses Unicode word boundaries; and
+- Latin text is compared case-insensitively while original text remains in the report.
+
+The scorer uses standard Levenshtein alignment and records substitutions (`S`), deletions (`D`),
+insertions (`I`), and reference word count (`N`). Per sample:
+
+```text
+WER = (S + D + I) / N
+```
+
+Dataset WER is the micro-average `(sum S + sum D + sum I) / sum N`, expressed as a percentage.
+It is not clamped and may exceed 100% when insertions outnumber reference words. Empty ready
+references are invalid, avoiding an undefined denominator. The report preserves the aligned edit
+operations needed to explain each difference.
+
+### 2. LLM similarity score
+
+The coding agent evaluates each human reference/fresh STT pair after the program writes the initial
+run JSON. While scoring, it uses only those two texts and a fixed, versioned rubric; it must not use
+the STT prompt, proper-noun annotations, prior score, thresholds, or baseline result to justify a
+score. The rubric defines:
+
+- `100`: meaning and factual content are fully equivalent; only immaterial formatting differs;
+- `90–99`: very small non-semantic wording, punctuation, or casing differences;
+- `70–89`: core meaning is retained but one or more recognizable errors remain;
+- `40–69`: omissions/substitutions materially change part of the meaning;
+- `1–39`: most important content is wrong or missing; and
+- `0`: no usable correspondence.
+
+The agent-authored review JSON must contain an integer `score` in `0..=100`, a concise reason, and
+structured difference entries for every sample. `apply-review` validates exact run/sample identity
+and complete coverage; invalid or out-of-range input never changes the canonical report. Dataset
+LLM score is the arithmetic mean of all accepted per-sample scores, so each completed recording has
+equal weight.
+
+The completed report records `review_source="coding_agent"` and the rubric version, but no Judge
+endpoint, model, temperature, or credential. The same rubric version is required for comparable
+runs. Because agent judgment can still vary, reasons and structured differences remain stored next
+to every score for review rather than presenting the number as a deterministic local metric.
+
+### 3. Proper-noun accuracy
+
+For each annotation, the scorer searches the fresh STT text for the canonical form or any accepted
+form under its declared case policy. Compatibility normalization is applied; alphanumeric forms
+must respect token boundaries, and overlapping matches are consumed longest-first so one span
+cannot satisfy two expected occurrences.
+
+Per annotation, matches are capped at `expected_occurrences`. Dataset proper-noun accuracy is the
+micro-average:
+
+```text
+proper noun accuracy = sum matched expected occurrences / sum expected occurrences
+```
+
+Samples without annotations do not enter this denominator. Because all three thresholds are
+required, evaluation preflight rejects a ready dataset containing zero expected proper-noun
+occurrences instead of reporting a misleading 100%. Per-sample JSON lists matched and missed
+canonical names and the accepted form that matched.
+
+### Three independent gates
+
+The report contains no combined score. A complete run sets `meets_targets=true` only when:
+
+```text
+WER percentage <= max_wer_percent
+LLM mean score >= min_llm_score
+proper-noun percentage >= min_proper_noun_percent
+```
+
+Thresholds are validated before requests: WER must be non-negative, and both 100-point metrics must
+be in `0..=100`.
+
+## Regression Execution and Failure Semantics
+
+Evaluation snapshots and validates the sorted ready sample set before making any API call. It
+computes a dataset digest only from scoring inputs: schema/scoring version, ready sample IDs, audio
+SHA-256 values, reference text, and proper-noun annotations. Initial capture transcripts and other
+non-scoring metadata cannot invalidate a comparison. Later scoring-input changes cannot silently
+alter the identity of an in-flight run.
+
+Each sample is then processed in stable ID order:
+
+```text
+historical WAV
+  -> current production WavChunkReader policy
+  -> fresh STT requests carrying the candidate prompt
+  -> existing language-aware chunk merge
+  -> WER + proper-noun scorer
+  -> awaiting-agent-review JSON
+  -> agent scores every reference/result pair
+  -> validated complete JSON
+```
+
+The first version is sequential to make provider load, report ordering, failure behavior, and cost
+obvious. Existing STT timeout/retry behavior still applies to each chunk. There is no second HTTP
+client or external semantic-evaluation request.
+
+Processing continues after a sample failure so the report captures every reachable issue. If any
+ready sample fails STT or merge, the run is written with `status="incomplete"`,
+`meets_targets=null`, and a non-empty failures array, then the command exits nonzero. Aggregate
+local values may be included as diagnostics but the report cannot accept agent review, compare
+against thresholds, or serve as a baseline. When all fresh STT results and local metrics succeed,
+the command exits successfully with `status="awaiting_agent_review"`; it remains unable to pass or
+serve as a comparison source until a valid complete agent review is applied.
+
+## JSON Run Report
+
+The versioned report contains:
+
+- run ID, timestamps, `incomplete`/`awaiting_agent_review`/`complete` status, and scoring/rubric
+  versions;
+- dataset digest, ready sample IDs, and pending/invalid sample counts;
+- sanitized STT endpoint, model, language, temperature, exact candidate prompt, and prompt digest;
+- the three requested thresholds;
+- WER edit totals and micro-average percentage;
+- proper-noun matched/expected totals and micro-average percentage;
+- empty agent-review fields while awaiting review, then review source/rubric, mean LLM score, scored
+  sample count, per-sample score/reason/differences, and review timestamp after `apply-review`;
+- `meets_targets` plus the individual gate results after review;
+- for every sample: audio digest/path, reference, fresh hypothesis, WER alignment/counts,
+  proper-noun matches/misses, agent review when present, and any error; and
+- when requested, compatible aggregate and per-sample deltas against the prior run.
+
+Reports and capture sidecars never contain STT credentials. The single owning process writes
+pretty-printed JSON directly to its final path and rewrites that path after agent review. An
+interrupted/malformed report is rejected on the next read and cannot serve as a comparison
+baseline; there is no automatic recovery or Markdown mirror.
+
+## Architecture and Module Layout
+
+```text
+src/
+  prompt_lab.rs                    — domain facade, common errors, versioned public contracts
+  prompt_lab/
+    dataset.rs                     — layout, sample schemas, direct correction, validation, digest
+    capture.rs                     — session archive worker and capture result persistence
+    metrics.rs                     — normalization, WER alignment, proper-noun matching
+    review.rs                      — agent-review schema, validation, aggregation, report finalizing
+    regression.rs                  — full-dataset runner, thresholds, comparison, JSON report
+  application/
+    prompt_lab.rs                  — CLI command handlers and prompt-lab listener assembly
+```
+
+`core::cli` only parses command intent. `application::prompt_lab` loads configuration, resolves the
+selected backend, starts Local when needed, and coordinates domain services. Dataset validation,
+metrics, agent-review validation, and report schemas do not depend on winit or native platform
+types.
+
+The normal listener and prompt-lab recorder share the recording state machine, tray/hotkey mapping,
+audio recorder, and session orchestrator. A small application-private listener output mode keeps
+normal final delivery (`PostProcessor` -> history -> native typer) separate from prompt-lab capture
+(`raw STT result` -> sample store). It carries `SessionId` explicitly and does not overload
+`TextTyper` with dataset persistence.
+
+`TranscriberConfig` remains module-owned. Runtime assembly adds a prompt-lab constructor that can
+replace only its prompt in memory and also returns redacted metadata for the report. The persisted
+v2 configuration schema and field catalog do not gain prompt-lab paths, thresholds, or reviewer
+configuration.
+
+## Planned Change Stack
+
+The approved plan remains the first change. Implementation is expected to use these natural child
+boundaries; they may be combined only if review shows that a boundary has no standalone behavior or
+rollback value.
+
+### 1. `feat(prompt-lab): collect and curate STT samples`
+
+- add dataset schemas, path containment, validation, digesting, and single-process sidecar
+  correction;
+- add the session-scoped WAV archive and prompt-lab listener output mode;
+- add `record`, `sample list/show/correct`, and `dataset validate` commands;
+- prove prompt-lab capture saves raw STT without post-processing, normal history, or injection;
+- keep capture/dataset tests and the README/audio/core architecture updates that describe this
+  available behavior in the same change.
+
+This change is independently useful as a reusable, human-corrected audio dataset builder.
+
+### 2. `feat(prompt-lab): score full prompt regressions`
+
+- add the in-memory prompt override, full historical-WAV runner, three metric implementations,
+  agent-review application, thresholds, compatible-run comparison, and direct two-phase JSON
+  reports;
+- add focused metric/review/report tests plus end-to-end fake-STT regression tests;
+- add the prompt-lab architecture document, documentation index entry, final README workflow,
+  `AGENTS.md` structure update, plan status, and changelog entry.
+
+This change depends on the dataset contract from change 1 and is independently revertible without
+invalidating already captured WAV/reference samples.
+
+## File Impact
+
+| File | Planned change |
+|---|---|
+| `Cargo.toml`, `Cargo.lock` | Add narrowly scoped hashing, Unicode normalization/boundary, and deterministic Chinese tokenization dependencies if the standard library cannot satisfy the locked scoring contract. |
+| `src/lib.rs` | Register the private prompt-lab domain module. |
+| `src/prompt_lab.rs`, `src/prompt_lab/*.rs` | Add dataset, capture, local metrics, agent-review validation, regression, comparison, errors, and versioned JSON contracts. |
+| `src/core/cli.rs` | Parse the `prompt-lab` recording, sample, dataset, and evaluation command tree and its mutually exclusive prompt/reference inputs. |
+| `src/application.rs`, `src/application/prompt_lab.rs` | Dispatch prompt-lab workflows, apply agent reviews, start the selected STT backend, and print report/sample paths. |
+| `src/application/listener.rs`, `src/application/listener/event_loop.rs` | Reuse native recording controls with an explicit capture output mode while preserving normal delivery behavior. |
+| `src/audio.rs`, `src/audio/recorder.rs`, prompt-lab capture module | Feed complete session chunks to the optional archive worker without adding callback disk I/O or cost to normal mode. |
+| `src/runtime_config.rs`, `src/transcriber.rs`, `src/transcriber/api.rs` | Build an in-memory prompt override and redacted run metadata without mutating persisted configuration or changing STT wire behavior. |
+| `README.md` | Document dataset capture/correction/evaluation commands, three metric meanings, agent-driven loop, plaintext/privacy boundary, and JSON-only output. |
+| `docs/architecture/audio.md`, `docs/architecture/core.md`, `docs/architecture/transcriber.md` | Record optional archive ownership, CLI/runtime assembly, prompt override, and fresh-request regression behavior. |
+| `docs/architecture/prompt-lab.md`, `docs/README.md` | Add the focused architecture reference and make it discoverable. |
+| `AGENTS.md` | Add the prompt-lab modules and supported workflow to current project guidance after implementation. |
+| `docs/plan/33-stt-prompt-regression-suite.md` | Record approval, implementation status, and material deviations. |
+| `changelog` | Record the user-visible prompt-lab dataset and regression CLI. |
+
+`config.example.json`, the strict v2 schema, post-process architecture, normal `history.jsonl`
+format, native typer/tray contracts, packaging workflow, and release runbook are not expected to
+change. Prompt-lab settings are invocation-scoped, its dataset is user-selected, and no new
+production configuration key or packaged native asset is introduced.
+
+## Test Strategy
+
+Implementation starts with failing tests at each behavior boundary.
+
+### Dataset and correction
+
+- initialize a missing dataset and strictly reject unknown/newer schema versions;
+- allocate collision-safe IDs and keep every sidecar paired with exactly one contained WAV path;
+- reject absolute paths, parent traversal, symlink escape, duplicate IDs/audio ownership, missing
+  WAVs, and digest mismatches;
+- round-trip multilingual transcripts, newlines, quotes, accepted proper-noun forms, and repeated
+  occurrence counts exactly;
+- keep invalid corrections pending and perform no write until the replacement passes full
+  in-memory validation;
+- detect pending/invalid samples without allowing them into the ready-set digest; and
+- detect truncated WAVs, malformed/truncated sidecars, digest mismatches, and unreferenced WAVs
+  after an interrupted direct write without attempting automatic repair.
+
+### Capture mode
+
+- combine several same-format live/tail WAV chunks into one complete ordered recording;
+- reject or surface mixed/corrupt chunks without publishing a ready sample;
+- route archive chunks and finalization by `SessionId`, ignoring stale session data;
+- persist successful, partial, failed, and interrupted initial STT states without treating any as a
+  reference;
+- document and test the one-process-per-dataset precondition without adding a dataset lock;
+- prove capture output is raw STT and does not call post-processing, history persistence, or the
+  native typer; and
+- prove normal listener mode does not construct an archive worker and retains existing finalization,
+  history, injection, cancellation, and shutdown behavior.
+
+### Metrics
+
+- verify exact-match WER zero and known substitution/deletion/insertion alignments;
+- verify dataset WER uses summed edits/reference tokens rather than a mean of sample percentages;
+- cover Chinese segmentation, mixed CJK/Latin text, compatibility forms, punctuation, whitespace,
+  casing, repeated words, and WER above 100%;
+- cover proper-noun canonical/accepted forms, case policies, token boundaries, overlaps, repeated
+  expected occurrences, misses, and samples with no annotations;
+- reject a regression dataset with no proper-noun denominator; and
+- snapshot the scoring-policy version with deterministic fixture results so a tokenizer/rule change
+  must deliberately bump report compatibility.
+
+### Agent review
+
+- write `awaiting_agent_review` with empty review fields after successful STT/local scoring;
+- accept only a versioned review whose run ID and sample IDs exactly cover the target report;
+- parse strict integer scores plus non-empty reasons and structured differences for every sample;
+- reject missing/duplicate/unknown samples, malformed JSON, fractional/out-of-range scores, rubric
+  mismatch, incomplete target runs, and a second review of an already complete report;
+- leave the original report byte-for-byte unchanged after invalid review input; and
+- directly rewrite the report after full review validation, compute the LLM mean and three gates,
+  and mark it complete without any network call or reviewer credential.
+
+### Regression and reports
+
+- recreate chunks and issue fresh STT calls for every ready audio file on every run;
+- apply the candidate prompt to every multipart chunk while leaving model/language/temperature
+  unchanged and bypassing post-processing;
+- preserve stable sample ordering and exact reference/hypothesis/difference data in JSON;
+- calculate all three gates at their inclusive boundaries and never build a combined score;
+- write `incomplete` plus failures and exit nonzero when fresh STT cannot complete;
+- keep `meets_targets` null until a complete validated agent review is written;
+- validate comparison compatibility before requests and report improvements/regressions against a
+  compatible complete run; and
+- prove no Markdown/report sidecar and no persisted config mutation are produced.
+
+### Validation
+
+Before PR readiness, run:
+
+```text
+cargo fmt --check
+cargo test
+cargo check
+cargo clippy --all-targets -- -D warnings
+cargo build
+cargo check --target x86_64-pc-windows-gnu
+git diff --check
+```
+
+Interactive validation on macOS and Windows:
+
+1. Capture Hold and Toggle samples and verify each session creates one playable complete WAV plus
+   one matching sidecar without typing or entering normal history.
+2. Correct pending samples containing Chinese, English, repeated proper nouns, aliases, numbers,
+   and punctuation; verify list/show/validate status changes.
+3. Run a configured-prompt baseline and a different prompt candidate; inspect the JSON to confirm
+   every ready historical WAV was freshly transcribed and per-sample differences are complete.
+4. Compare compatible runs, then change one dataset sample and verify the old comparison is rejected.
+5. Trigger an STT failure and verify an incomplete JSON remains inspectable; then try invalid,
+   partial, and out-of-range agent reviews and verify none can produce a threshold result or mutate
+   the report.
+6. Apply a complete agent review, verify all three gates and prior-run deltas, and confirm the
+   dataset/report contain no API keys and no external Judge request is made.
+
+Hosted macOS and Windows CI must pass on both code-bearing changes before the draft PR becomes
+ready.
+
+## Acceptance Criteria
+
+- `prompt-lab record` uses existing native recording controls and saves one complete WAV plus one
+  raw initial STT record under the same collision-safe sample ID for every archiveable session.
+- Prompt-lab recording never invokes LLM post-processing, normal transcription history, or text
+  injection; normal listener behavior remains unchanged.
+- A sample becomes ready only through an explicit, validated human reference correction, and its
+  proper nouns support canonical spelling, accepted variants, case policy, and expected count.
+- Every evaluation uses all ready historical recordings, rereads their verified WAVs, makes fresh
+  STT requests with the candidate prompt, and never sends reference answers to STT.
+- Reports expose exactly the agreed primary metrics: micro-average WER, mean 0–100 LLM similarity,
+  and micro-average proper-noun accuracy. They do not combine them into a single score.
+- A run passes only when all three user-supplied thresholds pass; incomplete and
+  awaiting-agent-review runs cannot pass or serve as comparison baselines.
+- The coding agent, not a configured Judge API/model, supplies each 0–100 semantic score, reason,
+  and structured difference under a fixed versioned rubric; validated review application makes no
+  network call.
+- Each run produces one directly written, versioned JSON report that progresses from local results
+  awaiting agent review to final aggregate values, per-sample differences, redacted metadata,
+  dataset/prompt identity, optional compatible deltas, and no Markdown mirror.
+- One prompt-lab process owns a dataset at a time. No locking or atomic publication is implemented;
+  validation excludes interrupted/truncated files until the user removes or rebuilds them.
+- The coding agent can read the JSON, tell the user the result, revise a prompt file, and repeat the
+  loop without changing product configuration or code between candidates.
+- Dataset/report plaintext and external-service privacy boundaries are documented; no credential is
+  written to dataset files, reports, or normal logs.
+- Automated tests, local validation, hosted cross-platform CI, documentation synchronization, and
+  native capture checks complete before the draft PR becomes ready.

--- a/docs/plan/33-stt-prompt-regression-suite.md
+++ b/docs/plan/33-stt-prompt-regression-suite.md
@@ -2,11 +2,10 @@
 
 ## Status
 
-**In progress.** The dataset schema, native prompt-lab recording mode, raw-STT capture path, sample
-curation commands, and dataset validation are implemented in the first code change. Regression
-execution, metrics, agent review application, comparison, and final validation remain. This feature
-targets the prompt sent directly to the STT endpoint; it does not evaluate or modify the existing
-LLM post-processing prompt.
+**Implemented.** The two-change implementation provides native dataset capture and curation,
+fresh full-dataset STT regression, versioned WER/proper-noun metrics, coding-agent semantic review,
+three independent gates, compatible-run comparison, and JSON-only reports. It targets the prompt
+sent directly to the STT endpoint and never evaluates or modifies the LLM post-processing prompt.
 
 ## Context
 

--- a/docs/plan/33-stt-prompt-regression-suite.md
+++ b/docs/plan/33-stt-prompt-regression-suite.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-**Approved on 2026-08-14; implementation has not started.** No product or test code has been
-written for this feature yet. This document defines a local dataset-capture and regression workflow
-for the prompt sent directly to the STT endpoint. It does not evaluate or modify the existing LLM
-post-processing prompt.
+**In progress.** The dataset schema, native prompt-lab recording mode, raw-STT capture path, sample
+curation commands, and dataset validation are implemented in the first code change. Regression
+execution, metrics, agent review application, comparison, and final validation remain. This feature
+targets the prompt sent directly to the STT endpoint; it does not evaluate or modify the existing
+LLM post-processing prompt.
 
 ## Context
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,5 @@
 mod listener;
+mod prompt_lab;
 
 use std::path::PathBuf;
 
@@ -55,6 +56,9 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         Some(Commands::Convert { input, output }) => {
             handle_convert(&input, output.as_deref())?;
+        }
+        Some(Commands::PromptLab { action }) => {
+            prompt_lab::handle(action)?;
         }
     }
 

--- a/src/application/listener.rs
+++ b/src/application/listener.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use tracing::{info, warn};
 
 use super::{LocalServiceGuard, config_context, load_config, start_local_backend};
@@ -5,6 +6,7 @@ use crate::core::config::EnvironmentSecretSource;
 use crate::core::recording_session::{RecordingState, SessionEvent};
 use crate::history::{HistoryStore, HistoryTyper};
 use crate::platform::PlatformAction;
+use crate::prompt_lab::{DatasetStore, PromptLabCapture, SttSnapshot};
 use crate::runtime_config::{self, ListenerConfig, ProfileSelection};
 use crate::{audio, core, postprocess, transcriber};
 
@@ -46,14 +48,31 @@ fn toggle_session_event(state: &RecordingState) -> Option<SessionEvent> {
 }
 
 /// Runs the listener using an already resolved workflow configuration.
-pub(super) fn run_with_config(
+pub(super) fn run_with_config(config: ListenerConfig) -> Result<(), Box<dyn std::error::Error>> {
+    run_with_mode(config, ListenerMode::Delivery)
+}
+
+pub(super) fn run_capture(
+    config: ListenerConfig,
+    store: DatasetStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+    run_with_mode(config, ListenerMode::Capture(Arc::new(store)))
+}
+
+enum ListenerMode {
+    Delivery,
+    Capture(Arc<DatasetStore>),
+}
+
+fn run_with_mode(
     mut config: ListenerConfig,
+    mode: ListenerMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::sync::Arc;
 
     use audio::AudioRecorder;
     use core::orchestrator::SessionOrchestrator;
-    use event_loop::{AppEvent, ListenerApplication};
+    use event_loop::{AppEvent, ListenerApplication, ListenerOutput};
     use postprocess::PostProcessor;
     use transcriber::ApiTranscriber;
     use winit::event_loop::{ControlFlow, EventLoop};
@@ -67,7 +86,10 @@ pub(super) fn run_with_config(
     let local_manager = start_local_backend(&mut config.backend)?;
     let _local_manager = LocalServiceGuard::new(local_manager);
 
-    let post_processor = PostProcessor::new(config.backend.post_process);
+    let capture_stt = match &mode {
+        ListenerMode::Delivery => None,
+        ListenerMode::Capture(_) => Some(SttSnapshot::from(config.backend.transcriber.metadata())),
+    };
     let orchestrator = Arc::new(SessionOrchestrator::new(
         Arc::new(ApiTranscriber::new(config.backend.transcriber)?),
         config.orchestrator,
@@ -78,35 +100,45 @@ pub(super) fn run_with_config(
     let proxy = event_loop.create_proxy();
 
     let platform_proxy = proxy.clone();
-    let history_store = HistoryStore::discover()
-        .inspect_err(|error| warn!(%error, "Transcription history is unavailable"))
-        .ok();
-    let recent_history = history_store
-        .as_ref()
-        .and_then(|store| {
-            store
-                .load_recent()
-                .inspect_err(|error| warn!(%error, "Ignoring unusable transcription history"))
-                .ok()
-        })
-        .unwrap_or_default();
-
     let mut platform = NativePlatform::start(&config.hotkeys, move |event| {
         let _ = platform_proxy.send_event(AppEvent::Platform(event));
     })?;
-    platform.set_history(recent_history);
-    let typer = match history_store {
-        Some(store) => {
-            let history_proxy = proxy.clone();
-            Arc::new(HistoryTyper::new(
-                store,
-                platform.text_typer(),
-                move |text| {
-                    let _ = history_proxy.send_event(AppEvent::HistorySaved(text));
-                },
-            )) as Arc<dyn crate::input::typer::TextTyper>
+    let output = match mode {
+        ListenerMode::Delivery => {
+            let history_store = HistoryStore::discover()
+                .inspect_err(|error| warn!(%error, "Transcription history is unavailable"))
+                .ok();
+            let recent_history = history_store
+                .as_ref()
+                .and_then(|store| {
+                    store
+                        .load_recent()
+                        .inspect_err(
+                            |error| warn!(%error, "Ignoring unusable transcription history"),
+                        )
+                        .ok()
+                })
+                .unwrap_or_default();
+            platform.set_history(recent_history);
+            let typer = match history_store {
+                Some(store) => {
+                    let history_proxy = proxy.clone();
+                    Arc::new(HistoryTyper::new(
+                        store,
+                        platform.text_typer(),
+                        move |text| {
+                            let _ = history_proxy.send_event(AppEvent::HistorySaved(text));
+                        },
+                    )) as Arc<dyn crate::input::typer::TextTyper>
+                }
+                None => platform.text_typer(),
+            };
+            ListenerOutput::delivery(typer, PostProcessor::new(config.backend.post_process))
         }
-        None => platform.text_typer(),
+        ListenerMode::Capture(store) => ListenerOutput::capture(
+            PromptLabCapture::new(store),
+            capture_stt.expect("capture mode snapshots STT metadata"),
+        ),
     };
 
     let audio_proxy = proxy.clone();
@@ -115,6 +147,12 @@ pub(super) fn run_with_config(
     });
 
     info!("System tray icon started");
+
+    if matches!(output, ListenerOutput::Capture { .. }) {
+        println!(
+            "Prompt-lab capture mode: audio and raw STT results are saved; text is not typed."
+        );
+    }
 
     if let Some(hotkey) = config.hotkeys.hold_label.as_deref() {
         println!("Hold {hotkey} to record, release to transcribe.");
@@ -125,14 +163,7 @@ pub(super) fn run_with_config(
     println!("Press Ctrl+C to exit.");
     println!();
 
-    let mut application = ListenerApplication::new(
-        recorder,
-        orchestrator,
-        platform,
-        typer,
-        post_processor,
-        proxy,
-    );
+    let mut application = ListenerApplication::new(recorder, orchestrator, platform, output, proxy);
     event_loop.run_app(&mut application)?;
     Ok(())
 }

--- a/src/application/listener/event_loop.rs
+++ b/src/application/listener/event_loop.rs
@@ -18,6 +18,7 @@ use crate::core::recording_session::{
 use crate::input::typer::TextTyper;
 use crate::platform::{NativePlatform, PlatformEvent, PlatformInterface};
 use crate::postprocess::{PostProcessor, PostProcessorSession};
+use crate::prompt_lab::{CaptureTranscription, PromptLabCapture, SttSnapshot};
 use crate::session::SessionId;
 
 #[derive(Debug, Clone)]
@@ -90,10 +91,59 @@ pub(super) struct ListenerApplication {
     recorder: AudioRecorder,
     orchestrator: Arc<SessionOrchestrator>,
     platform: NativePlatform,
-    typer: Arc<dyn TextTyper>,
-    post_processor: PostProcessor,
+    output: ListenerOutput,
     proxy: EventLoopProxy<AppEvent>,
     finalization: Option<FinalizationTask>,
+}
+
+pub(super) enum ListenerOutput {
+    Delivery {
+        typer: Arc<dyn TextTyper>,
+        post_processor: PostProcessor,
+    },
+    Capture {
+        capture: Box<PromptLabCapture>,
+        stt: SttSnapshot,
+    },
+}
+
+impl ListenerOutput {
+    pub(super) fn delivery(typer: Arc<dyn TextTyper>, post_processor: PostProcessor) -> Self {
+        Self::Delivery {
+            typer,
+            post_processor,
+        }
+    }
+
+    pub(super) fn capture(capture: PromptLabCapture, stt: SttSnapshot) -> Self {
+        Self::Capture {
+            capture: Box::new(capture),
+            stt,
+        }
+    }
+
+    fn start_session(&mut self, session_id: SessionId) -> Result<(), String> {
+        match self {
+            Self::Delivery { .. } => Ok(()),
+            Self::Capture { capture, .. } => capture
+                .start_now(session_id)
+                .map_err(|error| error.to_string()),
+        }
+    }
+
+    fn archive_chunk(&mut self, session_id: SessionId, chunk: &crate::audio::WavChunk) {
+        if let Self::Capture { capture, .. } = self
+            && let Err(error) = capture.push(session_id, chunk.clone())
+        {
+            error!(session_id = session_id.0, error = %error, "Failed to archive audio chunk");
+        }
+    }
+
+    fn cancel_session(&mut self, session_id: SessionId) {
+        if let Self::Capture { capture, .. } = self {
+            capture.cancel(session_id);
+        }
+    }
 }
 
 impl ListenerApplication {
@@ -101,8 +151,7 @@ impl ListenerApplication {
         recorder: AudioRecorder,
         orchestrator: Arc<SessionOrchestrator>,
         platform: NativePlatform,
-        typer: Arc<dyn TextTyper>,
-        post_processor: PostProcessor,
+        output: ListenerOutput,
         proxy: EventLoopProxy<AppEvent>,
     ) -> Self {
         Self {
@@ -110,8 +159,7 @@ impl ListenerApplication {
             recorder,
             orchestrator,
             platform,
-            typer,
-            post_processor,
+            output,
             proxy,
             finalization: None,
         }
@@ -174,11 +222,13 @@ impl ListenerApplication {
                         }
                     }
                     SessionEffect::SubmitChunk { session_id, chunk } => {
+                        self.output.archive_chunk(session_id, &chunk);
                         if let Err(error) = self.orchestrator.on_chunk_ready(session_id, chunk) {
                             warn!(session_id = session_id.0, error = %error, "Chunk was rejected");
                         }
                     }
                     SessionEffect::CancelRecorder { session_id } => {
+                        self.output.cancel_session(session_id);
                         let outcome = self.recorder.cancel_recording(session_id);
                         debug!(
                             session_id = session_id.0,
@@ -204,7 +254,29 @@ impl ListenerApplication {
         match self.recorder.start_recording(session_id) {
             RecorderStartOutcome::Started { session_id } => {
                 match self.orchestrator.start_session(session_id) {
-                    Ok(()) => SessionEvent::SessionStarted { session_id },
+                    Ok(()) => match self.output.start_session(session_id) {
+                        Ok(()) => SessionEvent::SessionStarted { session_id },
+                        Err(error) => {
+                            let cancel_outcome = self.recorder.cancel_recording(session_id);
+                            debug!(
+                                session_id = session_id.0,
+                                ?cancel_outcome,
+                                "Recorder startup rollback handled"
+                            );
+                            if let Err(abort_error) = self.orchestrator.abort_session(session_id) {
+                                debug!(
+                                    session_id = session_id.0,
+                                    error = %abort_error,
+                                    "Orchestrator startup rollback had no matching session"
+                                );
+                            }
+                            error!(
+                                session_id = session_id.0,
+                                error, "Failed to start prompt-lab capture"
+                            );
+                            SessionEvent::SessionStartFailed { session_id, error }
+                        }
+                    },
                     Err(error) => {
                         let active_session_id = match &error {
                             crate::core::orchestrator::SessionStartError::ActiveSession {
@@ -213,6 +285,7 @@ impl ListenerApplication {
                             } => *active,
                         };
                         let cancel_outcome = self.recorder.cancel_recording(session_id);
+                        self.output.cancel_session(active_session_id);
                         debug!(
                             session_id = session_id.0,
                             ?cancel_outcome,
@@ -242,6 +315,7 @@ impl ListenerApplication {
                 requested_session_id,
                 active_session_id,
             } => {
+                self.output.cancel_session(active_session_id);
                 let cancel_outcome = self.recorder.cancel_recording(active_session_id);
                 debug!(
                     session_id = active_session_id.0,
@@ -292,6 +366,7 @@ impl ListenerApplication {
                     );
                 }
                 for chunk in chunks {
+                    self.output.archive_chunk(session_id, &chunk);
                     if let Err(error) = self.orchestrator.on_chunk_ready(session_id, chunk) {
                         warn!(session_id = session_id.0, error = %error, "Stop-time chunk was rejected");
                     }
@@ -319,24 +394,67 @@ impl ListenerApplication {
             gate: Arc::clone(&gate),
         });
 
-        let orchestrator = Arc::clone(&self.orchestrator);
-        let mut post_processor = self.post_processor.start_session();
-        let typer = Arc::clone(&self.typer);
-        let proxy = self.proxy.clone();
-        spawn_finalization_worker(
-            session_id,
-            move || {
-                finish_transcription(
-                    orchestrator.finish_session(session_id),
-                    &mut post_processor,
-                    typer.as_ref(),
-                    gate.as_ref(),
+        match &mut self.output {
+            ListenerOutput::Delivery {
+                typer,
+                post_processor,
+            } => {
+                let orchestrator = Arc::clone(&self.orchestrator);
+                let mut post_processor = post_processor.start_session();
+                let typer = Arc::clone(typer);
+                let proxy = self.proxy.clone();
+                spawn_finalization_worker(
+                    session_id,
+                    move || {
+                        finish_transcription(
+                            orchestrator.finish_session(session_id),
+                            &mut post_processor,
+                            typer.as_ref(),
+                            gate.as_ref(),
+                        );
+                    },
+                    move |session_id| {
+                        let _ = proxy.send_event(AppEvent::FinalizationFinished { session_id });
+                    },
                 );
-            },
-            move |session_id| {
-                let _ = proxy.send_event(AppEvent::FinalizationFinished { session_id });
-            },
-        );
+            }
+            ListenerOutput::Capture { capture, stt } => {
+                let capture_session = capture.take(session_id);
+                let stt = stt.clone();
+                let orchestrator = Arc::clone(&self.orchestrator);
+                let proxy = self.proxy.clone();
+                spawn_finalization_worker(
+                    session_id,
+                    move || {
+                        let transcription =
+                            capture_transcription(orchestrator.finish_session(session_id), stt);
+                        match capture_session {
+                            Ok(capture_session) => match capture_session.finish(transcription) {
+                                Ok(sample) => println!(
+                                    "Captured {}\naudio: {}\nsidecar: {}",
+                                    sample.id,
+                                    sample.audio_path.display(),
+                                    sample.sidecar_path.display()
+                                ),
+                                Err(error) => error!(
+                                    session_id = session_id.0,
+                                    error = %error,
+                                    "Failed to finalize prompt-lab capture"
+                                ),
+                            },
+                            Err(error) => error!(
+                                session_id = session_id.0,
+                                error = %error,
+                                "Prompt-lab capture session was unavailable"
+                            ),
+                        }
+                    },
+                    move |session_id| {
+                        let _ = proxy.send_event(AppEvent::FinalizationFinished { session_id });
+                    },
+                );
+            }
+        }
     }
 
     fn cancel_finalization(&mut self) {
@@ -431,6 +549,32 @@ fn finish_transcription(
     }
 }
 
+fn capture_transcription(
+    result: Result<String, SessionError>,
+    stt: SttSnapshot,
+) -> CaptureTranscription {
+    match result {
+        Ok(text) if text.is_empty() => CaptureTranscription::failed("STT returned empty text", stt),
+        Ok(text) => CaptureTranscription::success(text, stt),
+        Err(error) => {
+            let partial_text = match &error {
+                SessionError::PartialFailure { partial_text, .. }
+                | SessionError::ConvergenceTimeout { partial_text, .. }
+                    if !partial_text.is_empty() =>
+                {
+                    Some(partial_text.clone())
+                }
+                _ => None,
+            };
+            let message = error.to_string();
+            match partial_text {
+                Some(text) => CaptureTranscription::partial(text, message, stt),
+                None => CaptureTranscription::failed(message, stt),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -441,12 +585,60 @@ mod tests {
 
     use crate::core::recording_session::{RecordingSessionMachine, RecordingState, SessionEvent};
     use crate::input::typer::TextTyper;
+    use crate::prompt_lab::SttSnapshot;
     use crate::session::SessionId;
+    use crate::transcriber::TranscribeError;
 
     use super::{
-        FinalizationGate, FinalizationTask, finalization_completion_event,
+        FinalizationGate, FinalizationTask, capture_transcription, finalization_completion_event,
         spawn_finalization_worker,
     };
+
+    fn stt_snapshot() -> SttSnapshot {
+        SttSnapshot {
+            endpoint: "https://api.example.test/v1/audio/transcriptions".to_string(),
+            model: "whisper-test".to_string(),
+            language: Some("zh".to_string()),
+            temperature: 0.0,
+            prompt: Some("候选提示词".to_string()),
+        }
+    }
+
+    #[test]
+    fn capture_transcription_preserves_raw_success_without_post_processing() {
+        let result = capture_transcription(Ok(" 原始转写 ".to_string()), stt_snapshot());
+
+        assert_eq!(result.text.as_deref(), Some(" 原始转写 "));
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn capture_transcription_keeps_partial_text_and_failure_details() {
+        let result = capture_transcription(
+            Err(crate::core::orchestrator::SessionError::PartialFailure {
+                errors: vec![(0, TranscribeError::Network("request failed".to_string()))],
+                partial_text: "部分结果".to_string(),
+            }),
+            stt_snapshot(),
+        );
+
+        assert_eq!(result.text.as_deref(), Some("部分结果"));
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap()
+                .contains("1 chunk(s) failed")
+        );
+    }
+
+    #[test]
+    fn capture_transcription_records_empty_success_as_failure() {
+        let result = capture_transcription(Ok(String::new()), stt_snapshot());
+
+        assert!(result.text.is_none());
+        assert_eq!(result.error.as_deref(), Some("STT returned empty text"));
+    }
 
     struct CountingTyper(AtomicUsize);
 

--- a/src/application/prompt_lab.rs
+++ b/src/application/prompt_lab.rs
@@ -1,0 +1,102 @@
+use std::fs;
+use std::path::PathBuf;
+
+use super::{config_context, load_config};
+use crate::core::cli::{
+    PromptLabCommand, PromptLabDatasetCommand, PromptLabSampleCommand, PromptLabSampleStatus,
+};
+use crate::core::config::EnvironmentSecretSource;
+use crate::prompt_lab::{DatasetStore, ProperNounAnnotation, ReferenceStatus};
+use crate::runtime_config::{self, ProfileSelection};
+
+pub(super) fn handle(action: PromptLabCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        PromptLabCommand::Record { dataset } => record(dataset),
+        PromptLabCommand::Sample { action } => sample(action),
+        PromptLabCommand::Dataset { action } => dataset(action),
+    }
+}
+
+fn record(root: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let dataset = DatasetStore::open_or_create(root)?;
+    let (store, document) = load_config()?;
+    let (config_dir, home_dir) = config_context(&store)?;
+    let config = runtime_config::resolve_listener(
+        &document,
+        &EnvironmentSecretSource,
+        ProfileSelection::Configured,
+        &config_dir,
+        &home_dir,
+    )?;
+    super::listener::run_capture(config, dataset)
+}
+
+fn sample(action: PromptLabSampleCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        PromptLabSampleCommand::List { dataset, status } => {
+            let store = DatasetStore::open_or_create(dataset)?;
+            let status = status.map(|status| match status {
+                PromptLabSampleStatus::Pending => ReferenceStatus::Pending,
+                PromptLabSampleStatus::Ready => ReferenceStatus::Ready,
+            });
+            for sample in store.list_samples(status)? {
+                let status = match sample.reference.status {
+                    ReferenceStatus::Pending => "pending",
+                    ReferenceStatus::Ready => "ready",
+                };
+                println!("{}\t{}\t{}", sample.id, status, sample.audio.path);
+            }
+            Ok(())
+        }
+        PromptLabSampleCommand::Show { dataset, id } => {
+            let store = DatasetStore::open_or_create(dataset)?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&store.load_sample(&id)?)?
+            );
+            Ok(())
+        }
+        PromptLabSampleCommand::Correct {
+            dataset,
+            id,
+            reference,
+            reference_file,
+            proper_nouns_file,
+        } => {
+            let reference = match (reference, reference_file) {
+                (Some(reference), None) => reference,
+                (None, Some(path)) => fs::read_to_string(path)?,
+                _ => unreachable!("clap enforces exactly one reference source"),
+            };
+            let proper_nouns = match proper_nouns_file {
+                Some(path) => {
+                    serde_json::from_slice::<Vec<ProperNounAnnotation>>(&fs::read(path)?)?
+                }
+                None => Vec::new(),
+            };
+            let store = DatasetStore::open_or_create(dataset)?;
+            let sample = store.correct_sample(&id, &reference, proper_nouns)?;
+            println!("{}", serde_json::to_string_pretty(&sample)?);
+            Ok(())
+        }
+    }
+}
+
+fn dataset(action: PromptLabDatasetCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        PromptLabDatasetCommand::Validate { dataset } => {
+            let store = DatasetStore::open_or_create(dataset)?;
+            let report = store.validate()?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            if report.issues.is_empty() {
+                Ok(())
+            } else {
+                Err(std::io::Error::other(format!(
+                    "dataset validation found {} issue(s)",
+                    report.issues.len()
+                ))
+                .into())
+            }
+        }
+    }
+}

--- a/src/application/prompt_lab.rs
+++ b/src/application/prompt_lab.rs
@@ -3,10 +3,14 @@ use std::path::PathBuf;
 
 use super::{config_context, load_config};
 use crate::core::cli::{
-    PromptLabCommand, PromptLabDatasetCommand, PromptLabSampleCommand, PromptLabSampleStatus,
+    PromptLabCommand, PromptLabDatasetCommand, PromptLabReportCommand, PromptLabSampleCommand,
+    PromptLabSampleStatus,
 };
 use crate::core::config::EnvironmentSecretSource;
-use crate::prompt_lab::{DatasetStore, ProperNounAnnotation, ReferenceStatus};
+use crate::prompt_lab::{
+    DatasetStore, EvaluationReport, EvaluationRequest, ProperNounAnnotation, ReferenceStatus,
+    RunStatus, SttSnapshot, Thresholds, apply_review, evaluate,
+};
 use crate::runtime_config::{self, ProfileSelection};
 
 pub(super) fn handle(action: PromptLabCommand) -> Result<(), Box<dyn std::error::Error>> {
@@ -14,6 +18,130 @@ pub(super) fn handle(action: PromptLabCommand) -> Result<(), Box<dyn std::error:
         PromptLabCommand::Record { dataset } => record(dataset),
         PromptLabCommand::Sample { action } => sample(action),
         PromptLabCommand::Dataset { action } => dataset(action),
+        PromptLabCommand::Evaluate {
+            dataset,
+            prompt_file,
+            no_prompt,
+            max_wer_percent,
+            min_llm_score,
+            min_proper_noun_percent,
+            compare_to,
+            output,
+        } => evaluate_command(EvaluateCommand {
+            dataset,
+            prompt_file,
+            no_prompt,
+            thresholds: Thresholds {
+                max_wer_percent,
+                min_llm_score,
+                min_proper_noun_percent,
+            },
+            compare_to,
+            output,
+        }),
+        PromptLabCommand::Report { action } => report(action),
+    }
+}
+
+struct EvaluateCommand {
+    dataset: PathBuf,
+    prompt_file: Option<PathBuf>,
+    no_prompt: bool,
+    thresholds: Thresholds,
+    compare_to: Option<PathBuf>,
+    output: Option<PathBuf>,
+}
+
+fn evaluate_command(command: EvaluateCommand) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::transcriber::ApiTranscriber;
+
+    let candidate_from_file = command
+        .prompt_file
+        .as_ref()
+        .map(fs::read_to_string)
+        .transpose()?;
+    if candidate_from_file
+        .as_deref()
+        .is_some_and(|prompt| prompt.trim().is_empty())
+    {
+        return Err(std::io::Error::other("candidate prompt file must not be empty").into());
+    }
+    let dataset = DatasetStore::open_or_create(command.dataset)?;
+    let prior = command
+        .compare_to
+        .as_deref()
+        .map(EvaluationReport::read)
+        .transpose()?;
+    let (store, document) = load_config()?;
+    let (config_dir, home_dir) = config_context(&store)?;
+    let mut config = runtime_config::resolve_convert(
+        &document,
+        &EnvironmentSecretSource,
+        &config_dir,
+        &home_dir,
+    )?;
+    let prompt = if command.no_prompt {
+        None
+    } else if let Some(prompt) = candidate_from_file {
+        Some(prompt)
+    } else {
+        config.backend.transcriber.metadata().prompt
+    };
+    config.backend.transcriber = config.backend.transcriber.with_prompt(prompt);
+    let stt = SttSnapshot::from(config.backend.transcriber.metadata());
+    let local_manager = super::start_local_backend(&mut config.backend)?;
+    let _local_manager = super::LocalServiceGuard::new(local_manager);
+    let transcriber = ApiTranscriber::new(config.backend.transcriber)?;
+    let outcome = evaluate(
+        &dataset,
+        &transcriber,
+        EvaluationRequest {
+            stt,
+            language: config.language,
+            max_chunk_duration_secs: config.max_chunk_duration_secs,
+            max_chunk_size_bytes: config.max_chunk_size_bytes,
+            thresholds: command.thresholds,
+            output: command.output,
+            compare_to: prior,
+        },
+    )?;
+    println!("report: {}", outcome.path.display());
+    println!("status: {}", outcome.report.status.as_str());
+    println!("wer_percent: {}", outcome.report.aggregates.wer.wer_percent);
+    println!(
+        "proper_noun_percent: {}",
+        outcome.report.aggregates.proper_nouns.accuracy_percent
+    );
+    if outcome.report.status == RunStatus::Incomplete {
+        Err(std::io::Error::other(format!(
+            "evaluation completed with {} sample failure(s)",
+            outcome.report.failures.len()
+        ))
+        .into())
+    } else {
+        Ok(())
+    }
+}
+
+fn report(action: PromptLabReportCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        PromptLabReportCommand::ApplyReview { report, review } => {
+            let report = apply_review(&report, &review)?;
+            let llm = report
+                .aggregates
+                .llm
+                .as_ref()
+                .expect("applied review creates LLM aggregate");
+            println!("status: {}", report.status.as_str());
+            println!("llm_score: {}", llm.mean_score);
+            println!(
+                "meets_targets: {}",
+                report
+                    .meets_targets
+                    .expect("complete report has gate result")
+            );
+            Ok(())
+        }
     }
 }
 

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -1,4 +1,6 @@
-use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
 
 /// ViberWhisper - 语音转文字输入工具
 #[derive(Parser, Debug)]
@@ -31,6 +33,84 @@ pub enum Commands {
         /// 可选：输出文件路径（默认打印到 stdout）
         #[arg(short, long)]
         output: Option<String>,
+    },
+    /// STT prompt 数据集采集、校对与回归
+    PromptLab {
+        #[command(subcommand)]
+        action: PromptLabCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PromptLabCommand {
+    /// 使用现有托盘和热键录制测试样本
+    Record {
+        /// 数据集根目录（同一时间只能由一个进程使用）
+        #[arg(long)]
+        dataset: PathBuf,
+    },
+    /// 查看或修正录音样本
+    Sample {
+        #[command(subcommand)]
+        action: PromptLabSampleCommand,
+    },
+    /// 数据集级操作
+    Dataset {
+        #[command(subcommand)]
+        action: PromptLabDatasetCommand,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PromptLabSampleStatus {
+    Pending,
+    Ready,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PromptLabSampleCommand {
+    /// 列出样本
+    List {
+        #[arg(long)]
+        dataset: PathBuf,
+        #[arg(long)]
+        status: Option<PromptLabSampleStatus>,
+    },
+    /// 以 JSON 显示一个样本
+    Show {
+        #[arg(long)]
+        dataset: PathBuf,
+        id: String,
+    },
+    /// 写入人工标准文本和专有名词标注
+    Correct {
+        #[arg(long)]
+        dataset: PathBuf,
+        id: String,
+        #[arg(
+            long,
+            conflicts_with = "reference_file",
+            required_unless_present = "reference_file"
+        )]
+        reference: Option<String>,
+        #[arg(
+            long,
+            conflicts_with = "reference",
+            required_unless_present = "reference"
+        )]
+        reference_file: Option<PathBuf>,
+        /// JSON 格式的专有名词标注数组；省略表示没有专有名词
+        #[arg(long)]
+        proper_nouns_file: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PromptLabDatasetCommand {
+    /// 校验 manifest、sidecar、WAV 和摘要
+    Validate {
+        #[arg(long)]
+        dataset: PathBuf,
     },
 }
 
@@ -122,5 +202,71 @@ mod tests {
                 action: LocalCommand::Start
             })
         ));
+    }
+
+    #[test]
+    fn parses_prompt_lab_sample_correction_inputs() {
+        let cli = Cli::try_parse_from([
+            "viberwhisper",
+            "prompt-lab",
+            "sample",
+            "correct",
+            "--dataset",
+            "/tmp/lab",
+            "sample-1-1",
+            "--reference-file",
+            "expected.txt",
+            "--proper-nouns-file",
+            "terms.json",
+        ])
+        .unwrap();
+
+        let Some(Commands::PromptLab {
+            action:
+                PromptLabCommand::Sample {
+                    action:
+                        PromptLabSampleCommand::Correct {
+                            dataset,
+                            id,
+                            reference,
+                            reference_file,
+                            proper_nouns_file,
+                        },
+                },
+        }) = cli.command
+        else {
+            panic!("expected prompt-lab sample correct");
+        };
+        assert_eq!(dataset, std::path::PathBuf::from("/tmp/lab"));
+        assert_eq!(id, "sample-1-1");
+        assert!(reference.is_none());
+        assert_eq!(
+            reference_file.as_deref(),
+            Some(std::path::Path::new("expected.txt"))
+        );
+        assert_eq!(
+            proper_nouns_file.as_deref(),
+            Some(std::path::Path::new("terms.json"))
+        );
+    }
+
+    #[test]
+    fn correction_rejects_two_reference_sources() {
+        let error = Cli::try_parse_from([
+            "viberwhisper",
+            "prompt-lab",
+            "sample",
+            "correct",
+            "--dataset",
+            "/tmp/lab",
+            "sample-1-1",
+            "--reference",
+            "inline",
+            "--reference-file",
+            "expected.txt",
+        ])
+        .unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }

--- a/src/core/cli.rs
+++ b/src/core/cli.rs
@@ -59,6 +59,41 @@ pub enum PromptLabCommand {
         #[command(subcommand)]
         action: PromptLabDatasetCommand,
     },
+    /// 使用候选 STT prompt 对全部 ready 样本执行回归
+    Evaluate {
+        #[arg(long)]
+        dataset: PathBuf,
+        #[arg(long, conflicts_with = "no_prompt")]
+        prompt_file: Option<PathBuf>,
+        #[arg(long, conflicts_with = "prompt_file")]
+        no_prompt: bool,
+        #[arg(long)]
+        max_wer_percent: f64,
+        #[arg(long)]
+        min_llm_score: f64,
+        #[arg(long)]
+        min_proper_noun_percent: f64,
+        #[arg(long)]
+        compare_to: Option<PathBuf>,
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+    /// 将编码代理的逐样本语义复核写入规范 JSON 报告
+    Report {
+        #[command(subcommand)]
+        action: PromptLabReportCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PromptLabReportCommand {
+    /// 验证并应用完整的代理复核 JSON
+    ApplyReview {
+        #[arg(long)]
+        report: PathBuf,
+        #[arg(long)]
+        review: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -268,5 +303,101 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn parses_prompt_lab_evaluation_thresholds_and_paths() {
+        let cli = Cli::try_parse_from([
+            "viberwhisper",
+            "prompt-lab",
+            "evaluate",
+            "--dataset",
+            "/tmp/lab",
+            "--prompt-file",
+            "candidate.txt",
+            "--max-wer-percent",
+            "8",
+            "--min-llm-score",
+            "95",
+            "--min-proper-noun-percent",
+            "98",
+            "--compare-to",
+            "baseline.json",
+            "--output",
+            "candidate.json",
+        ])
+        .unwrap();
+
+        let Some(Commands::PromptLab {
+            action:
+                PromptLabCommand::Evaluate {
+                    dataset,
+                    prompt_file,
+                    no_prompt,
+                    max_wer_percent,
+                    min_llm_score,
+                    min_proper_noun_percent,
+                    compare_to,
+                    output,
+                },
+        }) = cli.command
+        else {
+            panic!("expected prompt-lab evaluate");
+        };
+        assert_eq!(dataset, PathBuf::from("/tmp/lab"));
+        assert_eq!(prompt_file, Some(PathBuf::from("candidate.txt")));
+        assert!(!no_prompt);
+        assert_eq!(max_wer_percent, 8.0);
+        assert_eq!(min_llm_score, 95.0);
+        assert_eq!(min_proper_noun_percent, 98.0);
+        assert_eq!(compare_to, Some(PathBuf::from("baseline.json")));
+        assert_eq!(output, Some(PathBuf::from("candidate.json")));
+    }
+
+    #[test]
+    fn evaluation_rejects_prompt_file_with_no_prompt() {
+        let error = Cli::try_parse_from([
+            "viberwhisper",
+            "prompt-lab",
+            "evaluate",
+            "--dataset",
+            "/tmp/lab",
+            "--prompt-file",
+            "candidate.txt",
+            "--no-prompt",
+            "--max-wer-percent",
+            "8",
+            "--min-llm-score",
+            "95",
+            "--min-proper-noun-percent",
+            "98",
+        ])
+        .unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn parses_prompt_lab_agent_review_application() {
+        let cli = Cli::try_parse_from([
+            "viberwhisper",
+            "prompt-lab",
+            "report",
+            "apply-review",
+            "--report",
+            "run.json",
+            "--review",
+            "review.json",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::PromptLab {
+                action: PromptLabCommand::Report {
+                    action: PromptLabReportCommand::ApplyReview { .. }
+                }
+            })
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod input;
 mod local;
 mod platform;
 mod postprocess;
+mod prompt_lab;
 mod runtime_config;
 mod session;
 mod text;

--- a/src/prompt_lab.rs
+++ b/src/prompt_lab.rs
@@ -1,0 +1,7 @@
+mod capture;
+mod dataset;
+
+pub(crate) use capture::PromptLabCapture;
+pub(crate) use dataset::{
+    CaptureTranscription, DatasetStore, ProperNounAnnotation, ReferenceStatus, SttSnapshot,
+};

--- a/src/prompt_lab.rs
+++ b/src/prompt_lab.rs
@@ -1,7 +1,14 @@
 mod capture;
 mod dataset;
+mod metrics;
+mod regression;
+mod review;
 
 pub(crate) use capture::PromptLabCapture;
 pub(crate) use dataset::{
-    CaptureTranscription, DatasetStore, ProperNounAnnotation, ReferenceStatus, SttSnapshot,
+    CaptureTranscription, DatasetStore, ProperNounAnnotation, ReferenceStatus, ScoringDataset,
+    SttSnapshot,
 };
+pub(crate) use metrics::{ProperNounScore, WerScore, score_proper_nouns, score_wer};
+pub(crate) use regression::{EvaluationReport, EvaluationRequest, RunStatus, Thresholds, evaluate};
+pub(crate) use review::apply_review;

--- a/src/prompt_lab/capture.rs
+++ b/src/prompt_lab/capture.rs
@@ -1,0 +1,361 @@
+use std::fmt;
+use std::io::{BufWriter, Cursor};
+use std::sync::Arc;
+use std::sync::mpsc::{self, SyncSender};
+use std::thread::{self, JoinHandle};
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
+
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+
+use super::dataset::{CaptureTranscription, DatasetError, DatasetStore, SampleReservation};
+use crate::audio::WavChunk;
+use crate::session::SessionId;
+
+#[derive(Debug)]
+pub(crate) enum CaptureError {
+    Dataset(DatasetError),
+    Io(std::io::Error),
+    Wav(hound::Error),
+    Clock(SystemTimeError),
+    TimestampOverflow,
+    ActiveSession(SessionId),
+    NoActiveSession(SessionId),
+    SessionMismatch {
+        requested: SessionId,
+        active: SessionId,
+    },
+    WorkerClosed(SessionId),
+    WorkerPanicked,
+    NoAudioChunks,
+    UnsupportedFormat(WavSpec),
+    FormatChanged {
+        expected: WavSpec,
+        actual: WavSpec,
+    },
+}
+
+impl fmt::Display for CaptureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Dataset(error) => write!(formatter, "{error}"),
+            Self::Io(error) => write!(formatter, "capture I/O failed: {error}"),
+            Self::Wav(error) => write!(formatter, "capture WAV failed: {error}"),
+            Self::Clock(error) => write!(formatter, "capture clock failed: {error}"),
+            Self::TimestampOverflow => formatter.write_str("capture timestamp is too large"),
+            Self::ActiveSession(session_id) => {
+                write!(
+                    formatter,
+                    "capture session {} is already active",
+                    session_id.0
+                )
+            }
+            Self::NoActiveSession(session_id) => {
+                write!(formatter, "no capture session for session {}", session_id.0)
+            }
+            Self::SessionMismatch { requested, active } => write!(
+                formatter,
+                "capture request for session {} does not match active session {}",
+                requested.0, active.0
+            ),
+            Self::WorkerClosed(session_id) => write!(
+                formatter,
+                "capture worker closed for session {}",
+                session_id.0
+            ),
+            Self::WorkerPanicked => formatter.write_str("capture worker panicked"),
+            Self::NoAudioChunks => formatter.write_str("capture received no audio chunks"),
+            Self::UnsupportedFormat(spec) => {
+                write!(formatter, "capture does not support WAV format {spec:?}")
+            }
+            Self::FormatChanged { expected, actual } => write!(
+                formatter,
+                "capture WAV format changed from {expected:?} to {actual:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CaptureError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Dataset(error) => Some(error),
+            Self::Io(error) => Some(error),
+            Self::Wav(error) => Some(error),
+            Self::Clock(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<DatasetError> for CaptureError {
+    fn from(error: DatasetError) -> Self {
+        Self::Dataset(error)
+    }
+}
+
+impl From<std::io::Error> for CaptureError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<hound::Error> for CaptureError {
+    fn from(error: hound::Error) -> Self {
+        Self::Wav(error)
+    }
+}
+
+/// Owns at most one dataset archive because the recording state machine owns at most one session.
+pub(crate) struct PromptLabCapture {
+    store: Arc<DatasetStore>,
+    active: Option<CaptureSession>,
+}
+
+impl PromptLabCapture {
+    pub(crate) fn new(store: Arc<DatasetStore>) -> Self {
+        Self {
+            store,
+            active: None,
+        }
+    }
+
+    pub(crate) fn start(
+        &mut self,
+        session_id: SessionId,
+        created_at_unix_ms: u64,
+    ) -> Result<(), CaptureError> {
+        if let Some(active) = &self.active {
+            return Err(CaptureError::ActiveSession(active.session_id));
+        }
+        let reservation = self.store.reserve_sample(created_at_unix_ms)?;
+        let audio_path = reservation.audio_path.clone();
+        let (sender, receiver) = mpsc::sync_channel(2);
+        let worker = thread::Builder::new()
+            .name(format!("prompt-lab-archive-{}", session_id.0))
+            .spawn(move || archive_chunks(audio_path, receiver))?;
+        self.active = Some(CaptureSession {
+            session_id,
+            store: Arc::clone(&self.store),
+            reservation,
+            sender: Some(sender),
+            worker,
+        });
+        Ok(())
+    }
+
+    pub(crate) fn start_now(&mut self, session_id: SessionId) -> Result<(), CaptureError> {
+        let elapsed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(CaptureError::Clock)?;
+        let created_at_unix_ms =
+            u64::try_from(elapsed.as_millis()).map_err(|_| CaptureError::TimestampOverflow)?;
+        self.start(session_id, created_at_unix_ms)
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        session_id: SessionId,
+        chunk: WavChunk,
+    ) -> Result<(), CaptureError> {
+        let active = self
+            .active
+            .as_mut()
+            .ok_or(CaptureError::NoActiveSession(session_id))?;
+        if active.session_id != session_id {
+            return Err(CaptureError::SessionMismatch {
+                requested: session_id,
+                active: active.session_id,
+            });
+        }
+        let sender = active
+            .sender
+            .as_ref()
+            .ok_or(CaptureError::WorkerClosed(session_id))?;
+        sender
+            .send(chunk)
+            .map_err(|_| CaptureError::WorkerClosed(session_id))
+    }
+
+    pub(crate) fn take(&mut self, session_id: SessionId) -> Result<CaptureSession, CaptureError> {
+        let active = self
+            .active
+            .as_ref()
+            .ok_or(CaptureError::NoActiveSession(session_id))?;
+        if active.session_id != session_id {
+            return Err(CaptureError::SessionMismatch {
+                requested: session_id,
+                active: active.session_id,
+            });
+        }
+        Ok(self.active.take().expect("active capture was checked"))
+    }
+
+    pub(crate) fn cancel(&mut self, session_id: SessionId) {
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|active| active.session_id == session_id)
+        {
+            self.active.take();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CaptureSession {
+    session_id: SessionId,
+    store: Arc<DatasetStore>,
+    reservation: SampleReservation,
+    sender: Option<SyncSender<WavChunk>>,
+    worker: JoinHandle<Result<(), CaptureError>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CapturedSample {
+    pub(crate) id: String,
+    pub(crate) audio_path: std::path::PathBuf,
+    pub(crate) sidecar_path: std::path::PathBuf,
+}
+
+impl CaptureSession {
+    pub(crate) fn finish(
+        mut self,
+        transcription: CaptureTranscription,
+    ) -> Result<CapturedSample, CaptureError> {
+        self.sender.take();
+        self.worker
+            .join()
+            .map_err(|_| CaptureError::WorkerPanicked)??;
+        let sample = self
+            .store
+            .complete_capture(self.reservation, transcription)?;
+        Ok(CapturedSample {
+            audio_path: self.store.root().join(&sample.audio.path),
+            sidecar_path: self.store.samples_dir().join(format!("{}.json", sample.id)),
+            id: sample.id,
+        })
+    }
+}
+
+fn archive_chunks(
+    path: std::path::PathBuf,
+    receiver: mpsc::Receiver<WavChunk>,
+) -> Result<(), CaptureError> {
+    let mut writer: Option<WavWriter<BufWriter<std::fs::File>>> = None;
+    let mut expected_spec = None;
+    for chunk in receiver {
+        let mut reader = WavReader::new(Cursor::new(chunk.shared_bytes()))?;
+        let spec = reader.spec();
+        if spec.sample_format != SampleFormat::Int || spec.bits_per_sample != 16 {
+            return Err(CaptureError::UnsupportedFormat(spec));
+        }
+        if let Some(expected) = expected_spec {
+            if expected != spec {
+                return Err(CaptureError::FormatChanged {
+                    expected,
+                    actual: spec,
+                });
+            }
+        } else {
+            expected_spec = Some(spec);
+            writer = Some(WavWriter::create(&path, spec)?);
+        }
+        let output = writer
+            .as_mut()
+            .expect("writer is created for the first chunk");
+        for sample in reader.samples::<i16>() {
+            output.write_sample(sample?)?;
+        }
+    }
+    writer.ok_or(CaptureError::NoAudioChunks)?.finalize()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    use hound::WavReader;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::audio::chunk::encode_i16_wav;
+    use crate::prompt_lab::{CaptureTranscription, DatasetStore, SttSnapshot};
+
+    fn snapshot() -> SttSnapshot {
+        SttSnapshot {
+            endpoint: "https://api.example.test/v1/audio/transcriptions".to_string(),
+            model: "whisper-test".to_string(),
+            language: Some("zh".to_string()),
+            temperature: 0.0,
+            prompt: Some("词汇提示".to_string()),
+        }
+    }
+
+    #[test]
+    fn archives_all_session_chunks_into_one_sample_wav() {
+        let directory = tempdir().unwrap();
+        let store = Arc::new(DatasetStore::open_or_create(directory.path().join("lab")).unwrap());
+        let mut capture = PromptLabCapture::new(store.clone());
+        capture.start(SessionId(7), 42).unwrap();
+        capture
+            .push(SessionId(7), encode_i16_wav(&[1, 2], 16_000).unwrap())
+            .unwrap();
+        capture
+            .push(SessionId(7), encode_i16_wav(&[3, 4], 16_000).unwrap())
+            .unwrap();
+
+        let session = capture.take(SessionId(7)).unwrap();
+        let sample = session
+            .finish(CaptureTranscription::success("结果", snapshot()))
+            .unwrap();
+
+        let bytes = std::fs::read(&sample.audio_path).unwrap();
+        let samples = WavReader::new(Cursor::new(bytes))
+            .unwrap()
+            .samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(samples, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn rejects_chunks_and_take_for_another_session() {
+        let directory = tempdir().unwrap();
+        let store = Arc::new(DatasetStore::open_or_create(directory.path().join("lab")).unwrap());
+        let mut capture = PromptLabCapture::new(store);
+        capture.start(SessionId(7), 42).unwrap();
+
+        assert!(
+            capture
+                .push(SessionId(8), encode_i16_wav(&[1], 16_000).unwrap())
+                .unwrap_err()
+                .to_string()
+                .contains("session 8")
+        );
+        assert!(
+            capture
+                .take(SessionId(8))
+                .unwrap_err()
+                .to_string()
+                .contains("session 8")
+        );
+    }
+
+    #[test]
+    fn empty_archive_cannot_publish_a_sample() {
+        let directory = tempdir().unwrap();
+        let store = Arc::new(DatasetStore::open_or_create(directory.path().join("lab")).unwrap());
+        let mut capture = PromptLabCapture::new(store);
+        capture.start(SessionId(7), 42).unwrap();
+
+        let error = capture
+            .take(SessionId(7))
+            .unwrap()
+            .finish(CaptureTranscription::failed("no chunks", snapshot()))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("no audio chunks"));
+    }
+}

--- a/src/prompt_lab/dataset.rs
+++ b/src/prompt_lab/dataset.rs
@@ -8,6 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use unicode_normalization::UnicodeNormalization;
 
 use crate::transcriber::TranscriberMetadata;
 
@@ -292,7 +293,16 @@ pub(crate) struct DatasetIssue {
 pub(crate) struct DatasetValidation {
     pub(crate) ready_count: usize,
     pub(crate) pending_count: usize,
+    pub(crate) invalid_count: usize,
     pub(crate) issues: Vec<DatasetIssue>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ScoringDataset {
+    pub(crate) digest: String,
+    pub(crate) samples: Vec<SampleRecord>,
+    pub(crate) pending_count: usize,
+    pub(crate) invalid_count: usize,
 }
 
 #[derive(Debug)]
@@ -464,10 +474,44 @@ impl DatasetStore {
         Ok(self.samples_dir().join(format!("{id}.json")))
     }
 
+    pub(crate) fn scoring_snapshot(&self, scoring_policy_version: &str) -> Result<ScoringDataset> {
+        let validation = self.validate()?;
+        let mut entries = fs::read_dir(self.samples_dir())?.collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        let mut samples = Vec::new();
+        for entry in entries {
+            let path = entry.path();
+            if entry.file_type()?.is_symlink()
+                || path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            {
+                continue;
+            }
+            let Some(id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            let Ok(sample) = self.load_sample(id) else {
+                continue;
+            };
+            if self.validate_audio(&sample).is_ok()
+                && sample.reference.status == ReferenceStatus::Ready
+            {
+                samples.push(sample);
+            }
+        }
+        let digest = scoring_digest(scoring_policy_version, &samples)?;
+        Ok(ScoringDataset {
+            digest,
+            samples,
+            pending_count: validation.pending_count,
+            invalid_count: validation.invalid_count,
+        })
+    }
+
     pub(crate) fn validate(&self) -> Result<DatasetValidation> {
         let mut report = DatasetValidation {
             ready_count: 0,
             pending_count: 0,
+            invalid_count: 0,
             issues: Vec::new(),
         };
         let mut referenced_audio = HashSet::new();
@@ -478,6 +522,7 @@ impl DatasetStore {
             if entry.file_type()?.is_symlink()
                 || path.extension().and_then(|ext| ext.to_str()) != Some("json")
             {
+                report.invalid_count += 1;
                 report.issues.push(issue(
                     "sample_file",
                     &path,
@@ -491,6 +536,7 @@ impl DatasetStore {
             {
                 Ok(sample) => sample,
                 Err(error) => {
+                    report.invalid_count += 1;
                     report
                         .issues
                         .push(issue("sample_json", &path, &error.to_string()));
@@ -513,6 +559,7 @@ impl DatasetStore {
                     ReferenceStatus::Pending => report.pending_count += 1,
                 },
                 Err(error) => {
+                    report.invalid_count += 1;
                     report
                         .issues
                         .push(issue("sample_invalid", &path, &error.to_string()))
@@ -629,6 +676,44 @@ fn validate_id(id: &str) -> Result<()> {
     }
 }
 
+fn scoring_digest(scoring_policy_version: &str, samples: &[SampleRecord]) -> Result<String> {
+    #[derive(Serialize)]
+    struct DigestSample<'a> {
+        id: &'a str,
+        audio_sha256: &'a str,
+        reference: &'a str,
+        proper_nouns: &'a [ProperNounAnnotation],
+    }
+
+    #[derive(Serialize)]
+    struct DigestInput<'a> {
+        sample_schema_version: u32,
+        scoring_policy_version: &'a str,
+        samples: Vec<DigestSample<'a>>,
+    }
+
+    let samples = samples
+        .iter()
+        .map(|sample| {
+            let reference = sample.reference.text.as_deref().ok_or_else(|| {
+                DatasetError::Invalid(format!("ready sample {} has no reference", sample.id))
+            })?;
+            Ok(DigestSample {
+                id: &sample.id,
+                audio_sha256: &sample.audio.sha256,
+                reference,
+                proper_nouns: &sample.reference.proper_nouns,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let input = DigestInput {
+        sample_schema_version: SAMPLE_SCHEMA_VERSION,
+        scoring_policy_version,
+        samples,
+    };
+    Ok(sha256_bytes(&serde_json::to_vec(&input)?))
+}
+
 fn validate_annotations(text: &str, annotations: &[ProperNounAnnotation]) -> Result<()> {
     let mut all_forms = HashSet::new();
     for annotation in annotations {
@@ -665,7 +750,15 @@ fn validate_annotations(text: &str, annotations: &[ProperNounAnnotation]) -> Res
                 )));
             }
         }
-        let count = count_non_overlapping_forms(text, &forms, annotation.case_sensitive);
+    }
+    for (annotation, count) in
+        annotations
+            .iter()
+            .zip(super::metrics::count_proper_noun_occurrences(
+                text,
+                annotations,
+            ))
+    {
         if count != annotation.expected_occurrences as usize {
             return Err(DatasetError::Invalid(format!(
                 "proper noun {} expected_occurrences is {}, but reference contains {count}",
@@ -676,30 +769,10 @@ fn validate_annotations(text: &str, annotations: &[ProperNounAnnotation]) -> Res
     Ok(())
 }
 
-fn count_non_overlapping_forms(text: &str, forms: &[&str], case_sensitive: bool) -> usize {
-    let text = normalize_case(text, case_sensitive);
-    let mut forms = forms
-        .iter()
-        .map(|form| normalize_case(form, case_sensitive))
-        .collect::<Vec<_>>();
-    forms.sort_by_key(|form| std::cmp::Reverse(form.len()));
-    let mut occupied = vec![false; text.len()];
-    let mut count = 0;
-    for form in forms {
-        for (start, _) in text.match_indices(&form) {
-            let end = start + form.len();
-            if !occupied[start..end].iter().any(|value| *value) {
-                occupied[start..end].fill(true);
-                count += 1;
-            }
-        }
-    }
-    count
-}
-
 fn normalize_case(value: &str, case_sensitive: bool) -> String {
+    let value = value.nfkc().collect::<String>();
     if case_sensitive {
-        value.to_string()
+        value
     } else {
         value.to_lowercase()
     }
@@ -730,6 +803,12 @@ fn sha256_file(path: &Path) -> Result<String> {
         hasher.update(&buffer[..read]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+pub(crate) fn sha256_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
 }
 
 fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
@@ -868,6 +947,28 @@ mod tests {
     }
 
     #[test]
+    fn correction_uses_scoring_boundaries_for_proper_noun_occurrences() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        let id = captured_sample(&store, 42);
+
+        let error = store
+            .correct_sample(
+                &id,
+                "MyCodexTool",
+                vec![ProperNounAnnotation {
+                    canonical: "Codex".to_string(),
+                    accepted: Vec::new(),
+                    case_sensitive: true,
+                    expected_occurrences: 1,
+                }],
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("contains 0"));
+    }
+
+    #[test]
     fn validation_reports_malformed_and_unreferenced_files() {
         let directory = tempdir().unwrap();
         let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
@@ -878,6 +979,7 @@ mod tests {
 
         assert_eq!(report.ready_count, 0);
         assert_eq!(report.pending_count, 0);
+        assert_eq!(report.invalid_count, 1);
         assert_eq!(report.issues.len(), 2);
         assert!(
             report
@@ -955,5 +1057,29 @@ mod tests {
         assert_ne!(first.id, second.id);
         assert!(first.audio_path.starts_with(store.root()));
         assert!(second.audio_path.starts_with(store.root()));
+    }
+
+    #[test]
+    fn scoring_digest_ignores_capture_text_but_changes_with_reference() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        let id = captured_sample(&store, 42);
+        store.correct_sample(&id, "使用 Codex", Vec::new()).unwrap();
+        let first = store.scoring_snapshot("policy-v1").unwrap().digest;
+
+        let sidecar = store.sample_path(&id).unwrap();
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&sidecar).unwrap()).unwrap();
+        value["capture"]["transcription"]["text"] = serde_json::json!("另一个初始结果");
+        fs::write(&sidecar, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+        let capture_changed = store.scoring_snapshot("policy-v1").unwrap().digest;
+
+        store
+            .correct_sample(&id, "使用 Codex 完成任务", Vec::new())
+            .unwrap();
+        let reference_changed = store.scoring_snapshot("policy-v1").unwrap().digest;
+
+        assert_eq!(capture_changed, first);
+        assert_ne!(reference_changed, first);
     }
 }

--- a/src/prompt_lab/dataset.rs
+++ b/src/prompt_lab/dataset.rs
@@ -1,0 +1,959 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::transcriber::TranscriberMetadata;
+
+const DATASET_SCHEMA_VERSION: u32 = 1;
+const SAMPLE_SCHEMA_VERSION: u32 = 1;
+
+type Result<T> = std::result::Result<T, DatasetError>;
+
+#[derive(Debug)]
+pub(crate) enum DatasetError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    Wav(hound::Error),
+    Invalid(String),
+}
+
+impl fmt::Display for DatasetError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "dataset I/O failed: {error}"),
+            Self::Json(error) => write!(formatter, "invalid dataset JSON: {error}"),
+            Self::Wav(error) => write!(formatter, "invalid dataset WAV: {error}"),
+            Self::Invalid(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for DatasetError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Json(error) => Some(error),
+            Self::Wav(error) => Some(error),
+            Self::Invalid(_) => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for DatasetError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for DatasetError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl From<hound::Error> for DatasetError {
+    fn from(error: hound::Error) -> Self {
+        Self::Wav(error)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DatasetManifest {
+    schema_version: u32,
+    created_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SttSnapshot {
+    pub(crate) endpoint: String,
+    pub(crate) model: String,
+    pub(crate) language: Option<String>,
+    pub(crate) temperature: f32,
+    pub(crate) prompt: Option<String>,
+}
+
+impl From<TranscriberMetadata> for SttSnapshot {
+    fn from(metadata: TranscriberMetadata) -> Self {
+        Self {
+            endpoint: metadata.endpoint,
+            model: metadata.model,
+            language: metadata.language,
+            temperature: metadata.temperature,
+            prompt: metadata.prompt,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CaptureStatus {
+    Success,
+    Partial,
+    Failed,
+    Interrupted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CaptureTranscription {
+    pub(crate) status: CaptureStatus,
+    pub(crate) text: Option<String>,
+    pub(crate) error: Option<String>,
+    pub(crate) stt: SttSnapshot,
+}
+
+impl CaptureTranscription {
+    pub(crate) fn success(text: impl Into<String>, stt: SttSnapshot) -> Self {
+        Self {
+            status: CaptureStatus::Success,
+            text: Some(text.into()),
+            error: None,
+            stt,
+        }
+    }
+
+    pub(crate) fn partial(
+        text: impl Into<String>,
+        error: impl Into<String>,
+        stt: SttSnapshot,
+    ) -> Self {
+        Self {
+            status: CaptureStatus::Partial,
+            text: Some(text.into()),
+            error: Some(error.into()),
+            stt,
+        }
+    }
+
+    pub(crate) fn failed(error: impl Into<String>, stt: SttSnapshot) -> Self {
+        Self {
+            status: CaptureStatus::Failed,
+            text: None,
+            error: Some(error.into()),
+            stt,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if !self.stt.temperature.is_finite() {
+            return Err(DatasetError::Invalid(
+                "capture STT temperature must be finite".to_string(),
+            ));
+        }
+        if self.stt.endpoint.trim().is_empty() || self.stt.model.trim().is_empty() {
+            return Err(DatasetError::Invalid(
+                "capture STT endpoint and model must not be empty".to_string(),
+            ));
+        }
+        let has_text = self
+            .text
+            .as_deref()
+            .is_some_and(|text| !text.trim().is_empty());
+        let has_error = self
+            .error
+            .as_deref()
+            .is_some_and(|error| !error.trim().is_empty());
+        let valid = match self.status {
+            CaptureStatus::Success => has_text && self.error.is_none(),
+            CaptureStatus::Partial => has_text && has_error,
+            CaptureStatus::Failed | CaptureStatus::Interrupted => self.text.is_none() && has_error,
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(DatasetError::Invalid(format!(
+                "capture fields do not match {:?} status",
+                self.status
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProperNounAnnotation {
+    pub(crate) canonical: String,
+    #[serde(default)]
+    pub(crate) accepted: Vec<String>,
+    pub(crate) case_sensitive: bool,
+    pub(crate) expected_occurrences: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReferenceStatus {
+    Pending,
+    Ready,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReferenceRecord {
+    pub(crate) status: ReferenceStatus,
+    pub(crate) text: Option<String>,
+    #[serde(default)]
+    pub(crate) proper_nouns: Vec<ProperNounAnnotation>,
+}
+
+impl ReferenceRecord {
+    fn pending() -> Self {
+        Self {
+            status: ReferenceStatus::Pending,
+            text: None,
+            proper_nouns: Vec::new(),
+        }
+    }
+
+    fn ready(text: String, proper_nouns: Vec<ProperNounAnnotation>) -> Result<Self> {
+        let candidate = Self {
+            status: ReferenceStatus::Ready,
+            text: Some(text),
+            proper_nouns,
+        };
+        candidate.validate()?;
+        Ok(candidate)
+    }
+
+    fn validate(&self) -> Result<()> {
+        match self.status {
+            ReferenceStatus::Pending => {
+                if self.text.is_none() && self.proper_nouns.is_empty() {
+                    Ok(())
+                } else {
+                    Err(DatasetError::Invalid(
+                        "pending reference must not contain text or proper nouns".to_string(),
+                    ))
+                }
+            }
+            ReferenceStatus::Ready => {
+                let text = self.text.as_deref().ok_or_else(|| {
+                    DatasetError::Invalid("ready reference is missing text".to_string())
+                })?;
+                if text.trim().is_empty() {
+                    return Err(DatasetError::Invalid(
+                        "ready reference text must not be empty".to_string(),
+                    ));
+                }
+                validate_annotations(text, &self.proper_nouns)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AudioRecord {
+    pub(crate) path: String,
+    pub(crate) sha256: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CaptureRecord {
+    pub(crate) created_at_unix_ms: u64,
+    pub(crate) transcription: CaptureTranscription,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SampleRecord {
+    schema_version: u32,
+    pub(crate) id: String,
+    pub(crate) audio: AudioRecord,
+    pub(crate) capture: CaptureRecord,
+    pub(crate) reference: ReferenceRecord,
+}
+
+#[derive(Debug)]
+pub(crate) struct SampleReservation {
+    pub(crate) id: String,
+    pub(crate) audio_path: PathBuf,
+    sample_path: PathBuf,
+    created_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DatasetIssue {
+    pub(crate) code: String,
+    pub(crate) path: PathBuf,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct DatasetValidation {
+    pub(crate) ready_count: usize,
+    pub(crate) pending_count: usize,
+    pub(crate) issues: Vec<DatasetIssue>,
+}
+
+#[derive(Debug)]
+pub(crate) struct DatasetStore {
+    root: PathBuf,
+    next_id: AtomicU64,
+}
+
+impl DatasetStore {
+    pub(crate) fn open_or_create(root: PathBuf) -> Result<Self> {
+        fs::create_dir_all(&root)?;
+        let root = fs::canonicalize(root)?;
+        for name in ["audio", "samples", "runs"] {
+            ensure_owned_directory(&root, name)?;
+        }
+        let manifest_path = root.join("dataset.json");
+        match fs::symlink_metadata(&manifest_path) {
+            Ok(metadata) => {
+                if !metadata.is_file() || metadata.file_type().is_symlink() {
+                    return Err(DatasetError::Invalid(format!(
+                        "dataset manifest must be a regular file: {}",
+                        manifest_path.display()
+                    )));
+                }
+                let manifest: DatasetManifest = serde_json::from_slice(&fs::read(&manifest_path)?)?;
+                if manifest.schema_version != DATASET_SCHEMA_VERSION {
+                    return Err(DatasetError::Invalid(format!(
+                        "unsupported dataset schema_version {}; expected {DATASET_SCHEMA_VERSION}",
+                        manifest.schema_version
+                    )));
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                write_json(
+                    &manifest_path,
+                    &DatasetManifest {
+                        schema_version: DATASET_SCHEMA_VERSION,
+                        created_at_unix_ms: unix_time_ms()?,
+                    },
+                )?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+        Ok(Self {
+            root,
+            next_id: AtomicU64::new(1),
+        })
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn audio_dir(&self) -> PathBuf {
+        self.root.join("audio")
+    }
+
+    pub(crate) fn samples_dir(&self) -> PathBuf {
+        self.root.join("samples")
+    }
+
+    pub(crate) fn reserve_sample(&self, created_at_unix_ms: u64) -> Result<SampleReservation> {
+        loop {
+            let sequence = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let id = format!("sample-{created_at_unix_ms}-{sequence}");
+            let audio_path = self.audio_dir().join(format!("{id}.wav"));
+            let sample_path = self.samples_dir().join(format!("{id}.json"));
+            if !audio_path.exists() && !sample_path.exists() {
+                return Ok(SampleReservation {
+                    id,
+                    audio_path,
+                    sample_path,
+                    created_at_unix_ms,
+                });
+            }
+        }
+    }
+
+    pub(crate) fn complete_capture(
+        &self,
+        reservation: SampleReservation,
+        transcription: CaptureTranscription,
+    ) -> Result<SampleRecord> {
+        transcription.validate()?;
+        let expected_audio = self.audio_dir().join(format!("{}.wav", reservation.id));
+        let expected_sample = self.samples_dir().join(format!("{}.json", reservation.id));
+        if reservation.audio_path != expected_audio || reservation.sample_path != expected_sample {
+            return Err(DatasetError::Invalid(
+                "sample reservation does not belong to this dataset".to_string(),
+            ));
+        }
+        if expected_sample.exists() {
+            return Err(DatasetError::Invalid(format!(
+                "sample {} already exists",
+                reservation.id
+            )));
+        }
+        validate_wav(&expected_audio)?;
+        let sha256 = sha256_file(&expected_audio)?;
+        let sample = SampleRecord {
+            schema_version: SAMPLE_SCHEMA_VERSION,
+            id: reservation.id.clone(),
+            audio: AudioRecord {
+                path: format!("audio/{}.wav", reservation.id),
+                sha256,
+            },
+            capture: CaptureRecord {
+                created_at_unix_ms: reservation.created_at_unix_ms,
+                transcription,
+            },
+            reference: ReferenceRecord::pending(),
+        };
+        write_json(&expected_sample, &sample)?;
+        Ok(sample)
+    }
+
+    pub(crate) fn correct_sample(
+        &self,
+        id: &str,
+        text: &str,
+        proper_nouns: Vec<ProperNounAnnotation>,
+    ) -> Result<SampleRecord> {
+        let mut sample = self.load_sample(id)?;
+        let reference = ReferenceRecord::ready(text.to_string(), proper_nouns)?;
+        self.validate_audio(&sample)?;
+        sample.reference = reference;
+        write_json(&self.sample_path(id)?, &sample)?;
+        Ok(sample)
+    }
+
+    pub(crate) fn load_sample(&self, id: &str) -> Result<SampleRecord> {
+        validate_id(id)?;
+        let path = self.sample_path(id)?;
+        let sample: SampleRecord = serde_json::from_slice(&fs::read(path)?)?;
+        self.validate_sample_identity(&sample, id)?;
+        sample.capture.transcription.validate()?;
+        sample.reference.validate()?;
+        Ok(sample)
+    }
+
+    pub(crate) fn list_samples(
+        &self,
+        status: Option<ReferenceStatus>,
+    ) -> Result<Vec<SampleRecord>> {
+        let mut entries = fs::read_dir(self.samples_dir())?.collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        let mut samples = Vec::new();
+        for entry in entries {
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            let id = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .ok_or_else(|| {
+                    DatasetError::Invalid(format!("invalid sample file name: {}", path.display()))
+                })?;
+            let sample = self.load_sample(id)?;
+            if status.is_none_or(|status| sample.reference.status == status) {
+                samples.push(sample);
+            }
+        }
+        Ok(samples)
+    }
+
+    pub(crate) fn sample_path(&self, id: &str) -> Result<PathBuf> {
+        validate_id(id)?;
+        Ok(self.samples_dir().join(format!("{id}.json")))
+    }
+
+    pub(crate) fn validate(&self) -> Result<DatasetValidation> {
+        let mut report = DatasetValidation {
+            ready_count: 0,
+            pending_count: 0,
+            issues: Vec::new(),
+        };
+        let mut referenced_audio = HashSet::new();
+        let mut entries = fs::read_dir(self.samples_dir())?.collect::<std::io::Result<Vec<_>>>()?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            if entry.file_type()?.is_symlink()
+                || path.extension().and_then(|ext| ext.to_str()) != Some("json")
+            {
+                report.issues.push(issue(
+                    "sample_file",
+                    &path,
+                    "sample entry must be a regular JSON file",
+                ));
+                continue;
+            }
+            let sample: SampleRecord = match fs::read(&path)
+                .map_err(DatasetError::from)
+                .and_then(|bytes| serde_json::from_slice(&bytes).map_err(DatasetError::from))
+            {
+                Ok(sample) => sample,
+                Err(error) => {
+                    report
+                        .issues
+                        .push(issue("sample_json", &path, &error.to_string()));
+                    continue;
+                }
+            };
+            referenced_audio.insert(sample.audio.path.clone());
+            let expected_id = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("");
+            let validation = self
+                .validate_sample_identity(&sample, expected_id)
+                .and_then(|()| sample.capture.transcription.validate())
+                .and_then(|()| sample.reference.validate())
+                .and_then(|()| self.validate_audio(&sample));
+            match validation {
+                Ok(()) => match sample.reference.status {
+                    ReferenceStatus::Ready => report.ready_count += 1,
+                    ReferenceStatus::Pending => report.pending_count += 1,
+                },
+                Err(error) => {
+                    report
+                        .issues
+                        .push(issue("sample_invalid", &path, &error.to_string()))
+                }
+            }
+        }
+
+        let mut audio_entries =
+            fs::read_dir(self.audio_dir())?.collect::<std::io::Result<Vec<_>>>()?;
+        audio_entries.sort_by_key(|entry| entry.file_name());
+        for entry in audio_entries {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(&self.root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            if !referenced_audio.contains(&relative) {
+                report.issues.push(issue(
+                    "unreferenced_audio",
+                    &path,
+                    "audio file is not owned by a sample sidecar",
+                ));
+            }
+        }
+        Ok(report)
+    }
+
+    fn validate_sample_identity(&self, sample: &SampleRecord, expected_id: &str) -> Result<()> {
+        if sample.schema_version != SAMPLE_SCHEMA_VERSION {
+            return Err(DatasetError::Invalid(format!(
+                "unsupported sample schema_version {}; expected {SAMPLE_SCHEMA_VERSION}",
+                sample.schema_version
+            )));
+        }
+        validate_id(&sample.id)?;
+        if sample.id != expected_id {
+            return Err(DatasetError::Invalid(format!(
+                "sample ID {} does not match file name {expected_id}",
+                sample.id
+            )));
+        }
+        let expected = format!("audio/{}.wav", sample.id);
+        if sample.audio.path != expected {
+            return Err(DatasetError::Invalid(format!(
+                "sample audio path must be {expected}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_audio(&self, sample: &SampleRecord) -> Result<()> {
+        let path = self.root.join(&sample.audio.path);
+        let metadata = fs::symlink_metadata(&path)?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(DatasetError::Invalid(format!(
+                "sample audio is not a regular file: {}",
+                path.display()
+            )));
+        }
+        let canonical = fs::canonicalize(&path)?;
+        if !canonical.starts_with(&self.root) {
+            return Err(DatasetError::Invalid(
+                "sample audio escapes the dataset root".to_string(),
+            ));
+        }
+        validate_wav(&canonical)?;
+        let actual = sha256_file(&canonical)?;
+        if actual != sample.audio.sha256 {
+            return Err(DatasetError::Invalid(format!(
+                "sample audio digest mismatch for {}",
+                sample.id
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn ensure_owned_directory(root: &Path, name: &str) -> Result<()> {
+    let path = root.join(name);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir(&path)?;
+            fs::symlink_metadata(&path)?
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(DatasetError::Invalid(format!(
+            "dataset {name} directory must not be a symlink: {}",
+            path.display()
+        )));
+    }
+    let canonical = fs::canonicalize(&path)?;
+    if !canonical.starts_with(root) {
+        return Err(DatasetError::Invalid(format!(
+            "dataset {name} directory escapes the dataset root"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_id(id: &str) -> Result<()> {
+    let valid = id.starts_with("sample-")
+        && id.len() > "sample-".len()
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-');
+    if valid {
+        Ok(())
+    } else {
+        Err(DatasetError::Invalid(format!("invalid sample ID: {id}")))
+    }
+}
+
+fn validate_annotations(text: &str, annotations: &[ProperNounAnnotation]) -> Result<()> {
+    let mut all_forms = HashSet::new();
+    for annotation in annotations {
+        if annotation.canonical.trim().is_empty() {
+            return Err(DatasetError::Invalid(
+                "proper noun canonical form must not be empty".to_string(),
+            ));
+        }
+        if annotation.expected_occurrences == 0 {
+            return Err(DatasetError::Invalid(
+                "proper noun expected_occurrences must be greater than zero".to_string(),
+            ));
+        }
+        let mut forms = Vec::with_capacity(annotation.accepted.len() + 1);
+        forms.push(annotation.canonical.as_str());
+        forms.extend(annotation.accepted.iter().map(String::as_str));
+        let mut local_forms = HashSet::new();
+        for form in &forms {
+            if form.trim().is_empty() {
+                return Err(DatasetError::Invalid(
+                    "proper noun accepted forms must not be empty".to_string(),
+                ));
+            }
+            let normalized = normalize_case(form, annotation.case_sensitive);
+            if !local_forms.insert(normalized.clone()) {
+                return Err(DatasetError::Invalid(format!(
+                    "duplicate accepted form for {}",
+                    annotation.canonical
+                )));
+            }
+            if !all_forms.insert(normalized) {
+                return Err(DatasetError::Invalid(format!(
+                    "ambiguous proper noun form: {form}"
+                )));
+            }
+        }
+        let count = count_non_overlapping_forms(text, &forms, annotation.case_sensitive);
+        if count != annotation.expected_occurrences as usize {
+            return Err(DatasetError::Invalid(format!(
+                "proper noun {} expected_occurrences is {}, but reference contains {count}",
+                annotation.canonical, annotation.expected_occurrences
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn count_non_overlapping_forms(text: &str, forms: &[&str], case_sensitive: bool) -> usize {
+    let text = normalize_case(text, case_sensitive);
+    let mut forms = forms
+        .iter()
+        .map(|form| normalize_case(form, case_sensitive))
+        .collect::<Vec<_>>();
+    forms.sort_by_key(|form| std::cmp::Reverse(form.len()));
+    let mut occupied = vec![false; text.len()];
+    let mut count = 0;
+    for form in forms {
+        for (start, _) in text.match_indices(&form) {
+            let end = start + form.len();
+            if !occupied[start..end].iter().any(|value| *value) {
+                occupied[start..end].fill(true);
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+fn normalize_case(value: &str, case_sensitive: bool) -> String {
+    if case_sensitive {
+        value.to_string()
+    } else {
+        value.to_lowercase()
+    }
+}
+
+fn validate_wav(path: &Path) -> Result<()> {
+    let reader = hound::WavReader::open(path)?;
+    let spec = reader.spec();
+    if spec.channels == 0 || spec.sample_rate == 0 || spec.bits_per_sample == 0 || reader.len() == 0
+    {
+        return Err(DatasetError::Invalid(format!(
+            "sample WAV is empty or has an invalid format: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn unix_time_ms() -> Result<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            DatasetError::Invalid(format!("system clock is before UNIX epoch: {error}"))
+        })?
+        .as_millis()
+        .try_into()
+        .map_err(|_| DatasetError::Invalid("current timestamp does not fit u64".to_string()))
+}
+
+fn issue(code: &str, path: &Path, message: &str) -> DatasetIssue {
+    DatasetIssue {
+        code: code.to_string(),
+        path: path.to_path_buf(),
+        message: message.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use hound::{SampleFormat, WavSpec, WavWriter};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write_test_wav(path: &Path) {
+        let mut writer = WavWriter::create(
+            path,
+            WavSpec {
+                channels: 1,
+                sample_rate: 16_000,
+                bits_per_sample: 16,
+                sample_format: SampleFormat::Int,
+            },
+        )
+        .unwrap();
+        for sample in [0_i16, 1, -1, 2] {
+            writer.write_sample(sample).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn snapshot() -> SttSnapshot {
+        SttSnapshot {
+            endpoint: "https://api.example.test/v1/audio/transcriptions".to_string(),
+            model: "whisper-test".to_string(),
+            language: Some("zh".to_string()),
+            temperature: 0.0,
+            prompt: Some("技术词汇提示".to_string()),
+        }
+    }
+
+    fn captured_sample(store: &DatasetStore, timestamp: u64) -> String {
+        let reservation = store.reserve_sample(timestamp).unwrap();
+        write_test_wav(&reservation.audio_path);
+        let id = reservation.id.clone();
+        store
+            .complete_capture(
+                reservation,
+                CaptureTranscription::success("使用 ViberWhisper", snapshot()),
+            )
+            .unwrap();
+        id
+    }
+
+    #[test]
+    fn capture_and_correction_build_a_ready_sample() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        let id = captured_sample(&store, 42);
+
+        let pending = store.validate().unwrap();
+        assert_eq!(pending.ready_count, 0);
+        assert_eq!(pending.pending_count, 1);
+        assert!(pending.issues.is_empty());
+
+        store
+            .correct_sample(
+                &id,
+                "使用 ViberWhisper",
+                vec![ProperNounAnnotation {
+                    canonical: "ViberWhisper".to_string(),
+                    accepted: vec!["Viber Whisper".to_string()],
+                    case_sensitive: false,
+                    expected_occurrences: 1,
+                }],
+            )
+            .unwrap();
+
+        let sample = store.load_sample(&id).unwrap();
+        assert_eq!(sample.reference.status, ReferenceStatus::Ready);
+        assert_eq!(sample.reference.text.as_deref(), Some("使用 ViberWhisper"));
+        assert!(!sample.audio.sha256.is_empty());
+        let ready = store.validate().unwrap();
+        assert_eq!(ready.ready_count, 1);
+        assert_eq!(ready.pending_count, 0);
+        assert!(ready.issues.is_empty());
+    }
+
+    #[test]
+    fn invalid_correction_does_not_rewrite_the_sidecar() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        let id = captured_sample(&store, 42);
+        let path = store.sample_path(&id).unwrap();
+        let before = fs::read(&path).unwrap();
+
+        let error = store
+            .correct_sample(
+                &id,
+                "只出现一次 Example",
+                vec![ProperNounAnnotation {
+                    canonical: "Example".to_string(),
+                    accepted: Vec::new(),
+                    case_sensitive: true,
+                    expected_occurrences: 2,
+                }],
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("expected_occurrences"));
+        assert_eq!(fs::read(path).unwrap(), before);
+    }
+
+    #[test]
+    fn validation_reports_malformed_and_unreferenced_files() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        fs::write(store.samples_dir().join("broken.json"), b"{broken").unwrap();
+        write_test_wav(&store.audio_dir().join("orphan.wav"));
+
+        let report = store.validate().unwrap();
+
+        assert_eq!(report.ready_count, 0);
+        assert_eq!(report.pending_count, 0);
+        assert_eq!(report.issues.len(), 2);
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.code == "sample_json")
+        );
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.code == "unreferenced_audio")
+        );
+    }
+
+    #[test]
+    fn strict_manifest_rejects_unknown_fields() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("dataset");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("dataset.json"),
+            r#"{"schema_version":1,"created_at_unix_ms":1,"unknown":true}"#,
+        )
+        .unwrap();
+
+        let error = DatasetStore::open_or_create(root).unwrap_err();
+
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opening_dataset_rejects_symlinked_storage_directory() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("dataset");
+        let outside = directory.path().join("outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, root.join("audio")).unwrap();
+
+        let error = DatasetStore::open_or_create(root).unwrap_err();
+
+        assert!(error.to_string().contains("audio"));
+        assert!(error.to_string().contains("symlink"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opening_dataset_rejects_dangling_manifest_symlink_without_writing_target() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("dataset");
+        let outside_manifest = directory.path().join("outside-dataset.json");
+        fs::create_dir_all(&root).unwrap();
+        symlink(&outside_manifest, root.join("dataset.json")).unwrap();
+
+        let error = DatasetStore::open_or_create(root).unwrap_err();
+
+        assert!(error.to_string().contains("manifest"));
+        assert!(!outside_manifest.exists());
+    }
+
+    #[test]
+    fn reservations_remain_unique_for_the_same_timestamp() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+
+        let first = store.reserve_sample(42).unwrap();
+        let second = store.reserve_sample(42).unwrap();
+
+        assert_ne!(first.id, second.id);
+        assert!(first.audio_path.starts_with(store.root()));
+        assert!(second.audio_path.starts_with(store.root()));
+    }
+}

--- a/src/prompt_lab/metrics.rs
+++ b/src/prompt_lab/metrics.rs
@@ -1,0 +1,432 @@
+use jieba_rs::Jieba;
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+use unicode_normalization::UnicodeNormalization;
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::ProperNounAnnotation;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WerOperation {
+    Equal,
+    Substitution,
+    Deletion,
+    Insertion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WerEdit {
+    pub(crate) operation: WerOperation,
+    pub(crate) reference: Option<String>,
+    pub(crate) hypothesis: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WerScore {
+    pub(crate) reference_words: u64,
+    pub(crate) substitutions: u64,
+    pub(crate) deletions: u64,
+    pub(crate) insertions: u64,
+    pub(crate) wer_percent: f64,
+    pub(crate) alignment: Vec<WerEdit>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProperNounAnnotationScore {
+    pub(crate) canonical: String,
+    pub(crate) expected_occurrences: u32,
+    pub(crate) matched_occurrences: u32,
+    pub(crate) matched_forms: Vec<String>,
+    pub(crate) missed_occurrences: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProperNounScore {
+    pub(crate) matched_occurrences: u64,
+    pub(crate) expected_occurrences: u64,
+    pub(crate) accuracy_percent: f64,
+    pub(crate) annotations: Vec<ProperNounAnnotationScore>,
+}
+
+pub(crate) fn score_wer(reference: &str, hypothesis: &str) -> WerScore {
+    let reference = normalize(reference);
+    let hypothesis = normalize(hypothesis);
+    let use_jieba = reference.chars().any(is_han);
+    let reference_tokens = tokenize(&reference, use_jieba);
+    let hypothesis_tokens = tokenize(&hypothesis, use_jieba);
+    align_tokens(&reference_tokens, &hypothesis_tokens)
+}
+
+fn tokenize(text: &str, use_jieba: bool) -> Vec<String> {
+    let tokens = if use_jieba {
+        static JIEBA: OnceLock<Jieba> = OnceLock::new();
+        JIEBA
+            .get_or_init(Jieba::new)
+            .cut(text, false)
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    } else {
+        text.unicode_words().map(str::to_string).collect()
+    };
+    tokens
+        .into_iter()
+        .filter(|token| token.chars().any(is_scored_character))
+        .map(|token| token.to_lowercase())
+        .collect()
+}
+
+fn align_tokens(reference: &[String], hypothesis: &[String]) -> WerScore {
+    let row_len = hypothesis.len() + 1;
+    let mut costs = vec![0_usize; (reference.len() + 1) * row_len];
+    for (index, cost) in costs.iter_mut().take(row_len).enumerate() {
+        *cost = index;
+    }
+    for index in 1..=reference.len() {
+        costs[index * row_len] = index;
+    }
+    for reference_index in 1..=reference.len() {
+        for hypothesis_index in 1..=hypothesis.len() {
+            let substitution = costs[(reference_index - 1) * row_len + hypothesis_index - 1]
+                + usize::from(reference[reference_index - 1] != hypothesis[hypothesis_index - 1]);
+            let deletion = costs[(reference_index - 1) * row_len + hypothesis_index] + 1;
+            let insertion = costs[reference_index * row_len + hypothesis_index - 1] + 1;
+            costs[reference_index * row_len + hypothesis_index] =
+                substitution.min(deletion).min(insertion);
+        }
+    }
+
+    let mut reference_index = reference.len();
+    let mut hypothesis_index = hypothesis.len();
+    let mut alignment = Vec::with_capacity(reference_index.max(hypothesis_index));
+    let mut substitutions = 0_u64;
+    let mut deletions = 0_u64;
+    let mut insertions = 0_u64;
+    while reference_index > 0 || hypothesis_index > 0 {
+        let current = costs[reference_index * row_len + hypothesis_index];
+        if reference_index > 0
+            && hypothesis_index > 0
+            && reference[reference_index - 1] == hypothesis[hypothesis_index - 1]
+            && current == costs[(reference_index - 1) * row_len + hypothesis_index - 1]
+        {
+            alignment.push(WerEdit {
+                operation: WerOperation::Equal,
+                reference: Some(reference[reference_index - 1].clone()),
+                hypothesis: Some(hypothesis[hypothesis_index - 1].clone()),
+            });
+            reference_index -= 1;
+            hypothesis_index -= 1;
+        } else if reference_index > 0
+            && hypothesis_index > 0
+            && current == costs[(reference_index - 1) * row_len + hypothesis_index - 1] + 1
+        {
+            alignment.push(WerEdit {
+                operation: WerOperation::Substitution,
+                reference: Some(reference[reference_index - 1].clone()),
+                hypothesis: Some(hypothesis[hypothesis_index - 1].clone()),
+            });
+            substitutions += 1;
+            reference_index -= 1;
+            hypothesis_index -= 1;
+        } else if reference_index > 0
+            && current == costs[(reference_index - 1) * row_len + hypothesis_index] + 1
+        {
+            alignment.push(WerEdit {
+                operation: WerOperation::Deletion,
+                reference: Some(reference[reference_index - 1].clone()),
+                hypothesis: None,
+            });
+            deletions += 1;
+            reference_index -= 1;
+        } else {
+            alignment.push(WerEdit {
+                operation: WerOperation::Insertion,
+                reference: None,
+                hypothesis: Some(hypothesis[hypothesis_index - 1].clone()),
+            });
+            insertions += 1;
+            hypothesis_index -= 1;
+        }
+    }
+    alignment.reverse();
+    let reference_words = reference.len() as u64;
+    let errors = substitutions + deletions + insertions;
+    let wer_percent = if reference_words == 0 {
+        0.0
+    } else {
+        errors as f64 * 100.0 / reference_words as f64
+    };
+    WerScore {
+        reference_words,
+        substitutions,
+        deletions,
+        insertions,
+        wer_percent,
+        alignment,
+    }
+}
+
+pub(crate) fn score_proper_nouns(
+    hypothesis: &str,
+    annotations: &[ProperNounAnnotation],
+) -> ProperNounScore {
+    let matched_forms = match_proper_nouns(hypothesis, annotations, true);
+    let annotations = annotations
+        .iter()
+        .zip(matched_forms)
+        .map(|(annotation, matched_forms)| {
+            let matched_occurrences = matched_forms.len() as u32;
+            ProperNounAnnotationScore {
+                canonical: annotation.canonical.clone(),
+                expected_occurrences: annotation.expected_occurrences,
+                matched_occurrences,
+                matched_forms,
+                missed_occurrences: annotation.expected_occurrences - matched_occurrences,
+            }
+        })
+        .collect::<Vec<_>>();
+    let matched_occurrences = annotations
+        .iter()
+        .map(|annotation| u64::from(annotation.matched_occurrences))
+        .sum();
+    let expected_occurrences = annotations
+        .iter()
+        .map(|annotation| u64::from(annotation.expected_occurrences))
+        .sum();
+    let accuracy_percent = if expected_occurrences == 0 {
+        0.0
+    } else {
+        matched_occurrences as f64 * 100.0 / expected_occurrences as f64
+    };
+    ProperNounScore {
+        matched_occurrences,
+        expected_occurrences,
+        accuracy_percent,
+        annotations,
+    }
+}
+
+pub(super) fn count_proper_noun_occurrences(
+    text: &str,
+    annotations: &[ProperNounAnnotation],
+) -> Vec<usize> {
+    match_proper_nouns(text, annotations, false)
+        .into_iter()
+        .map(|forms| forms.len())
+        .collect()
+}
+
+fn match_proper_nouns(
+    hypothesis: &str,
+    annotations: &[ProperNounAnnotation],
+    cap_at_expected: bool,
+) -> Vec<Vec<String>> {
+    let text = normalize(hypothesis);
+    let text_chars = text.chars().collect::<Vec<_>>();
+    let mut candidates = Vec::new();
+    for (annotation_index, annotation) in annotations.iter().enumerate() {
+        for form in std::iter::once(&annotation.canonical).chain(annotation.accepted.iter()) {
+            let normalized_form = normalize(form);
+            let form_chars = normalized_form.chars().collect::<Vec<_>>();
+            if form_chars.is_empty() || form_chars.len() > text_chars.len() {
+                continue;
+            }
+            for start in 0..=text_chars.len() - form_chars.len() {
+                let end = start + form_chars.len();
+                if form_matches(
+                    &text_chars[start..end],
+                    &form_chars,
+                    annotation.case_sensitive,
+                ) && has_required_boundaries(&text_chars, start, end, &form_chars)
+                {
+                    candidates.push(MatchCandidate {
+                        annotation_index,
+                        start,
+                        end,
+                        form: form.clone(),
+                    });
+                }
+            }
+        }
+    }
+    candidates.sort_by(|left, right| {
+        (right.end - right.start)
+            .cmp(&(left.end - left.start))
+            .then(left.start.cmp(&right.start))
+            .then(left.annotation_index.cmp(&right.annotation_index))
+            .then(left.form.cmp(&right.form))
+    });
+
+    let mut occupied = vec![false; text_chars.len()];
+    let mut matched_forms = vec![Vec::new(); annotations.len()];
+    for candidate in candidates {
+        let annotation = &annotations[candidate.annotation_index];
+        if (cap_at_expected
+            && matched_forms[candidate.annotation_index].len()
+                >= annotation.expected_occurrences as usize)
+            || occupied[candidate.start..candidate.end]
+                .iter()
+                .any(|occupied| *occupied)
+        {
+            continue;
+        }
+        occupied[candidate.start..candidate.end].fill(true);
+        matched_forms[candidate.annotation_index].push(candidate.form);
+    }
+    matched_forms
+}
+
+struct MatchCandidate {
+    annotation_index: usize,
+    start: usize,
+    end: usize,
+    form: String,
+}
+
+fn form_matches(text: &[char], form: &[char], case_sensitive: bool) -> bool {
+    text.iter().zip(form).all(|(left, right)| {
+        left == right
+            || (!case_sensitive
+                && left
+                    .to_lowercase()
+                    .to_string()
+                    .eq(&right.to_lowercase().to_string()))
+    })
+}
+
+fn has_required_boundaries(text: &[char], start: usize, end: usize, form: &[char]) -> bool {
+    if !form.iter().all(|character| character.is_alphanumeric()) {
+        return true;
+    }
+    let starts_at_boundary = start == 0 || !text[start - 1].is_alphanumeric();
+    let ends_at_boundary = end == text.len() || !text[end].is_alphanumeric();
+    starts_at_boundary && ends_at_boundary
+}
+
+fn normalize(text: &str) -> String {
+    text.nfkc().collect()
+}
+
+fn is_scored_character(character: char) -> bool {
+    character.is_alphanumeric() || is_han(character)
+}
+
+fn is_han(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0x20000..=0x2FA1F
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prompt_lab::ProperNounAnnotation;
+
+    use super::{WerOperation, score_proper_nouns, score_wer};
+
+    #[test]
+    fn wer_aligns_substitutions_deletions_and_insertions() {
+        let score = score_wer(
+            "start deleted anchor replace old end",
+            "start anchor replace new inserted end",
+        );
+
+        assert_eq!(score.reference_words, 6);
+        assert_eq!(score.substitutions, 1);
+        assert_eq!(score.deletions, 1);
+        assert_eq!(score.insertions, 1);
+        assert_eq!(score.wer_percent, 50.0);
+        assert!(
+            score
+                .alignment
+                .iter()
+                .any(|edit| edit.operation == WerOperation::Substitution)
+        );
+    }
+
+    #[test]
+    fn wer_uses_nfkc_case_folding_and_han_segmentation() {
+        let equivalent = score_wer("ＶｉｂｅｒWhisper 使用语音输入", "viberwhisper使用语音输入");
+        let changed = score_wer("我喜欢自然语言处理", "我喜欢自然处理");
+
+        assert_eq!(equivalent.wer_percent, 0.0);
+        assert!(changed.deletions + changed.substitutions > 0);
+    }
+
+    #[test]
+    fn wer_can_exceed_one_hundred_percent_for_insertions() {
+        let score = score_wer("one", "one extra words");
+
+        assert_eq!(score.insertions, 2);
+        assert_eq!(score.wer_percent, 200.0);
+    }
+
+    #[test]
+    fn proper_nouns_accept_aliases_case_policy_and_occurrence_caps() {
+        let annotations = vec![ProperNounAnnotation {
+            canonical: "ViberWhisper".to_string(),
+            accepted: vec!["Viber Whisper".to_string()],
+            case_sensitive: false,
+            expected_occurrences: 2,
+        }];
+
+        let score = score_proper_nouns(
+            "VIBERWHISPER and Viber Whisper and ViberWhisper",
+            &annotations,
+        );
+
+        assert_eq!(score.matched_occurrences, 2);
+        assert_eq!(score.expected_occurrences, 2);
+        assert_eq!(score.accuracy_percent, 100.0);
+        assert_eq!(score.annotations[0].matched_forms.len(), 2);
+    }
+
+    #[test]
+    fn proper_noun_alphanumeric_forms_require_token_boundaries() {
+        let annotations = vec![ProperNounAnnotation {
+            canonical: "Codex".to_string(),
+            accepted: Vec::new(),
+            case_sensitive: true,
+            expected_occurrences: 1,
+        }];
+
+        let embedded = score_proper_nouns("MyCodexTool", &annotations);
+        let standalone = score_proper_nouns("Use Codex now", &annotations);
+
+        assert_eq!(embedded.matched_occurrences, 0);
+        assert_eq!(standalone.matched_occurrences, 1);
+    }
+
+    #[test]
+    fn proper_noun_overlaps_are_consumed_longest_first() {
+        let annotations = vec![
+            ProperNounAnnotation {
+                canonical: "OpenAI Codex".to_string(),
+                accepted: Vec::new(),
+                case_sensitive: true,
+                expected_occurrences: 1,
+            },
+            ProperNounAnnotation {
+                canonical: "Codex".to_string(),
+                accepted: Vec::new(),
+                case_sensitive: true,
+                expected_occurrences: 1,
+            },
+        ];
+
+        let score = score_proper_nouns("OpenAI Codex", &annotations);
+
+        assert_eq!(score.matched_occurrences, 1);
+        assert_eq!(score.expected_occurrences, 2);
+        assert_eq!(score.annotations[0].matched_occurrences, 1);
+        assert_eq!(score.annotations[1].matched_occurrences, 0);
+    }
+}

--- a/src/prompt_lab/regression.rs
+++ b/src/prompt_lab/regression.rs
@@ -1,0 +1,1308 @@
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::dataset::{DatasetError, sha256_bytes};
+use super::{
+    DatasetStore, ProperNounAnnotation, ProperNounScore, ScoringDataset, SttSnapshot, WerScore,
+    score_proper_nouns, score_wer,
+};
+use crate::audio::WavChunkReader;
+use crate::text::merge_texts;
+use crate::transcriber::Transcriber;
+
+pub(crate) const REPORT_SCHEMA_VERSION: u32 = 1;
+pub(crate) const SCORING_POLICY_VERSION: &str = "stt-prompt-scoring-v1";
+pub(crate) const AGENT_REVIEW_RUBRIC_VERSION: &str = "semantic-equivalence-v1";
+
+type Result<T> = std::result::Result<T, RegressionError>;
+
+#[derive(Debug)]
+pub(crate) enum RegressionError {
+    Dataset(DatasetError),
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    Invalid(String),
+}
+
+impl fmt::Display for RegressionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Dataset(error) => write!(formatter, "{error}"),
+            Self::Io(error) => write!(formatter, "regression I/O failed: {error}"),
+            Self::Json(error) => write!(formatter, "invalid regression JSON: {error}"),
+            Self::Invalid(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for RegressionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Dataset(error) => Some(error),
+            Self::Io(error) => Some(error),
+            Self::Json(error) => Some(error),
+            Self::Invalid(_) => None,
+        }
+    }
+}
+
+impl From<DatasetError> for RegressionError {
+    fn from(error: DatasetError) -> Self {
+        Self::Dataset(error)
+    }
+}
+
+impl From<std::io::Error> for RegressionError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for RegressionError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Thresholds {
+    pub(crate) max_wer_percent: f64,
+    pub(crate) min_llm_score: f64,
+    pub(crate) min_proper_noun_percent: f64,
+}
+
+impl Thresholds {
+    fn validate(&self) -> Result<()> {
+        if !self.max_wer_percent.is_finite() || self.max_wer_percent < 0.0 {
+            return Err(RegressionError::Invalid(
+                "max WER percent must be a finite non-negative number".to_string(),
+            ));
+        }
+        for (name, value) in [
+            ("minimum LLM score", self.min_llm_score),
+            ("minimum proper-noun percent", self.min_proper_noun_percent),
+        ] {
+            if !value.is_finite() || !(0.0..=100.0).contains(&value) {
+                return Err(RegressionError::Invalid(format!(
+                    "{name} must be between 0 and 100"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) struct EvaluationRequest {
+    pub(crate) stt: SttSnapshot,
+    pub(crate) language: Option<String>,
+    pub(crate) max_chunk_duration_secs: u32,
+    pub(crate) max_chunk_size_bytes: u64,
+    pub(crate) thresholds: Thresholds,
+    pub(crate) output: Option<PathBuf>,
+    pub(crate) compare_to: Option<EvaluationReport>,
+}
+
+#[derive(Debug)]
+pub(crate) struct EvaluationOutcome {
+    pub(crate) report: EvaluationReport,
+    pub(crate) path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RunStatus {
+    Incomplete,
+    AwaitingAgentReview,
+    Complete,
+}
+
+impl RunStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Incomplete => "incomplete",
+            Self::AwaitingAgentReview => "awaiting_agent_review",
+            Self::Complete => "complete",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DatasetSummary {
+    pub(crate) root: String,
+    pub(crate) digest: String,
+    pub(crate) ready_sample_ids: Vec<String>,
+    pub(crate) pending_count: usize,
+    pub(crate) invalid_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WerAggregate {
+    pub(crate) reference_words: u64,
+    pub(crate) substitutions: u64,
+    pub(crate) deletions: u64,
+    pub(crate) insertions: u64,
+    pub(crate) wer_percent: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProperNounAggregate {
+    pub(crate) matched_occurrences: u64,
+    pub(crate) expected_occurrences: u64,
+    pub(crate) accuracy_percent: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LlmAggregate {
+    pub(crate) mean_score: f64,
+    pub(crate) scored_samples: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Aggregates {
+    pub(crate) wer: WerAggregate,
+    pub(crate) proper_nouns: ProperNounAggregate,
+    pub(crate) llm: Option<LlmAggregate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AgentDifference {
+    pub(crate) category: String,
+    pub(crate) reference: Option<String>,
+    pub(crate) hypothesis: Option<String>,
+    pub(crate) explanation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AgentSampleReview {
+    pub(crate) score: u8,
+    pub(crate) reason: String,
+    pub(crate) differences: Vec<AgentDifference>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReviewSummary {
+    pub(crate) source: String,
+    pub(crate) rubric_version: String,
+    pub(crate) reviewed_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GateResults {
+    pub(crate) wer: bool,
+    pub(crate) llm: bool,
+    pub(crate) proper_nouns: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SampleResult {
+    pub(crate) sample_id: String,
+    pub(crate) audio_path: String,
+    pub(crate) audio_sha256: String,
+    pub(crate) reference: String,
+    pub(crate) proper_noun_annotations: Vec<ProperNounAnnotation>,
+    pub(crate) hypothesis: Option<String>,
+    pub(crate) wer: Option<WerScore>,
+    pub(crate) proper_nouns: Option<ProperNounScore>,
+    pub(crate) agent_review: Option<AgentSampleReview>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RunFailure {
+    pub(crate) sample_id: String,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SampleComparison {
+    pub(crate) sample_id: String,
+    pub(crate) wer_percent_delta: Option<f64>,
+    pub(crate) proper_noun_percent_delta: Option<f64>,
+    pub(crate) llm_score_delta: Option<f64>,
+    pub(crate) prior_llm_score: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RunComparison {
+    pub(crate) prior_run_id: String,
+    pub(crate) wer_percent_delta: f64,
+    pub(crate) proper_noun_percent_delta: f64,
+    pub(crate) llm_score_delta: Option<f64>,
+    pub(crate) prior_llm_mean_score: f64,
+    pub(crate) samples: Vec<SampleComparison>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct EvaluationReport {
+    pub(crate) schema_version: u32,
+    pub(crate) run_id: String,
+    pub(crate) created_at_unix_ms: u64,
+    pub(crate) completed_at_unix_ms: Option<u64>,
+    pub(crate) status: RunStatus,
+    pub(crate) scoring_policy_version: String,
+    pub(crate) agent_review_rubric_version: String,
+    pub(crate) dataset: DatasetSummary,
+    pub(crate) stt: SttSnapshot,
+    pub(crate) prompt_sha256: String,
+    pub(crate) thresholds: Thresholds,
+    pub(crate) aggregates: Aggregates,
+    pub(crate) review: Option<ReviewSummary>,
+    pub(crate) gates: Option<GateResults>,
+    pub(crate) meets_targets: Option<bool>,
+    pub(crate) samples: Vec<SampleResult>,
+    pub(crate) failures: Vec<RunFailure>,
+    pub(crate) comparison: Option<RunComparison>,
+}
+
+impl EvaluationReport {
+    pub(crate) fn read(path: &Path) -> Result<Self> {
+        let metadata = fs::symlink_metadata(path)?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(RegressionError::Invalid(format!(
+                "report must be a regular JSON file: {}",
+                path.display()
+            )));
+        }
+        let report: Self = serde_json::from_slice(&fs::read(path)?)?;
+        report.validate_contract()?;
+        Ok(report)
+    }
+
+    pub(crate) fn write(&self, path: &Path) -> Result<()> {
+        let mut bytes = serde_json::to_vec_pretty(self)?;
+        bytes.push(b'\n');
+        fs::write(path, bytes)?;
+        Ok(())
+    }
+
+    pub(crate) fn validate_contract(&self) -> Result<()> {
+        if self.schema_version != REPORT_SCHEMA_VERSION {
+            return Err(RegressionError::Invalid(format!(
+                "unsupported report schema_version {}; expected {REPORT_SCHEMA_VERSION}",
+                self.schema_version
+            )));
+        }
+        if self.scoring_policy_version != SCORING_POLICY_VERSION
+            || self.agent_review_rubric_version != AGENT_REVIEW_RUBRIC_VERSION
+        {
+            return Err(RegressionError::Invalid(
+                "report policy or rubric version is incompatible".to_string(),
+            ));
+        }
+        self.thresholds.validate()?;
+        validate_stt(&self.stt)?;
+        let expected_prompt_digest = sha256_bytes(&serde_json::to_vec(&self.stt.prompt)?);
+        if self.prompt_sha256 != expected_prompt_digest {
+            return Err(RegressionError::Invalid(
+                "report prompt digest does not match its STT prompt".to_string(),
+            ));
+        }
+        let sample_ids = self
+            .samples
+            .iter()
+            .map(|sample| sample.sample_id.as_str())
+            .collect::<Vec<_>>();
+        if sample_ids.is_empty() {
+            return Err(RegressionError::Invalid(
+                "report contains no scored samples".to_string(),
+            ));
+        }
+        let unique_ids = sample_ids
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+        let ready_ids = self
+            .dataset
+            .ready_sample_ids
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if sample_ids != ready_ids || unique_ids.len() != sample_ids.len() {
+            return Err(RegressionError::Invalid(
+                "report sample coverage does not match the dataset summary".to_string(),
+            ));
+        }
+        let local_aggregates = aggregate_local_scores(&self.samples);
+        if !same_wer_aggregate(&self.aggregates.wer, &local_aggregates.wer)
+            || !same_proper_noun_aggregate(
+                &self.aggregates.proper_nouns,
+                &local_aggregates.proper_nouns,
+            )
+        {
+            return Err(RegressionError::Invalid(
+                "report local aggregates do not match its per-sample metrics".to_string(),
+            ));
+        }
+        let sample_failures = self
+            .samples
+            .iter()
+            .filter(|sample| sample.error.is_some())
+            .count();
+        if sample_failures != self.failures.len()
+            || self.failures.iter().any(|failure| {
+                !self.samples.iter().any(|sample| {
+                    sample.sample_id == failure.sample_id
+                        && sample.error.as_deref() == Some(failure.message.as_str())
+                })
+            })
+        {
+            return Err(RegressionError::Invalid(
+                "report failure summary does not match its sample errors".to_string(),
+            ));
+        }
+        for sample in &self.samples {
+            match sample.hypothesis.as_deref() {
+                Some(hypothesis) => {
+                    let expected_wer = score_wer(&sample.reference, hypothesis);
+                    let expected_proper_nouns =
+                        score_proper_nouns(hypothesis, &sample.proper_noun_annotations);
+                    if serde_json::to_value(sample.wer.as_ref())?
+                        != serde_json::to_value(Some(expected_wer))?
+                        || serde_json::to_value(sample.proper_nouns.as_ref())?
+                            != serde_json::to_value(Some(expected_proper_nouns))?
+                    {
+                        return Err(RegressionError::Invalid(format!(
+                            "sample {} metrics do not match its reference and hypothesis",
+                            sample.sample_id
+                        )));
+                    }
+                }
+                None if sample.wer.is_some() || sample.proper_nouns.is_some() => {
+                    return Err(RegressionError::Invalid(format!(
+                        "failed sample {} contains local metrics",
+                        sample.sample_id
+                    )));
+                }
+                None => {}
+            }
+        }
+        match self.status {
+            RunStatus::Incomplete
+                if self.failures.is_empty()
+                    || self.review.is_some()
+                    || self.aggregates.llm.is_some()
+                    || self.meets_targets.is_some()
+                    || self.gates.is_some()
+                    || self.completed_at_unix_ms.is_some()
+                    || self
+                        .samples
+                        .iter()
+                        .any(|sample| sample.agent_review.is_some()) =>
+            {
+                Err(RegressionError::Invalid(
+                    "incomplete report contains inconsistent final fields".to_string(),
+                ))
+            }
+            RunStatus::AwaitingAgentReview
+                if !self.failures.is_empty()
+                    || self.review.is_some()
+                    || self.aggregates.llm.is_some()
+                    || self.meets_targets.is_some()
+                    || self.gates.is_some()
+                    || self.completed_at_unix_ms.is_some()
+                    || self.samples.iter().any(|sample| {
+                        sample.agent_review.is_some()
+                            || sample.hypothesis.is_none()
+                            || sample.wer.is_none()
+                            || sample.proper_nouns.is_none()
+                            || sample.error.is_some()
+                    }) =>
+            {
+                Err(RegressionError::Invalid(
+                    "awaiting-review report already contains final review fields".to_string(),
+                ))
+            }
+            RunStatus::Complete
+                if self.review.is_none()
+                    || self.aggregates.llm.is_none()
+                    || self.meets_targets.is_none()
+                    || self.gates.is_none()
+                    || self.completed_at_unix_ms.is_none()
+                    || !self.failures.is_empty()
+                    || self.samples.iter().any(|sample| {
+                        sample.agent_review.is_none()
+                            || sample.hypothesis.is_none()
+                            || sample.wer.is_none()
+                            || sample.proper_nouns.is_none()
+                            || sample.error.is_some()
+                    }) =>
+            {
+                Err(RegressionError::Invalid(
+                    "complete report is missing final review fields".to_string(),
+                ))
+            }
+            RunStatus::Complete => self.validate_complete_review(),
+            _ => Ok(()),
+        }?;
+        self.validate_comparison_contract()
+    }
+
+    fn validate_complete_review(&self) -> Result<()> {
+        let review = self.review.as_ref().expect("complete fields were checked");
+        if review.source != "coding_agent"
+            || review.rubric_version != AGENT_REVIEW_RUBRIC_VERSION
+            || review.reviewed_at_unix_ms != self.completed_at_unix_ms.unwrap()
+        {
+            return Err(RegressionError::Invalid(
+                "complete report review metadata is invalid".to_string(),
+            ));
+        }
+        let mut total = 0_u64;
+        for sample in &self.samples {
+            let review = sample
+                .agent_review
+                .as_ref()
+                .expect("complete sample review was checked");
+            if review.score > 100 || review.reason.trim().is_empty() {
+                return Err(RegressionError::Invalid(format!(
+                    "sample {} has an invalid agent review",
+                    sample.sample_id
+                )));
+            }
+            if review.score < 100 && review.differences.is_empty() {
+                return Err(RegressionError::Invalid(format!(
+                    "sample {} review below 100 has no differences",
+                    sample.sample_id
+                )));
+            }
+            if review.differences.iter().any(|difference| {
+                difference.category.trim().is_empty() || difference.explanation.trim().is_empty()
+            }) {
+                return Err(RegressionError::Invalid(format!(
+                    "sample {} has an invalid structured difference",
+                    sample.sample_id
+                )));
+            }
+            total += u64::from(review.score);
+        }
+        let llm = self
+            .aggregates
+            .llm
+            .as_ref()
+            .expect("complete LLM aggregate was checked");
+        let mean = total as f64 / self.samples.len() as f64;
+        if llm.scored_samples != self.samples.len() || !float_eq(llm.mean_score, mean) {
+            return Err(RegressionError::Invalid(
+                "LLM aggregate does not match per-sample reviews".to_string(),
+            ));
+        }
+        let expected_gates = GateResults {
+            wer: self.aggregates.wer.wer_percent <= self.thresholds.max_wer_percent,
+            llm: llm.mean_score >= self.thresholds.min_llm_score,
+            proper_nouns: self.aggregates.proper_nouns.accuracy_percent
+                >= self.thresholds.min_proper_noun_percent,
+        };
+        let gates = self.gates.as_ref().expect("complete gates were checked");
+        let meets = gates.wer && gates.llm && gates.proper_nouns;
+        if gates.wer != expected_gates.wer
+            || gates.llm != expected_gates.llm
+            || gates.proper_nouns != expected_gates.proper_nouns
+            || self.meets_targets != Some(meets)
+        {
+            return Err(RegressionError::Invalid(
+                "complete report gates do not match metrics and thresholds".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_comparison_contract(&self) -> Result<()> {
+        let Some(comparison) = &self.comparison else {
+            return Ok(());
+        };
+        let ids = comparison
+            .samples
+            .iter()
+            .map(|sample| sample.sample_id.as_str())
+            .collect::<Vec<_>>();
+        let report_ids = self
+            .samples
+            .iter()
+            .map(|sample| sample.sample_id.as_str())
+            .collect::<Vec<_>>();
+        if comparison.prior_run_id.trim().is_empty()
+            || ids != report_ids
+            || !(0.0..=100.0).contains(&comparison.prior_llm_mean_score)
+            || !comparison.wer_percent_delta.is_finite()
+            || !comparison.proper_noun_percent_delta.is_finite()
+            || comparison.samples.iter().any(|sample| {
+                sample.prior_llm_score > 100
+                    || sample
+                        .wer_percent_delta
+                        .is_some_and(|delta| !delta.is_finite())
+                    || sample
+                        .proper_noun_percent_delta
+                        .is_some_and(|delta| !delta.is_finite())
+            })
+        {
+            return Err(RegressionError::Invalid(
+                "report comparison metadata is invalid".to_string(),
+            ));
+        }
+        match self.status {
+            RunStatus::Complete => {
+                let mean = self
+                    .aggregates
+                    .llm
+                    .as_ref()
+                    .expect("complete report fields were checked")
+                    .mean_score;
+                if !comparison
+                    .llm_score_delta
+                    .is_some_and(|delta| float_eq(delta, mean - comparison.prior_llm_mean_score))
+                    || comparison.samples.iter().any(|comparison| {
+                        let score = self
+                            .samples
+                            .iter()
+                            .find(|sample| sample.sample_id == comparison.sample_id)
+                            .and_then(|sample| sample.agent_review.as_ref())
+                            .map(|review| f64::from(review.score));
+                        !comparison.llm_score_delta.is_some_and(|delta| {
+                            score.is_some_and(|score| {
+                                float_eq(delta, score - f64::from(comparison.prior_llm_score))
+                            })
+                        })
+                    })
+                {
+                    return Err(RegressionError::Invalid(
+                        "report comparison LLM deltas are invalid".to_string(),
+                    ));
+                }
+            }
+            RunStatus::Incomplete | RunStatus::AwaitingAgentReview => {
+                if comparison.llm_score_delta.is_some()
+                    || comparison
+                        .samples
+                        .iter()
+                        .any(|sample| sample.llm_score_delta.is_some())
+                {
+                    return Err(RegressionError::Invalid(
+                        "unfinished report comparison contains LLM deltas".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn same_wer_aggregate(left: &WerAggregate, right: &WerAggregate) -> bool {
+    left.reference_words == right.reference_words
+        && left.substitutions == right.substitutions
+        && left.deletions == right.deletions
+        && left.insertions == right.insertions
+        && float_eq(left.wer_percent, right.wer_percent)
+}
+
+fn same_proper_noun_aggregate(left: &ProperNounAggregate, right: &ProperNounAggregate) -> bool {
+    left.matched_occurrences == right.matched_occurrences
+        && left.expected_occurrences == right.expected_occurrences
+        && float_eq(left.accuracy_percent, right.accuracy_percent)
+}
+
+fn float_eq(left: f64, right: f64) -> bool {
+    (left - right).abs() <= f64::EPSILON * left.abs().max(right.abs()).max(1.0) * 8.0
+}
+
+pub(crate) fn evaluate(
+    store: &DatasetStore,
+    transcriber: &dyn Transcriber,
+    request: EvaluationRequest,
+) -> Result<EvaluationOutcome> {
+    request.thresholds.validate()?;
+    validate_stt(&request.stt)?;
+    let dataset = store.scoring_snapshot(SCORING_POLICY_VERSION)?;
+    validate_scoring_dataset(&dataset)?;
+    if let Some(prior) = request.compare_to.as_ref() {
+        validate_comparison(prior, &dataset, &request.stt)?;
+    }
+
+    let created_at_unix_ms = unix_time_ms()?;
+    let prompt_sha256 = sha256_bytes(&serde_json::to_vec(&request.stt.prompt)?);
+    let run_id = next_run_id(created_at_unix_ms);
+    let path = request
+        .output
+        .clone()
+        .unwrap_or_else(|| store.root().join("runs").join(format!("{run_id}.json")));
+    validate_new_output_path(&path)?;
+
+    let mut samples = Vec::with_capacity(dataset.samples.len());
+    let mut failures = Vec::new();
+    for sample in &dataset.samples {
+        let reference = sample
+            .reference
+            .text
+            .as_deref()
+            .expect("scoring snapshots contain ready references")
+            .to_string();
+        let result = transcribe_sample(
+            &store.root().join(&sample.audio.path),
+            transcriber,
+            request.max_chunk_duration_secs,
+            request.max_chunk_size_bytes,
+            request.language.as_deref(),
+        );
+        match result {
+            Ok(hypothesis) => samples.push(SampleResult {
+                sample_id: sample.id.clone(),
+                audio_path: sample.audio.path.clone(),
+                audio_sha256: sample.audio.sha256.clone(),
+                proper_noun_annotations: sample.reference.proper_nouns.clone(),
+                wer: Some(score_wer(&reference, &hypothesis)),
+                proper_nouns: Some(score_proper_nouns(
+                    &hypothesis,
+                    &sample.reference.proper_nouns,
+                )),
+                reference,
+                hypothesis: Some(hypothesis),
+                agent_review: None,
+                error: None,
+            }),
+            Err(message) => {
+                failures.push(RunFailure {
+                    sample_id: sample.id.clone(),
+                    message: message.clone(),
+                });
+                samples.push(SampleResult {
+                    sample_id: sample.id.clone(),
+                    audio_path: sample.audio.path.clone(),
+                    audio_sha256: sample.audio.sha256.clone(),
+                    proper_noun_annotations: sample.reference.proper_nouns.clone(),
+                    reference,
+                    hypothesis: None,
+                    wer: None,
+                    proper_nouns: None,
+                    agent_review: None,
+                    error: Some(message),
+                });
+            }
+        }
+    }
+    let aggregates = aggregate_local_scores(&samples);
+    let status = if failures.is_empty() {
+        RunStatus::AwaitingAgentReview
+    } else {
+        RunStatus::Incomplete
+    };
+    let comparison = request
+        .compare_to
+        .as_ref()
+        .map(|prior| build_comparison(prior, &samples, &aggregates));
+    let report = EvaluationReport {
+        schema_version: REPORT_SCHEMA_VERSION,
+        run_id,
+        created_at_unix_ms,
+        completed_at_unix_ms: None,
+        status,
+        scoring_policy_version: SCORING_POLICY_VERSION.to_string(),
+        agent_review_rubric_version: AGENT_REVIEW_RUBRIC_VERSION.to_string(),
+        dataset: DatasetSummary {
+            root: store.root().display().to_string(),
+            digest: dataset.digest,
+            ready_sample_ids: dataset
+                .samples
+                .iter()
+                .map(|sample| sample.id.clone())
+                .collect(),
+            pending_count: dataset.pending_count,
+            invalid_count: dataset.invalid_count,
+        },
+        stt: request.stt,
+        prompt_sha256,
+        thresholds: request.thresholds,
+        aggregates,
+        review: None,
+        gates: None,
+        meets_targets: None,
+        samples,
+        failures,
+        comparison,
+    };
+    report.validate_contract()?;
+    report.write(&path)?;
+    Ok(EvaluationOutcome { report, path })
+}
+
+fn validate_new_output_path(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => {
+            return Err(RegressionError::Invalid(format!(
+                "report output already exists: {}",
+                path.display()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    if !fs::metadata(parent)?.is_dir() {
+        return Err(RegressionError::Invalid(format!(
+            "report output parent is not a directory: {}",
+            parent.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_stt(stt: &SttSnapshot) -> Result<()> {
+    if stt.endpoint.trim().is_empty() || stt.model.trim().is_empty() || !stt.temperature.is_finite()
+    {
+        return Err(RegressionError::Invalid(
+            "STT metadata is incomplete or invalid".to_string(),
+        ));
+    }
+    let endpoint = reqwest::Url::parse(&stt.endpoint)
+        .map_err(|error| RegressionError::Invalid(format!("invalid STT endpoint: {error}")))?;
+    if !matches!(endpoint.scheme(), "http" | "https")
+        || !endpoint.username().is_empty()
+        || endpoint.password().is_some()
+        || endpoint.query().is_some()
+        || endpoint.fragment().is_some()
+    {
+        return Err(RegressionError::Invalid(
+            "STT endpoint metadata must be sanitized".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_scoring_dataset(dataset: &ScoringDataset) -> Result<()> {
+    if dataset.samples.is_empty() {
+        return Err(RegressionError::Invalid(
+            "dataset has no ready samples".to_string(),
+        ));
+    }
+    let mut expected_proper_nouns = 0_u64;
+    for sample in &dataset.samples {
+        let reference = sample
+            .reference
+            .text
+            .as_deref()
+            .expect("scoring snapshots contain ready references");
+        if score_wer(reference, reference).reference_words == 0 {
+            return Err(RegressionError::Invalid(format!(
+                "ready sample {} has no scoreable reference words",
+                sample.id
+            )));
+        }
+        expected_proper_nouns += sample
+            .reference
+            .proper_nouns
+            .iter()
+            .map(|annotation| u64::from(annotation.expected_occurrences))
+            .sum::<u64>();
+    }
+    if expected_proper_nouns == 0 {
+        return Err(RegressionError::Invalid(
+            "ready dataset has no expected proper-noun occurrences".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn transcribe_sample(
+    path: &Path,
+    transcriber: &dyn Transcriber,
+    max_chunk_duration_secs: u32,
+    max_chunk_size_bytes: u64,
+    language: Option<&str>,
+) -> std::result::Result<String, String> {
+    let mut reader = WavChunkReader::open(path, max_chunk_duration_secs, max_chunk_size_bytes)
+        .map_err(|error| error.to_string())?;
+    let mut texts = Vec::new();
+    for chunk in reader.chunks() {
+        let chunk = chunk.map_err(|error| error.to_string())?;
+        texts.push(
+            transcriber
+                .transcribe(&chunk)
+                .map_err(|error| error.to_string())?,
+        );
+    }
+    if texts.is_empty() {
+        return Err("WAV produced no transcribable chunks".to_string());
+    }
+    let text = merge_texts(&texts, language);
+    if text.is_empty() {
+        Err("STT returned empty text".to_string())
+    } else {
+        Ok(text)
+    }
+}
+
+fn aggregate_local_scores(samples: &[SampleResult]) -> Aggregates {
+    let mut wer = WerAggregate {
+        reference_words: 0,
+        substitutions: 0,
+        deletions: 0,
+        insertions: 0,
+        wer_percent: 0.0,
+    };
+    let mut proper_nouns = ProperNounAggregate {
+        matched_occurrences: 0,
+        expected_occurrences: 0,
+        accuracy_percent: 0.0,
+    };
+    for sample in samples {
+        if let Some(score) = &sample.wer {
+            wer.reference_words += score.reference_words;
+            wer.substitutions += score.substitutions;
+            wer.deletions += score.deletions;
+            wer.insertions += score.insertions;
+        }
+        if let Some(score) = &sample.proper_nouns {
+            proper_nouns.matched_occurrences += score.matched_occurrences;
+            proper_nouns.expected_occurrences += score.expected_occurrences;
+        }
+    }
+    if wer.reference_words > 0 {
+        wer.wer_percent = (wer.substitutions + wer.deletions + wer.insertions) as f64 * 100.0
+            / wer.reference_words as f64;
+    }
+    if proper_nouns.expected_occurrences > 0 {
+        proper_nouns.accuracy_percent = proper_nouns.matched_occurrences as f64 * 100.0
+            / proper_nouns.expected_occurrences as f64;
+    }
+    Aggregates {
+        wer,
+        proper_nouns,
+        llm: None,
+    }
+}
+
+fn validate_comparison(
+    prior: &EvaluationReport,
+    dataset: &ScoringDataset,
+    stt: &SttSnapshot,
+) -> Result<()> {
+    prior.validate_contract()?;
+    let sample_ids = dataset
+        .samples
+        .iter()
+        .map(|sample| sample.id.as_str())
+        .collect::<Vec<_>>();
+    let prior_ids = prior
+        .dataset
+        .ready_sample_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let compatible = prior.status == RunStatus::Complete
+        && prior.dataset.digest == dataset.digest
+        && prior_ids == sample_ids
+        && prior.stt.endpoint == stt.endpoint
+        && prior.stt.model == stt.model
+        && prior.stt.language == stt.language
+        && prior.stt.temperature == stt.temperature
+        && prior.failures.is_empty();
+    if compatible {
+        Ok(())
+    } else {
+        Err(RegressionError::Invalid(format!(
+            "comparison report {} is not compatible with this evaluation",
+            prior.run_id
+        )))
+    }
+}
+
+fn build_comparison(
+    prior: &EvaluationReport,
+    samples: &[SampleResult],
+    aggregates: &Aggregates,
+) -> RunComparison {
+    let samples = samples
+        .iter()
+        .map(|sample| {
+            let old = prior
+                .samples
+                .iter()
+                .find(|old| old.sample_id == sample.sample_id)
+                .expect("comparison compatibility checks exact sample coverage");
+            SampleComparison {
+                sample_id: sample.sample_id.clone(),
+                wer_percent_delta: sample
+                    .wer
+                    .as_ref()
+                    .zip(old.wer.as_ref())
+                    .map(|(new, old)| new.wer_percent - old.wer_percent),
+                proper_noun_percent_delta: sample
+                    .proper_nouns
+                    .as_ref()
+                    .zip(old.proper_nouns.as_ref())
+                    .map(|(new, old)| new.accuracy_percent - old.accuracy_percent),
+                llm_score_delta: None,
+                prior_llm_score: old
+                    .agent_review
+                    .as_ref()
+                    .expect("complete comparison report has per-sample reviews")
+                    .score,
+            }
+        })
+        .collect();
+    RunComparison {
+        prior_run_id: prior.run_id.clone(),
+        wer_percent_delta: aggregates.wer.wer_percent - prior.aggregates.wer.wer_percent,
+        proper_noun_percent_delta: aggregates.proper_nouns.accuracy_percent
+            - prior.aggregates.proper_nouns.accuracy_percent,
+        llm_score_delta: None,
+        prior_llm_mean_score: prior
+            .aggregates
+            .llm
+            .as_ref()
+            .expect("complete comparison report has LLM aggregate")
+            .mean_score,
+        samples,
+    }
+}
+
+fn next_run_id(created_at_unix_ms: u64) -> String {
+    static SEQUENCE: AtomicU64 = AtomicU64::new(1);
+    format!(
+        "run-{created_at_unix_ms}-{}",
+        SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+pub(crate) fn unix_time_ms() -> Result<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| RegressionError::Invalid(format!("system clock failed: {error}")))?
+        .as_millis()
+        .try_into()
+        .map_err(|_| RegressionError::Invalid("current timestamp does not fit u64".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use hound::{SampleFormat, WavSpec, WavWriter};
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::prompt_lab::apply_review;
+    use crate::prompt_lab::{CaptureTranscription, ProperNounAnnotation};
+    use crate::transcriber::{TranscribeError, Transcriber};
+
+    struct SequenceTranscriber(Mutex<VecDeque<std::result::Result<String, TranscribeError>>>);
+
+    impl SequenceTranscriber {
+        fn new(
+            results: impl IntoIterator<Item = std::result::Result<String, TranscribeError>>,
+        ) -> Self {
+            Self(Mutex::new(results.into_iter().collect()))
+        }
+    }
+
+    impl Transcriber for SequenceTranscriber {
+        fn transcribe(
+            &self,
+            _chunk: &crate::audio::WavChunk,
+        ) -> std::result::Result<String, TranscribeError> {
+            self.0
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("one fake result per sample")
+        }
+    }
+
+    fn write_wav(path: &Path) {
+        let mut writer = WavWriter::create(
+            path,
+            WavSpec {
+                channels: 1,
+                sample_rate: 16_000,
+                bits_per_sample: 16,
+                sample_format: SampleFormat::Int,
+            },
+        )
+        .unwrap();
+        for sample in [1_i16, 2, 3, 4] {
+            writer.write_sample(sample).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn snapshot(prompt: Option<&str>) -> SttSnapshot {
+        SttSnapshot {
+            endpoint: "https://api.example.test/v1/audio/transcriptions".to_string(),
+            model: "whisper-test".to_string(),
+            language: Some("zh".to_string()),
+            temperature: 0.0,
+            prompt: prompt.map(str::to_string),
+        }
+    }
+
+    fn add_ready_sample(store: &DatasetStore, timestamp: u64, reference: &str, term: &str) {
+        let reservation = store.reserve_sample(timestamp).unwrap();
+        write_wav(&reservation.audio_path);
+        let id = reservation.id.clone();
+        store
+            .complete_capture(
+                reservation,
+                CaptureTranscription::success("initial", snapshot(Some("baseline"))),
+            )
+            .unwrap();
+        store
+            .correct_sample(
+                &id,
+                reference,
+                vec![ProperNounAnnotation {
+                    canonical: term.to_string(),
+                    accepted: Vec::new(),
+                    case_sensitive: true,
+                    expected_occurrences: 1,
+                }],
+            )
+            .unwrap();
+    }
+
+    fn request(output: std::path::PathBuf) -> EvaluationRequest {
+        EvaluationRequest {
+            stt: snapshot(Some("candidate")),
+            language: Some("zh".to_string()),
+            max_chunk_duration_secs: 30,
+            max_chunk_size_bytes: 23 * 1024 * 1024,
+            thresholds: Thresholds {
+                max_wer_percent: 20.0,
+                min_llm_score: 90.0,
+                min_proper_noun_percent: 100.0,
+            },
+            output: Some(output),
+            compare_to: None,
+        }
+    }
+
+    #[test]
+    fn evaluates_every_ready_sample_and_writes_awaiting_review_report() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        add_ready_sample(&store, 1, "使用 Codex", "Codex");
+        add_ready_sample(&store, 2, "运行 ViberWhisper", "ViberWhisper");
+        let output = directory.path().join("run.json");
+        let transcriber = SequenceTranscriber::new([
+            Ok("使用 Codex".to_string()),
+            Ok("运行 ViberWhisper".to_string()),
+        ]);
+
+        let outcome = evaluate(&store, &transcriber, request(output.clone())).unwrap();
+
+        assert_eq!(outcome.report.status, RunStatus::AwaitingAgentReview);
+        assert_eq!(outcome.report.samples.len(), 2);
+        assert_eq!(outcome.report.aggregates.wer.wer_percent, 0.0);
+        assert_eq!(
+            outcome.report.aggregates.proper_nouns.accuracy_percent,
+            100.0
+        );
+        assert!(outcome.report.aggregates.llm.is_none());
+        assert!(outcome.report.meets_targets.is_none());
+        assert_eq!(outcome.path, output);
+        assert_eq!(
+            EvaluationReport::read(&outcome.path).unwrap().run_id,
+            outcome.report.run_id
+        );
+    }
+
+    #[test]
+    fn sample_failure_is_reported_without_skipping_later_samples() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        add_ready_sample(&store, 1, "使用 Codex", "Codex");
+        add_ready_sample(&store, 2, "运行 ViberWhisper", "ViberWhisper");
+        let transcriber = SequenceTranscriber::new([
+            Err(TranscribeError::Network("offline".to_string())),
+            Ok("运行 ViberWhisper".to_string()),
+        ]);
+
+        let outcome = evaluate(
+            &store,
+            &transcriber,
+            request(directory.path().join("failed.json")),
+        )
+        .unwrap();
+
+        assert_eq!(outcome.report.status, RunStatus::Incomplete);
+        assert_eq!(outcome.report.failures.len(), 1);
+        assert!(outcome.report.samples[0].error.is_some());
+        assert!(outcome.report.samples[1].hypothesis.is_some());
+    }
+
+    #[test]
+    fn dataset_wer_is_a_micro_average_of_edit_totals() {
+        fn sample(id: &str, reference: &str, hypothesis: &str) -> SampleResult {
+            SampleResult {
+                sample_id: id.to_string(),
+                audio_path: format!("audio/{id}.wav"),
+                audio_sha256: "digest".to_string(),
+                reference: reference.to_string(),
+                proper_noun_annotations: Vec::new(),
+                hypothesis: Some(hypothesis.to_string()),
+                wer: Some(score_wer(reference, hypothesis)),
+                proper_nouns: Some(score_proper_nouns(hypothesis, &[])),
+                agent_review: None,
+                error: None,
+            }
+        }
+        let samples = [
+            sample("sample-1-1", "wrong", "changed"),
+            sample(
+                "sample-2-1",
+                "one two three four five six seven eight nine",
+                "one two three four five six seven eight nine",
+            ),
+        ];
+
+        let aggregates = aggregate_local_scores(&samples);
+
+        assert_eq!(aggregates.wer.reference_words, 10);
+        assert_eq!(aggregates.wer.substitutions, 1);
+        assert_eq!(aggregates.wer.wer_percent, 10.0);
+    }
+
+    #[test]
+    fn compatible_complete_run_produces_local_and_reviewed_deltas() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        add_ready_sample(&store, 1, "使用 Codex", "Codex");
+
+        let baseline_path = directory.path().join("baseline.json");
+        let baseline = evaluate(
+            &store,
+            &SequenceTranscriber::new([Ok("使用 Codex".to_string())]),
+            request(baseline_path.clone()),
+        )
+        .unwrap();
+        let baseline_review = directory.path().join("baseline-review.json");
+        write_review(&baseline_review, &baseline.report.run_id, 100, false);
+        let baseline = apply_review(&baseline_path, &baseline_review).unwrap();
+
+        let candidate_path = directory.path().join("candidate.json");
+        let mut candidate_request = request(candidate_path.clone());
+        candidate_request.compare_to = Some(baseline);
+        let candidate = evaluate(
+            &store,
+            &SequenceTranscriber::new([Ok("使用 Code".to_string())]),
+            candidate_request,
+        )
+        .unwrap();
+
+        let comparison = candidate.report.comparison.as_ref().unwrap();
+        assert!(comparison.wer_percent_delta > 0.0);
+        assert_eq!(comparison.proper_noun_percent_delta, -100.0);
+        assert!(comparison.llm_score_delta.is_none());
+
+        let candidate_review = directory.path().join("candidate-review.json");
+        write_review(&candidate_review, &candidate.report.run_id, 80, true);
+        let candidate = apply_review(&candidate_path, &candidate_review).unwrap();
+        let comparison = candidate.comparison.unwrap();
+        assert_eq!(comparison.llm_score_delta, Some(-20.0));
+        assert_eq!(comparison.samples[0].llm_score_delta, Some(-20.0));
+    }
+
+    #[test]
+    fn incompatible_comparison_is_rejected_before_transcription() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        add_ready_sample(&store, 1, "使用 Codex", "Codex");
+        let baseline_path = directory.path().join("baseline.json");
+        let baseline = evaluate(
+            &store,
+            &SequenceTranscriber::new([Ok("使用 Codex".to_string())]),
+            request(baseline_path.clone()),
+        )
+        .unwrap();
+        let review_path = directory.path().join("review.json");
+        write_review(&review_path, &baseline.report.run_id, 100, false);
+        let mut baseline = apply_review(&baseline_path, &review_path).unwrap();
+        baseline.stt.model = "another-model".to_string();
+        let mut candidate_request = request(directory.path().join("candidate.json"));
+        candidate_request.compare_to = Some(baseline);
+
+        let error = evaluate(&store, &SequenceTranscriber::new([]), candidate_request).unwrap_err();
+
+        assert!(error.to_string().contains("not compatible"));
+    }
+
+    #[test]
+    fn dataset_without_proper_noun_denominator_is_rejected_before_transcription() {
+        let directory = tempdir().unwrap();
+        let store = DatasetStore::open_or_create(directory.path().join("dataset")).unwrap();
+        let reservation = store.reserve_sample(1).unwrap();
+        write_wav(&reservation.audio_path);
+        let id = reservation.id.clone();
+        store
+            .complete_capture(
+                reservation,
+                CaptureTranscription::success("initial", snapshot(Some("baseline"))),
+            )
+            .unwrap();
+        store
+            .correct_sample(&id, "普通参考文本", Vec::new())
+            .unwrap();
+
+        let error = evaluate(
+            &store,
+            &SequenceTranscriber::new([]),
+            request(directory.path().join("run.json")),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("proper-noun"));
+    }
+
+    fn write_review(path: &Path, run_id: &str, score: u8, with_difference: bool) {
+        let differences = if with_difference {
+            vec![serde_json::json!({
+                "category": "proper_noun",
+                "reference": "Codex",
+                "hypothesis": "Code",
+                "explanation": "专有名词识别错误"
+            })]
+        } else {
+            Vec::new()
+        };
+        fs::write(
+            path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "run_id": run_id,
+                "rubric_version": AGENT_REVIEW_RUBRIC_VERSION,
+                "samples": [{
+                    "sample_id": "sample-1-1",
+                    "score": score,
+                    "reason": if score == 100 { "语义一致" } else { "专有名词错误" },
+                    "differences": differences
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+}

--- a/src/prompt_lab/review.rs
+++ b/src/prompt_lab/review.rs
@@ -1,0 +1,381 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use super::regression::{
+    AGENT_REVIEW_RUBRIC_VERSION, AgentDifference, AgentSampleReview, EvaluationReport, GateResults,
+    LlmAggregate, RegressionError, ReviewSummary, RunStatus, unix_time_ms,
+};
+
+type Result<T> = std::result::Result<T, RegressionError>;
+
+const REVIEW_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentReviewInput {
+    schema_version: u32,
+    run_id: String,
+    rubric_version: String,
+    samples: Vec<AgentReviewSampleInput>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentReviewSampleInput {
+    sample_id: String,
+    score: u8,
+    reason: String,
+    differences: Vec<AgentDifference>,
+}
+
+pub(crate) fn apply_review(report_path: &Path, review_path: &Path) -> Result<EvaluationReport> {
+    let mut report = EvaluationReport::read(report_path)?;
+    if report.status != RunStatus::AwaitingAgentReview {
+        return Err(RegressionError::Invalid(
+            "agent review can only be applied to an awaiting_agent_review report".to_string(),
+        ));
+    }
+    let metadata = fs::symlink_metadata(review_path)?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(RegressionError::Invalid(format!(
+            "agent review must be a regular JSON file: {}",
+            review_path.display()
+        )));
+    }
+    let input: AgentReviewInput = serde_json::from_slice(&fs::read(review_path)?)?;
+    validate_input_identity(&input, &report)?;
+
+    let mut reviews = HashMap::with_capacity(input.samples.len());
+    for sample in input.samples {
+        validate_sample_review(&sample)?;
+        let id = sample.sample_id.clone();
+        if reviews
+            .insert(
+                id.clone(),
+                AgentSampleReview {
+                    score: sample.score,
+                    reason: sample.reason,
+                    differences: sample.differences,
+                },
+            )
+            .is_some()
+        {
+            return Err(RegressionError::Invalid(format!(
+                "agent review contains duplicate sample ID {id}"
+            )));
+        }
+    }
+    let expected = report
+        .samples
+        .iter()
+        .map(|sample| sample.sample_id.as_str())
+        .collect::<HashSet<_>>();
+    let actual = reviews.keys().map(String::as_str).collect::<HashSet<_>>();
+    if actual != expected {
+        return Err(RegressionError::Invalid(
+            "agent review sample coverage does not exactly match the report".to_string(),
+        ));
+    }
+
+    let mut score_total = 0_u64;
+    for sample in &mut report.samples {
+        let review = reviews
+            .remove(&sample.sample_id)
+            .expect("coverage was checked before report mutation");
+        score_total += u64::from(review.score);
+        sample.agent_review = Some(review);
+    }
+    let mean_score = score_total as f64 / report.samples.len() as f64;
+    let gates = GateResults {
+        wer: report.aggregates.wer.wer_percent <= report.thresholds.max_wer_percent,
+        llm: mean_score >= report.thresholds.min_llm_score,
+        proper_nouns: report.aggregates.proper_nouns.accuracy_percent
+            >= report.thresholds.min_proper_noun_percent,
+    };
+    let meets_targets = gates.wer && gates.llm && gates.proper_nouns;
+    let reviewed_at_unix_ms = unix_time_ms()?;
+    report.status = RunStatus::Complete;
+    report.completed_at_unix_ms = Some(reviewed_at_unix_ms);
+    report.aggregates.llm = Some(LlmAggregate {
+        mean_score,
+        scored_samples: report.samples.len(),
+    });
+    report.review = Some(ReviewSummary {
+        source: "coding_agent".to_string(),
+        rubric_version: AGENT_REVIEW_RUBRIC_VERSION.to_string(),
+        reviewed_at_unix_ms,
+    });
+    report.gates = Some(gates);
+    report.meets_targets = Some(meets_targets);
+    if let Some(comparison) = &mut report.comparison {
+        comparison.llm_score_delta = Some(mean_score - comparison.prior_llm_mean_score);
+        for sample in &report.samples {
+            let comparison = comparison
+                .samples
+                .iter_mut()
+                .find(|comparison| comparison.sample_id == sample.sample_id)
+                .expect("comparison contains every compatible sample");
+            comparison.llm_score_delta = Some(
+                f64::from(
+                    sample
+                        .agent_review
+                        .as_ref()
+                        .expect("review was just assigned")
+                        .score,
+                ) - f64::from(comparison.prior_llm_score),
+            );
+        }
+    }
+    report.validate_contract()?;
+    report.write(report_path)?;
+    Ok(report)
+}
+
+fn validate_input_identity(input: &AgentReviewInput, report: &EvaluationReport) -> Result<()> {
+    if input.schema_version != REVIEW_SCHEMA_VERSION {
+        return Err(RegressionError::Invalid(format!(
+            "unsupported agent review schema_version {}; expected {REVIEW_SCHEMA_VERSION}",
+            input.schema_version
+        )));
+    }
+    if input.run_id != report.run_id {
+        return Err(RegressionError::Invalid(format!(
+            "agent review run ID {} does not match {}",
+            input.run_id, report.run_id
+        )));
+    }
+    if input.rubric_version != AGENT_REVIEW_RUBRIC_VERSION
+        || input.rubric_version != report.agent_review_rubric_version
+    {
+        return Err(RegressionError::Invalid(
+            "agent review rubric version is incompatible".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sample_review(sample: &AgentReviewSampleInput) -> Result<()> {
+    if sample.sample_id.trim().is_empty() {
+        return Err(RegressionError::Invalid(
+            "agent review sample ID must not be empty".to_string(),
+        ));
+    }
+    if sample.score > 100 {
+        return Err(RegressionError::Invalid(format!(
+            "agent review score for {} exceeds 100",
+            sample.sample_id
+        )));
+    }
+    if sample.reason.trim().is_empty() {
+        return Err(RegressionError::Invalid(format!(
+            "agent review reason for {} must not be empty",
+            sample.sample_id
+        )));
+    }
+    if sample.score < 100 && sample.differences.is_empty() {
+        return Err(RegressionError::Invalid(format!(
+            "agent review below 100 for {} must describe at least one difference",
+            sample.sample_id
+        )));
+    }
+    for difference in &sample.differences {
+        if difference.category.trim().is_empty() || difference.explanation.trim().is_empty() {
+            return Err(RegressionError::Invalid(format!(
+                "agent review difference for {} needs category and explanation",
+                sample.sample_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::prompt_lab::regression::{
+        AGENT_REVIEW_RUBRIC_VERSION, Aggregates, DatasetSummary, EvaluationReport,
+        ProperNounAggregate, REPORT_SCHEMA_VERSION, RunStatus, SCORING_POLICY_VERSION,
+        SampleResult, Thresholds, WerAggregate,
+    };
+    use crate::prompt_lab::{ProperNounAnnotation, SttSnapshot, score_proper_nouns, score_wer};
+
+    fn awaiting_report() -> EvaluationReport {
+        let reference = "使用 Codex".to_string();
+        let hypothesis = "使用 Codex".to_string();
+        EvaluationReport {
+            schema_version: REPORT_SCHEMA_VERSION,
+            run_id: "run-test-1".to_string(),
+            created_at_unix_ms: 1,
+            completed_at_unix_ms: None,
+            status: RunStatus::AwaitingAgentReview,
+            scoring_policy_version: SCORING_POLICY_VERSION.to_string(),
+            agent_review_rubric_version: AGENT_REVIEW_RUBRIC_VERSION.to_string(),
+            dataset: DatasetSummary {
+                root: "/tmp/lab".to_string(),
+                digest: "digest".to_string(),
+                ready_sample_ids: vec!["sample-1-1".to_string()],
+                pending_count: 0,
+                invalid_count: 0,
+            },
+            stt: SttSnapshot {
+                endpoint: "https://api.example.test/v1/audio/transcriptions".to_string(),
+                model: "whisper-test".to_string(),
+                language: Some("zh".to_string()),
+                temperature: 0.0,
+                prompt: Some("candidate".to_string()),
+            },
+            prompt_sha256: crate::prompt_lab::dataset::sha256_bytes(
+                &serde_json::to_vec(&Some("candidate".to_string())).unwrap(),
+            ),
+            thresholds: Thresholds {
+                max_wer_percent: 0.0,
+                min_llm_score: 100.0,
+                min_proper_noun_percent: 100.0,
+            },
+            aggregates: Aggregates {
+                wer: WerAggregate {
+                    reference_words: 2,
+                    substitutions: 0,
+                    deletions: 0,
+                    insertions: 0,
+                    wer_percent: 0.0,
+                },
+                proper_nouns: ProperNounAggregate {
+                    matched_occurrences: 1,
+                    expected_occurrences: 1,
+                    accuracy_percent: 100.0,
+                },
+                llm: None,
+            },
+            review: None,
+            gates: None,
+            meets_targets: None,
+            samples: vec![SampleResult {
+                sample_id: "sample-1-1".to_string(),
+                audio_path: "audio/sample-1-1.wav".to_string(),
+                audio_sha256: "audio-digest".to_string(),
+                reference: reference.clone(),
+                proper_noun_annotations: vec![ProperNounAnnotation {
+                    canonical: "Codex".to_string(),
+                    accepted: Vec::new(),
+                    case_sensitive: true,
+                    expected_occurrences: 1,
+                }],
+                hypothesis: Some(hypothesis.clone()),
+                wer: Some(score_wer(&reference, &hypothesis)),
+                proper_nouns: Some(score_proper_nouns(
+                    &hypothesis,
+                    &[ProperNounAnnotation {
+                        canonical: "Codex".to_string(),
+                        accepted: Vec::new(),
+                        case_sensitive: true,
+                        expected_occurrences: 1,
+                    }],
+                )),
+                agent_review: None,
+                error: None,
+            }],
+            failures: Vec::new(),
+            comparison: None,
+        }
+    }
+
+    #[test]
+    fn complete_agent_review_finalizes_report_and_all_gates() {
+        let directory = tempdir().unwrap();
+        let report_path = directory.path().join("run.json");
+        let review_path = directory.path().join("review.json");
+        awaiting_report().write(&report_path).unwrap();
+        fs::write(
+            &review_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "run_id": "run-test-1",
+                "rubric_version": AGENT_REVIEW_RUBRIC_VERSION,
+                "samples": [{
+                    "sample_id": "sample-1-1",
+                    "score": 100,
+                    "reason": "语义完全一致",
+                    "differences": []
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let report = apply_review(&report_path, &review_path).unwrap();
+
+        assert_eq!(report.status, RunStatus::Complete);
+        assert_eq!(report.aggregates.llm.as_ref().unwrap().mean_score, 100.0);
+        assert_eq!(report.meets_targets, Some(true));
+        assert!(report.gates.as_ref().unwrap().wer);
+        assert!(EvaluationReport::read(&report_path).is_ok());
+    }
+
+    #[test]
+    fn incomplete_review_is_rejected_without_rewriting_report() {
+        let directory = tempdir().unwrap();
+        let report_path = directory.path().join("run.json");
+        let review_path = directory.path().join("review.json");
+        awaiting_report().write(&report_path).unwrap();
+        let before = fs::read(&report_path).unwrap();
+        fs::write(
+            &review_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "run_id": "run-test-1",
+                "rubric_version": AGENT_REVIEW_RUBRIC_VERSION,
+                "samples": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = apply_review(&report_path, &review_path).unwrap_err();
+
+        assert!(error.to_string().contains("coverage"));
+        assert_eq!(fs::read(&report_path).unwrap(), before);
+    }
+
+    #[test]
+    fn out_of_range_score_is_rejected_without_rewriting_report() {
+        let directory = tempdir().unwrap();
+        let report_path = directory.path().join("run.json");
+        let review_path = directory.path().join("review.json");
+        awaiting_report().write(&report_path).unwrap();
+        let before = fs::read(&report_path).unwrap();
+        fs::write(
+            &review_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "run_id": "run-test-1",
+                "rubric_version": AGENT_REVIEW_RUBRIC_VERSION,
+                "samples": [{
+                    "sample_id": "sample-1-1",
+                    "score": 101,
+                    "reason": "invalid",
+                    "differences": [{
+                        "category": "other",
+                        "reference": null,
+                        "hypothesis": null,
+                        "explanation": "invalid"
+                    }]
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = apply_review(&report_path, &review_path).unwrap_err();
+
+        assert!(error.to_string().contains("exceeds 100"));
+        assert_eq!(fs::read(&report_path).unwrap(), before);
+    }
+}

--- a/src/transcriber.rs
+++ b/src/transcriber.rs
@@ -1,6 +1,7 @@
 pub mod api;
 #[cfg(test)]
 pub use api::MockTranscriber;
+pub(crate) use api::TranscriberMetadata;
 pub use api::{ApiTranscriber, Transcriber, TranscriberConfig};
 
 use std::fmt;

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -37,6 +37,15 @@ pub struct TranscriberConfig {
     temperature: f32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TranscriberMetadata {
+    pub(crate) endpoint: String,
+    pub(crate) model: String,
+    pub(crate) language: Option<String>,
+    pub(crate) prompt: Option<String>,
+    pub(crate) temperature: f32,
+}
+
 impl TranscriberConfig {
     pub(crate) fn validate(
         endpoint: &str,
@@ -81,6 +90,21 @@ impl TranscriberConfig {
                 temperature: transcription.temperature,
             }),
             _ => Err(issues),
+        }
+    }
+
+    pub(crate) fn metadata(&self) -> TranscriberMetadata {
+        let mut endpoint = self.endpoint.clone();
+        let _ = endpoint.set_username("");
+        let _ = endpoint.set_password(None);
+        endpoint.set_query(None);
+        endpoint.set_fragment(None);
+        TranscriberMetadata {
+            endpoint: endpoint.to_string(),
+            model: self.model.clone(),
+            language: self.language.clone(),
+            prompt: self.prompt.clone(),
+            temperature: self.temperature,
         }
     }
 }
@@ -271,6 +295,24 @@ mod tests {
             &TranscriptionSection::default(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn metadata_omits_endpoint_credentials_and_query_parameters() {
+        let config = validated_config(
+            "https://user:password@api.example.test/v1/audio/transcriptions?token=secret#fragment",
+        );
+
+        let metadata = config.metadata();
+
+        assert_eq!(
+            metadata.endpoint,
+            "https://api.example.test/v1/audio/transcriptions"
+        );
+        assert_eq!(metadata.model, "whisper-large-v3-turbo");
+        assert_eq!(metadata.language.as_deref(), Some("zh"));
+        assert_eq!(metadata.temperature, 0.0);
+        assert!(metadata.prompt.is_some());
     }
 
     // --- structured error tests against a local HTTP stub ---

--- a/src/transcriber/api.rs
+++ b/src/transcriber/api.rs
@@ -107,6 +107,11 @@ impl TranscriberConfig {
             temperature: self.temperature,
         }
     }
+
+    pub(crate) fn with_prompt(mut self, prompt: Option<String>) -> Self {
+        self.prompt = prompt;
+        self
+    }
 }
 
 /// Generic HTTP-based transcriber compatible with OpenAI-style multipart audio endpoints.
@@ -313,6 +318,22 @@ mod tests {
         assert_eq!(metadata.language.as_deref(), Some("zh"));
         assert_eq!(metadata.temperature, 0.0);
         assert!(metadata.prompt.is_some());
+    }
+
+    #[test]
+    fn prompt_override_changes_only_the_in_memory_transcriber_prompt() {
+        let config = validated_config("https://api.example.test/v1/audio/transcriptions");
+        let before = config.metadata();
+
+        let after = config
+            .with_prompt(Some("candidate prompt".to_string()))
+            .metadata();
+
+        assert_eq!(after.endpoint, before.endpoint);
+        assert_eq!(after.model, before.model);
+        assert_eq!(after.language, before.language);
+        assert_eq!(after.temperature, before.temperature);
+        assert_eq!(after.prompt.as_deref(), Some("candidate prompt"));
     }
 
     // --- structured error tests against a local HTTP stub ---


### PR DESCRIPTION
## Summary

- design a prompt-lab recording mode that pairs complete WAV files with raw STT captures and human references
- define full historical-audio regression with local WER and proper-noun metrics
- define a two-phase JSON workflow where the coding agent supplies the 0-100 semantic review without a Judge API or model
- assume one prompt-lab process per dataset and use direct writes without locking or atomic publication
- keep prompt candidates invocation-scoped and preserve JSON-only reporting

## Scope

This PR currently contains the plan and documentation index entry only. It deliberately does not contain product or test code.

## Approval gate

Implementation will begin on child changes in this same PR only after explicit user approval of the revised plan.